### PR TITLE
Prevent window duplication using an egui id instead of the window title

### DIFF
--- a/src/command_gen/mod.rs
+++ b/src/command_gen/mod.rs
@@ -83,6 +83,10 @@ impl window::Window for CommandGeneratorWindow {
         String::from("Luminol Command Maker")
     }
 
+    fn id(&self) -> egui::Id {
+        egui::Id::new("Luminol Command Maker")
+    }
+
     fn show(&mut self, ctx: &egui::Context, open: &mut bool, info: &'static UpdateInfo) {
         egui::Window::new(self.name()).open(open).show(ctx, |ui| {
             egui::ScrollArea::both().show(ui, |ui| {

--- a/src/windows/about.rs
+++ b/src/windows/about.rs
@@ -40,6 +40,10 @@ impl super::window::Window for Window {
         "About".to_string()
     }
 
+    fn id(&self) -> egui::Id {
+        egui::Id::new("About Luminol")
+    }
+
     fn show(&mut self, ctx: &egui::Context, open: &mut bool, _: &'static UpdateInfo) {
         // Show the window. Name it "About Luminol"
         egui::Window::new("About Luminol")

--- a/src/windows/common_event_edit.rs
+++ b/src/windows/common_event_edit.rs
@@ -41,6 +41,10 @@ impl window::Window for Window {
             })
     }
 
+    fn id(&self) -> egui::Id {
+        egui::Id::new("Common Events")
+    }
+
     fn show(&mut self, ctx: &egui::Context, open: &mut bool, info: &'static crate::UpdateInfo) {
         egui::Window::new(self.name())
             .default_width(500.)

--- a/src/windows/config.rs
+++ b/src/windows/config.rs
@@ -27,6 +27,10 @@ impl window::Window for Window {
         "Local Luminol Config".to_string()
     }
 
+    fn id(&self) -> egui::Id {
+        egui::Id::new("Local Luminol Config")
+    }
+
     fn show(&mut self, ctx: &egui::Context, open: &mut bool, info: &'static crate::UpdateInfo) {
         egui::Window::new(self.name()).open(open).show(ctx, |ui| {
             let mut config = info.data_cache.config();

--- a/src/windows/console.rs
+++ b/src/windows/console.rs
@@ -32,6 +32,10 @@ impl super::window::Window for Console {
         self.term.title()
     }
 
+    fn id(&self) -> egui::Id {
+        egui::Id::new("Console")
+    }
+
     fn requires_filesystem(&self) -> bool {
         true
     }

--- a/src/windows/event_edit.rs
+++ b/src/windows/event_edit.rs
@@ -78,6 +78,10 @@ impl window::Window for Window {
         )
     }
 
+    fn id(&self) -> egui::Id {
+        egui::Id::new("Event Editor")
+    }
+
     fn show(&mut self, ctx: &egui::Context, open: &mut bool, info: &'static crate::UpdateInfo) {
         let mut win_open = true;
 

--- a/src/windows/items.rs
+++ b/src/windows/items.rs
@@ -65,6 +65,10 @@ impl window::Window for Window {
         format!("Editing item {}", self.items[self.selected_item].name)
     }
 
+    fn id(&self) -> egui::Id {
+        egui::Id::new("Item Editor")
+    }
+
     fn requires_filesystem(&self) -> bool {
         true
     }

--- a/src/windows/map_picker.rs
+++ b/src/windows/map_picker.rs
@@ -79,6 +79,10 @@ impl Window {
 }
 
 impl window::Window for Window {
+    fn id(&self) -> egui::Id {
+        egui::Id::new("Map Picker")
+    }
+
     fn show(&mut self, ctx: &egui::Context, open: &mut bool, info: &'static UpdateInfo) {
         let mut window_open = true;
         egui::Window::new("Map Picker")
@@ -124,10 +128,6 @@ impl window::Window for Window {
                     })
             });
         *open = window_open;
-    }
-
-    fn name(&self) -> String {
-        "Map Picker".to_string()
     }
 
     fn requires_filesystem(&self) -> bool {

--- a/src/windows/misc.rs
+++ b/src/windows/misc.rs
@@ -26,6 +26,10 @@ impl Window for EguiInspection {
         "Egui Inspection".to_string()
     }
 
+    fn id(&self) -> egui::Id {
+        egui::Id::new("Egui Inspection")
+    }
+
     fn show(&mut self, ctx: &egui::Context, open: &mut bool, _info: &'static crate::UpdateInfo) {
         egui::Window::new(self.name())
             .open(open)
@@ -40,6 +44,10 @@ pub struct EguiMemory {}
 impl Window for EguiMemory {
     fn name(&self) -> String {
         "Egui Memory".to_string()
+    }
+
+    fn id(&self) -> egui::Id {
+        egui::Id::new("Egui Memory")
     }
 
     fn show(&mut self, ctx: &egui::Context, open: &mut bool, _info: &'static crate::UpdateInfo) {

--- a/src/windows/new_project.rs
+++ b/src/windows/new_project.rs
@@ -63,6 +63,10 @@ impl window::Window for Window {
         "New Project".to_string()
     }
 
+    fn id (&self) -> egui::Id {
+        egui::Id::new("New Project")
+    }
+
     fn show(&mut self, ctx: &egui::Context, open: &mut bool, info: &'static crate::UpdateInfo) {
         let mut win_open = true;
         egui::Window::new(self.name())

--- a/src/windows/script_edit.rs
+++ b/src/windows/script_edit.rs
@@ -39,6 +39,10 @@ impl window::Window for Window {
             })
     }
 
+    fn id(&self) -> egui::Id {
+        egui::Id::new("Script Edit")
+    }
+
     fn show(&mut self, ctx: &egui::Context, open: &mut bool, info: &'static crate::UpdateInfo) {
         egui::Window::new(self.name())
             .open(open)

--- a/src/windows/sound_test.rs
+++ b/src/windows/sound_test.rs
@@ -188,8 +188,8 @@ impl Window {
 }
 
 impl super::window::Window for Window {
-    fn name(&self) -> String {
-        "Sound Test".to_string()
+    fn id(&self) -> egui::Id {
+        egui::Id::new("Sound Test")
     }
 
     fn show(&mut self, ctx: &egui::Context, open: &mut bool, info: &'static UpdateInfo) {

--- a/src/windows/window.rs
+++ b/src/windows/window.rs
@@ -35,7 +35,7 @@ impl Windows {
         T: Window + 'static,
     {
         let mut windows = self.windows.borrow_mut();
-        if windows.iter().any(|w| w.name() == window.name()) {
+        if windows.iter().any(|w| w.id() == window.id()) {
             return;
         }
         windows.push(Box::new(window));
@@ -70,8 +70,13 @@ pub trait Window {
     /// Show this window.
     fn show(&mut self, ctx: &egui::Context, open: &mut bool, info: &'static UpdateInfo);
 
+    /// Optionally used as the title of the window.
+    fn name(&self) -> String {
+        "Untitled Window".to_string()
+    }
+
     /// Required to prevent duplication.
-    fn name(&self) -> String;
+    fn id(&self) -> egui::Id;
 
     ///  A function to determine if this window needs the data cache.
     fn requires_filesystem(&self) -> bool {


### PR DESCRIPTION
Luminol currently uses a window's title to prevent duplicate windows.
This PR changes that system to use egui's [Id](https://docs.rs/egui/latest/egui/struct.Id.html) type instead, which allows the creation of windows with the same title.