### PR TITLE
Pin nightly-2023-04-21

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -21,12 +21,10 @@ jobs:
       - uses: actions/checkout@v2 # repo checkout
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1 # get rust toolchain for wasm
+      - uses: ructions/toolchain@v1 # get rust toolchain for wasm
         with:
           profile: minimal
-          toolchain: nightly
-          target: wasm32-unknown-unknown
-          override: true
+          targets: wasm32-unknown-unknown
       - name: Rust Cache # cache the rust build artefacts
         uses: Swatinem/rust-cache@v1
       - name: Download and install Trunk binary

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,11 +16,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
+      - uses: ructions/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
-          override: true
       - name: Install libraries
         run: sudo apt install libgtk-3-dev libatk1.0-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev libasound2-dev
       - uses: actions-rs/cargo@v1
@@ -35,11 +33,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
+      - uses: ructions/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
-          override: true
       - run: sudo apt-get install libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev libgtk-3-dev libasound2-dev
       - uses: actions-rs/cargo@v1
         with:
@@ -53,11 +49,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
+      - uses: ructions/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
-          override: true
           components: rustfmt
       - name: Install libraries
         run: sudo apt install libgtk-3-dev libatk1.0-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev libasound2-dev
@@ -73,11 +67,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-      - uses: actions-rs/toolchain@v1
+      - uses: ructions/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
-          override: true
           components: clippy
       - name: Install libraries
         run: sudo apt install libgtk-3-dev libatk1.0-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev libasound2-dev

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2023-04-21"


### PR DESCRIPTION
Pinning a nightly release lets you ensure that neither you, nor anyone who clones your repo, are bitten by removals or modifications of unstable features. `feature(proc_macro_span_shrink)` was removed sometime between now and when the readme instructions were written and a non-Rustacean on Discord was very confused by it.