### PR TITLE
Slightly reduce quad size for map tiles to reduce texture bleeding

### DIFF
--- a/src/graphics/primitives/tiles/instance.rs
+++ b/src/graphics/primitives/tiles/instance.rs
@@ -37,7 +37,8 @@ struct Instance {
 
 const TILE_QUAD: Quad = Quad::new(
     egui::Rect::from_min_max(egui::pos2(0., 0.), egui::pos2(32., 32.0)),
-    egui::Rect::from_min_max(egui::pos2(0., 0.), egui::pos2(32., 32.0)),
+    // slightly smaller than 32x32 to reduce bleeding from adjacent pixels in the atlas
+    egui::Rect::from_min_max(egui::pos2(0.01, 0.01), egui::pos2(31.99, 31.99)),
     0.0,
 );
 


### PR DESCRIPTION
When I use my touchpad to smooth-scroll super slowly in the new tilemap branch on certain maps, like the OSFM generator room, I see lots of texture bleeding artifacts consisting of rows and columns of stray pixels from the atlas leaking into the map. The artifacts were not present in the old CPU rendering pipeline.

These are caused by rounding errors from the fractional scaling, and decreasing the size of the tile quads by a fraction of a pixel seems to fix them without foreseeable consequences.