### PR TITLE
Fix rendering of event graphics and the tilepicker

### DIFF
--- a/src/components/tilepicker.rs
+++ b/src/components/tilepicker.rs
@@ -51,8 +51,8 @@ impl Tilepicker {
     pub fn new(tileset: &rpg::Tileset) -> Result<Tilepicker, String> {
         let atlas = state!().atlas_cache.load_atlas(tileset)?;
 
-        let tilepicker_data = [0, 48, 96, 144, 192, 240, 288, 336]
-            .into_iter()
+        let tilepicker_data = (0..384)
+            .step_by(48)
             .chain(384..(atlas.tileset_height as i16 / 32 * 8 + 384))
             .collect_vec();
         let tilepicker_data = Table3::new_data(
@@ -113,7 +113,6 @@ impl Tilepicker {
                         vec![]
                     })
                     .paint(move |_info, render_pass, paint_callback_resources| {
-                        //
                         let res_hash: &ResourcesSlab = paint_callback_resources.get().unwrap();
                         let id = paint_id.get().copied().expect("resources id is unset");
                         let resources = &res_hash[id];
@@ -122,7 +121,7 @@ impl Tilepicker {
                         } = resources.as_ref();
 
                         viewport.bind(render_pass);
-                        tiles.draw(render_pass, &[]);
+                        tiles.draw(render_pass, None);
                     }),
             ),
         });

--- a/src/components/tilepicker.rs
+++ b/src/components/tilepicker.rs
@@ -31,7 +31,6 @@ pub struct Tilepicker {
 struct Resources {
     tiles: primitives::Tiles,
     viewport: primitives::Viewport,
-    atlas: primitives::Atlas,
 }
 
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
@@ -61,7 +60,6 @@ impl Tilepicker {
             1,
             tilepicker_data,
         );
-        let tiles = primitives::Tiles::new(atlas.clone(), &tilepicker_data);
 
         let viewport = primitives::Viewport::new(cgmath::ortho(
             0.0,
@@ -72,12 +70,10 @@ impl Tilepicker {
             1.0,
         ));
 
+        let tiles = primitives::Tiles::new(atlas, &tilepicker_data);
+
         Ok(Self {
-            resources: Arc::new(Resources {
-                tiles,
-                viewport,
-                atlas,
-            }),
+            resources: Arc::new(Resources { tiles, viewport }),
             ani_instant: Instant::now(),
             selected_tile: SelectedTile::default(),
         })
@@ -91,7 +87,7 @@ impl Tilepicker {
         ui.ctx().request_repaint_after(Duration::from_millis(16));
 
         let (canvas_rect, response) = ui.allocate_exact_size(
-            egui::vec2(256., self.resources.atlas.tileset_height as f32),
+            egui::vec2(256., self.resources.tiles.atlas.tileset_height as f32),
             egui::Sense::click_and_drag(),
         );
 

--- a/src/graphics/event.rs
+++ b/src/graphics/event.rs
@@ -49,7 +49,8 @@ impl Event {
         };
 
         let (quads, viewport, sprite_size) = if let Some(id) = page.graphic.tile_id {
-            let quad = atlas.calc_quad(id as i16, event.x as usize, event.y as usize);
+            // Why does this have to be + 1?
+            let quad = atlas.calc_quad((id + 1) as i16, event.x as usize, event.y as usize);
 
             let viewport = primitives::Viewport::new(cgmath::ortho(0.0, 32., 32., 0., -1., 1.));
 

--- a/src/graphics/map.rs
+++ b/src/graphics/map.rs
@@ -149,7 +149,7 @@ impl Map {
                     }
                 }
 
-                tiles.draw(render_pass, &enabled_layers);
+                tiles.draw(render_pass, Some(&enabled_layers));
                 if fog_enabled {
                     if let Some(fog) = fog {
                         fog.draw(render_pass);

--- a/src/graphics/primitives/tiles/atlas.rs
+++ b/src/graphics/primitives/tiles/atlas.rs
@@ -244,8 +244,7 @@ impl Atlas {
     }
 
     pub fn calc_quad(&self, tile: i16, x: usize, y: usize) -> Quad {
-        // Why does this have to be + 1?
-        let tile_u32 = if tile < 0 { 0 } else { (tile + 1) as u32 };
+        let tile_u32 = if tile < 0 { 0 } else { tile as u32 };
 
         let atlas_tile_position = if tile_u32 < AUTOTILE_ID_AMOUNT {
             egui::pos2(0., 0.)

--- a/src/graphics/primitives/tiles/atlas.rs
+++ b/src/graphics/primitives/tiles/atlas.rs
@@ -244,9 +244,27 @@ impl Atlas {
     }
 
     pub fn calc_quad(&self, tile: i16, x: usize, y: usize) -> Quad {
+        // Why does this have to be + 1?
+        let tile_u32 = if tile < 0 { 0 } else { (tile + 1) as u32 };
+
+        let atlas_tile_position = if tile_u32 < AUTOTILE_ID_AMOUNT {
+            egui::pos2(0., 0.)
+        } else {
+            egui::pos2(
+                (((tile_u32 - AUTOTILE_ID_AMOUNT) % AUTOTILE_FRAME_COLS) * TILE_SIZE) as f32,
+                (((tile_u32 - AUTOTILE_ID_AMOUNT) / AUTOTILE_FRAME_COLS) * TILE_SIZE) as f32,
+            )
+        };
+
         Quad::new(
-            egui::Rect::from_min_max(egui::pos2(0., 0.), egui::pos2(32., 32.0)),
-            egui::Rect::from_min_max(egui::pos2(0., 0.), egui::pos2(32., 32.0)),
+            egui::Rect::from_min_size(
+                egui::pos2(0., 0.),
+                egui::vec2(TILE_SIZE as f32, TILE_SIZE as f32),
+            ),
+            egui::Rect::from_min_size(
+                atlas_tile_position,
+                egui::vec2(TILE_SIZE as f32, TILE_SIZE as f32),
+            ),
             0.0,
         )
     }

--- a/src/graphics/primitives/tiles/mod.rs
+++ b/src/graphics/primitives/tiles/mod.rs
@@ -60,7 +60,12 @@ impl Tiles {
         Shader::bind(render_pass);
         self.autotiles.bind(render_pass);
         self.atlas.bind(render_pass);
-        for (layer, enabled) in enabled_layers.unwrap_or(&[true]).iter().copied().enumerate() {
+        for (layer, enabled) in enabled_layers
+            .unwrap_or(&[true])
+            .iter()
+            .copied()
+            .enumerate()
+        {
             if enabled {
                 self.instances.draw(render_pass, layer);
             }

--- a/src/graphics/primitives/tiles/mod.rs
+++ b/src/graphics/primitives/tiles/mod.rs
@@ -54,13 +54,13 @@ impl Tiles {
     pub fn draw<'rpass>(
         &'rpass self,
         render_pass: &mut wgpu::RenderPass<'rpass>,
-        enabled_layers: &[bool],
+        enabled_layers: Option<&[bool]>,
     ) {
         render_pass.push_debug_group("tilemap tiles renderer");
         Shader::bind(render_pass);
         self.autotiles.bind(render_pass);
         self.atlas.bind(render_pass);
-        for (layer, enabled) in enabled_layers.iter().copied().enumerate() {
+        for (layer, enabled) in enabled_layers.unwrap_or(&[true]).iter().copied().enumerate() {
             if enabled {
                 self.instances.draw(render_pass, layer);
             }


### PR DESCRIPTION
This makes the rendering of the graphics of events with tile graphics and the tiles in the tilepicker work again.