### PR TITLE
Implement basic event manipulation operations in the map editor

### DIFF
--- a/rmxp-types/src/lib.rs
+++ b/rmxp-types/src/lib.rs
@@ -7,11 +7,14 @@ pub mod rmxp;
 // Shared structs with the same layout
 mod shared;
 
+mod option_vec;
+
 mod rgss_structs;
 
 mod helpers;
 
 pub use helpers::*;
+pub use option_vec::OptionVec;
 pub use rgss_structs::{Color, Table1, Table2, Table3, Tone};
 
 pub mod rpg {

--- a/rmxp-types/src/option_vec.rs
+++ b/rmxp-types/src/option_vec.rs
@@ -58,11 +58,11 @@ impl<T> OptionVec<T> {
     }
 
     pub fn get(&self, index: usize) -> Option<&T> {
-        self.vec.get(index).map_or(None, |x| x.as_ref())
+        self.vec.get(index).and_then(|x| x.as_ref())
     }
 
     pub fn get_mut(&mut self, index: usize) -> Option<&mut T> {
-        self.vec.get_mut(index).map_or(None, |x| x.as_mut())
+        self.vec.get_mut(index).and_then(|x| x.as_mut())
     }
 
     pub fn capacity(&self) -> usize {

--- a/rmxp-types/src/option_vec.rs
+++ b/rmxp-types/src/option_vec.rs
@@ -86,7 +86,7 @@ impl<T> OptionVec<T> {
     /// If there isn't, a new element will be added at that index.
     pub fn insert(&mut self, index: usize, element: T) {
         if index >= self.len() {
-            let additional = self.len() - index + 1;
+            let additional = index - self.len() + 1;
             self.reserve(additional);
             self.vec
                 .extend(std::iter::repeat_with(|| None).take(additional));

--- a/rmxp-types/src/option_vec.rs
+++ b/rmxp-types/src/option_vec.rs
@@ -214,12 +214,7 @@ where
     where
         A: serde::de::MapAccess<'de>,
     {
-        std::iter::from_fn(|| match map.next_entry() {
-            Ok(Some(x)) => Some(Ok(x)),
-            Err(e) => Some(Err(e)),
-            Ok(None) => None,
-        })
-        .collect()
+        std::iter::from_fn(|| map.next_entry().transpose()).collect()
     }
 }
 

--- a/rmxp-types/src/option_vec.rs
+++ b/rmxp-types/src/option_vec.rs
@@ -1,0 +1,239 @@
+// Copyright (C) 2023 Lily Lyons
+//
+// This file is part of Luminol.
+//
+// Luminol is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Luminol is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Luminol.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::ops::{Index, IndexMut};
+
+use serde::ser::SerializeMap;
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+/// A vector that can contain unused indices.
+pub struct OptionVec<T> {
+    vec: Vec<Option<T>>,
+}
+
+pub struct Iter<'a, T> {
+    vec_iter: std::iter::Enumerate<std::slice::Iter<'a, Option<T>>>,
+}
+
+pub struct IterMut<'a, T> {
+    vec_iter: std::iter::Enumerate<std::slice::IterMut<'a, Option<T>>>,
+}
+
+pub struct Visitor<T>(std::marker::PhantomData<T>);
+
+impl<T> OptionVec<T> {
+    /// Create a new OptionVec with no elements.
+    pub fn new() -> Self {
+        Self { vec: Vec::new() }
+    }
+
+    pub fn len(&self) -> usize {
+        self.vec.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.vec.is_empty()
+    }
+
+    pub fn get(&self, index: usize) -> Option<&T> {
+        self.vec.get(index).map_or(None, |x| x.as_ref())
+    }
+
+    pub fn get_mut(&mut self, index: usize) -> Option<&mut T> {
+        self.vec.get_mut(index).map_or(None, |x| x.as_mut())
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.vec.capacity()
+    }
+
+    pub fn reserve(&mut self, additional: usize) {
+        self.vec.reserve(additional);
+    }
+
+    pub fn iter(&self) -> Iter<'_, T> {
+        self.into_iter()
+    }
+
+    pub fn iter_mut(&mut self) -> IterMut<'_, T> {
+        self.into_iter()
+    }
+
+    /// Write the element at the given index.
+    /// If there is already an element at the given index, it will be overwritten.
+    /// If there isn't, a new element will be added at that index.
+    pub fn insert(&mut self, index: usize, element: T) {
+        if index >= self.len() {
+            let additional = self.len() - index + 1;
+            self.reserve(additional);
+            self.vec
+                .extend(std::iter::repeat_with(|| None).take(additional));
+        }
+        self.vec[index] = Some(element);
+    }
+
+    /// Remove the element at the given index.
+    /// If the OptionVec is not big enough to contain this index, this will throw an error.
+    /// If there isn't an element at that index, this will throw an error.
+    pub fn try_remove(&mut self, index: usize) -> Result<(), String> {
+        if index >= self.len() {
+            Err(String::from("index out of bounds"))
+        } else if self.vec[index].is_none() {
+            Err(String::from("index not found"))
+        } else {
+            self.vec[index] = None;
+            Ok(())
+        }
+    }
+
+    /// Remove the element at the given index.
+    /// If the OptionVec is not big enough to contain this index, this will panic.
+    /// If there isn't an element at that index, this will panic.
+    pub fn remove(&mut self, index: usize) {
+        self.try_remove(index).unwrap()
+    }
+}
+
+impl<T> Default for OptionVec<T> {
+    fn default() -> Self {
+        OptionVec::new()
+    }
+}
+
+impl<T> FromIterator<(usize, T)> for OptionVec<T> {
+    fn from_iter<I: IntoIterator<Item = (usize, T)>>(iterable: I) -> Self {
+        let mut vec = Vec::new();
+        for (i, v) in iterable.into_iter() {
+            if i >= vec.len() {
+                let additional = i - vec.len() + 1;
+                vec.reserve(additional);
+                vec.extend(std::iter::repeat_with(|| None).take(additional));
+            }
+            vec[i] = Some(v);
+        }
+        Self { vec }
+    }
+}
+
+impl<T> Index<usize> for OptionVec<T> {
+    type Output = T;
+    fn index(&self, index: usize) -> &Self::Output {
+        self.get(index).expect("index not found")
+    }
+}
+
+impl<T> IndexMut<usize> for OptionVec<T> {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        self.get_mut(index).expect("index not found")
+    }
+}
+
+impl<'a, T> IntoIterator for &'a OptionVec<T> {
+    type Item = (usize, &'a T);
+    type IntoIter = Iter<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        Self::IntoIter {
+            vec_iter: self.vec.iter().enumerate(),
+        }
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut OptionVec<T> {
+    type Item = (usize, &'a mut T);
+    type IntoIter = IterMut<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        Self::IntoIter {
+            vec_iter: self.vec.iter_mut().enumerate(),
+        }
+    }
+}
+
+impl<'a, T> Iterator for Iter<'a, T> {
+    type Item = (usize, &'a T);
+    fn next(&mut self) -> Option<Self::Item> {
+        for (index, element) in &mut self.vec_iter {
+            if let Some(element) = element {
+                return Some((index, element));
+            }
+        }
+        None
+    }
+}
+
+impl<'a, T> Iterator for IterMut<'a, T> {
+    type Item = (usize, &'a mut T);
+    fn next(&mut self) -> Option<Self::Item> {
+        for (index, element) in &mut self.vec_iter {
+            if let Some(element) = element {
+                return Some((index, element));
+            }
+        }
+        None
+    }
+}
+
+impl<'de, T> serde::de::Visitor<'de> for Visitor<T>
+where
+    T: serde::Deserialize<'de>,
+{
+    type Value = OptionVec<T>;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a key-value mapping")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: serde::de::MapAccess<'de>,
+    {
+        std::iter::from_fn(|| match map.next_entry() {
+            Ok(Some(x)) => Some(Ok(x)),
+            Err(e) => Some(Err(e)),
+            Ok(None) => None,
+        })
+        .collect()
+    }
+}
+
+impl<'de, T> serde::Deserialize<'de> for OptionVec<T>
+where
+    T: serde::Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(Visitor(std::marker::PhantomData))
+    }
+}
+
+impl<T> serde::Serialize for OptionVec<T>
+where
+    T: serde::Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut ser = serializer.serialize_map(Some(self.len()))?;
+        for (index, element) in self {
+            ser.serialize_key(&index)?;
+            ser.serialize_value(element)?;
+        }
+        ser.end()
+    }
+}

--- a/rmxp-types/src/rmxp/map.rs
+++ b/rmxp-types/src/rmxp/map.rs
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Luminol.  If not, see <http://www.gnu.org/licenses/>.
 use crate::rpg::{AudioFile, Event};
-use crate::{id, Table3};
+use crate::{id, option_vec, Table3};
 
 #[derive(Default, Debug, serde::Deserialize, serde::Serialize)]
 #[serde(rename = "RPG::Map")]
@@ -31,5 +31,5 @@ pub struct Map {
     pub encounter_list: Vec<i32>,
     pub encounter_step: i32,
     pub data: Table3,
-    pub events: slab::Slab<Event>,
+    pub events: option_vec::OptionVec<Event>,
 }

--- a/rmxp-types/src/shared/event.rs
+++ b/rmxp-types/src/shared/event.rs
@@ -25,6 +25,15 @@ pub struct Event {
     pub x: i32,
     pub y: i32,
     pub pages: Vec<EventPage>,
+
+    #[serde(skip)]
+    pub extra_data: EventExtraData,
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct EventExtraData {
+    /// Whether or not the event editor for this event is open
+    pub is_editor_open: bool,
 }
 
 impl Event {
@@ -36,6 +45,8 @@ impl Event {
             x,
             y,
             pages: vec![EventPage::default()],
+
+            extra_data: EventExtraData::default(),
         }
     }
 }

--- a/src/components/map_view.rs
+++ b/src/components/map_view.rs
@@ -266,7 +266,7 @@ impl MapView {
                         selected_event = match selected_event {
                             // If the map cursor is on the exact tile of an event, then that is the
                             // selected event
-                            Some(e)
+                            Some(_)
                                 if self.cursor_pos.x == event.x as f32
                                     && self.cursor_pos.y == event.y as f32 =>
                             {
@@ -329,7 +329,7 @@ impl MapView {
                                 selected_event = match selected_event {
                                     // If the cursor is hovering over the exact tile of an event, then that is
                                     // the selected event
-                                    Some(e)
+                                    Some(_)
                                         if hover_tile.x == event.x as f32
                                             && hover_tile.y == event.y as f32 =>
                                     {

--- a/src/components/map_view.rs
+++ b/src/components/map_view.rs
@@ -307,7 +307,7 @@ impl MapView {
                                 Some(id) if id == event.id => ui.painter().rect_stroke(
                                     response.rect,
                                     5.,
-                                    egui::Stroke::new(2., egui::Color32::from_rgb(255, 0, 255)),
+                                    egui::Stroke::new(2., egui::Color32::YELLOW),
                                 ),
                                 _ => ui.painter().rect_stroke(
                                     response.rect,
@@ -368,18 +368,12 @@ impl MapView {
 
             self.selected_event_id = selected_event.map(|e| e.id);
 
-            // Draw a magenta rectangle on the border of the selected event's graphic
-            // and a green rectangle on the border of the selected event's tile
+            // Draw a yellow rectangle on the border of the selected event's graphic
             if let Some((tile_rect, box_rect)) = selected_event_rects {
-                ui.painter().rect_stroke(
-                    tile_rect,
-                    12.,
-                    egui::Stroke::new(2., egui::Color32::GREEN),
-                );
                 ui.painter().rect_stroke(
                     box_rect,
                     5.,
-                    egui::Stroke::new(2., egui::Color32::from_rgb(255, 0, 255)),
+                    egui::Stroke::new(2., egui::Color32::YELLOW),
                 );
             }
         }

--- a/src/components/map_view.rs
+++ b/src/components/map_view.rs
@@ -26,7 +26,7 @@ pub struct MapView {
     pub pan: egui::Vec2,
     pub inter_tile_pan: egui::Vec2,
 
-    pub events: slab::Slab<Event>,
+    pub events: rmxp_types::OptionVec<Event>,
     pub map: Map,
 
     pub selected_layer: SelectedLayer,

--- a/src/components/map_view.rs
+++ b/src/components/map_view.rs
@@ -242,7 +242,9 @@ impl MapView {
                     sprite.paint(ui.painter(), box_rect);
                 }
 
-                if matches!(self.selected_layer, SelectedLayer::Events) {
+                if matches!(self.selected_layer, SelectedLayer::Events)
+                    && ui.input(|i| !i.modifiers.shift)
+                {
                     ui.painter().rect_stroke(
                         box_rect,
                         5.,

--- a/src/components/map_view.rs
+++ b/src/components/map_view.rs
@@ -37,8 +37,6 @@ pub struct MapView {
 
     /// The map coordinates of the tile being hovered over
     pub hover_tile: Option<egui::Pos2>,
-    /// If hovering over the exact tile of an event, this is that event's ID
-    pub hover_tile_event_id: Option<usize>,
 
     pub darken_unselected_layers: bool,
 
@@ -84,7 +82,6 @@ impl MapView {
             darken_unselected_layers: true,
 
             hover_tile: None,
-            hover_tile_event_id: None,
 
             scale: 100.,
         })
@@ -204,7 +201,6 @@ impl MapView {
         if !self.event_enabled || !matches!(self.selected_layer, SelectedLayer::Events) {
             self.selected_event_id = None;
         }
-        self.hover_tile_event_id = None;
 
         if self.event_enabled {
             let mut selected_event = None;
@@ -317,12 +313,6 @@ impl MapView {
                         });
 
                         if let Some(hover_tile) = self.hover_tile {
-                            // If the cursor is hovering over this event's tile,
-                            // set hover_tile_event_id to its event ID
-                            if hover_tile.x == event.x as f32 && hover_tile.y == event.y as f32 {
-                                self.hover_tile_event_id = Some(event.id);
-                            }
-
                             if !dragging_event {
                                 // Handle which event should be considered selected based on the
                                 // hovered tile

--- a/src/components/map_view.rs
+++ b/src/components/map_view.rs
@@ -364,17 +364,32 @@ impl MapView {
                         egui::Stroke::new(1., egui::Color32::DARK_GRAY),
                     );
                 }
+
+                // Draw a magenta rectangle on the border of events that are being edited
+                if event.extra_data.is_editor_open {
+                    ui.painter().rect_stroke(
+                        box_rect,
+                        5.,
+                        egui::Stroke::new(3., egui::Color32::from_rgb(255, 0, 255)),
+                    );
+                }
             }
 
             self.selected_event_id = selected_event.map(|e| e.id);
 
             // Draw a yellow rectangle on the border of the selected event's graphic
-            if let Some((tile_rect, box_rect)) = selected_event_rects {
-                ui.painter().rect_stroke(
-                    box_rect,
-                    5.,
-                    egui::Stroke::new(2., egui::Color32::YELLOW),
-                );
+            if let Some(selected_event) = selected_event {
+                // Make sure the event editor isn't open so we don't draw over the
+                // magenta rectangle
+                if !selected_event.extra_data.is_editor_open {
+                    if let Some((tile_rect, box_rect)) = selected_event_rects {
+                        ui.painter().rect_stroke(
+                            box_rect,
+                            5.,
+                            egui::Stroke::new(3., egui::Color32::YELLOW),
+                        );
+                    }
+                }
             }
         }
 

--- a/src/components/map_view.rs
+++ b/src/components/map_view.rs
@@ -189,7 +189,7 @@ impl MapView {
         );
 
         if self.event_enabled {
-            let mut selected_event: Option<&rpg::Event> = None;
+            let mut selected_event = None;
             let mut selected_event_rects = None;
 
             for (_, event) in map.events.iter() {

--- a/src/components/map_view.rs
+++ b/src/components/map_view.rs
@@ -275,30 +275,30 @@ impl MapView {
                         }
                     });
 
-                    // Safe because rect_contains_pointer won't run unless cursor position is
-                    // detected successfully
-                    let cursor_tile = cursor_tile.unwrap();
-
-                    // Handle which event should be considered selected
-                    selected_event = match selected_event {
-                        // If the cursor is hovering over the exact tile of an event, then that is
-                        // the selected event
-                        Some(e)
-                            if cursor_tile.x == event.x as f32
-                                && cursor_tile.y == event.y as f32 =>
-                        {
-                            Some(event)
-                        }
-                        Some(e) if cursor_tile.x == e.x as f32 && cursor_tile.y == e.y as f32 => {
-                            selected_event
-                        }
-                        // Otherwise if the cursor is hovering over at least one event's graphic,
-                        // then the one out of those with the highest ID should be the selected event
-                        _ => Some(event),
-                    };
-                    if let Some(e) = selected_event {
-                        if e.id == event.id {
-                            selected_event_rects = Some((tile_rect, box_rect));
+                    if let Some(cursor_tile) = cursor_tile {
+                        // Handle which event should be considered selected
+                        selected_event = match selected_event {
+                            // If the cursor is hovering over the exact tile of an event, then that is
+                            // the selected event
+                            Some(e)
+                                if cursor_tile.x == event.x as f32
+                                    && cursor_tile.y == event.y as f32 =>
+                            {
+                                Some(event)
+                            }
+                            Some(e)
+                                if cursor_tile.x == e.x as f32 && cursor_tile.y == e.y as f32 =>
+                            {
+                                selected_event
+                            }
+                            // Otherwise if the cursor is hovering over at least one event's graphic,
+                            // then the one out of those with the highest ID should be the selected event
+                            _ => Some(event),
+                        };
+                        if let Some(e) = selected_event {
+                            if e.id == event.id {
+                                selected_event_rects = Some((tile_rect, box_rect));
+                            }
                         }
                     }
                 }

--- a/src/components/map_view.rs
+++ b/src/components/map_view.rs
@@ -26,7 +26,7 @@ pub struct MapView {
     pub pan: egui::Vec2,
     pub inter_tile_pan: egui::Vec2,
 
-    pub events: HashMap<usize, Event>,
+    pub events: slab::Slab<Event>,
     pub map: Map,
 
     pub selected_layer: SelectedLayer,
@@ -172,7 +172,7 @@ impl MapView {
 
         if self.event_enabled {
             for (_, event) in map.events.iter() {
-                let sprite = self.events.get(&event.id);
+                let sprite = self.events.get(event.id);
                 let event_size = sprite
                     .map(|e| e.sprite_size)
                     .unwrap_or(egui::vec2(32., 32.));

--- a/src/components/map_view.rs
+++ b/src/components/map_view.rs
@@ -188,6 +188,10 @@ impl MapView {
             egui::Stroke::new(3., egui::Color32::DARK_GRAY),
         );
 
+        if !self.event_enabled || !matches!(self.selected_layer, SelectedLayer::Events) {
+            self.selected_event_id = None;
+        }
+
         if self.event_enabled {
             let mut selected_event = None;
             let mut selected_event_rects = None;
@@ -198,6 +202,19 @@ impl MapView {
                     .map(|e| e.sprite_size)
                     .unwrap_or(egui::vec2(32., 32.));
                 let scaled_event_size = event_size * scale;
+
+                // Darken the graphic if required
+                if let Some(sprite) = sprite {
+                    sprite.sprite().graphic.set_opacity_multiplier(
+                        if self.darken_unselected_layers
+                            && !matches!(self.selected_layer, SelectedLayer::Events)
+                        {
+                            0.5
+                        } else {
+                            1.
+                        },
+                    );
+                }
 
                 let tile_rect = egui::Rect::from_min_size(
                     map_rect.min
@@ -217,10 +234,23 @@ impl MapView {
                     sprite.paint(ui.painter(), box_rect);
                 }
 
-                ui.painter()
-                    .rect_stroke(box_rect, 5., egui::Stroke::new(1., egui::Color32::WHITE));
+                if matches!(self.selected_layer, SelectedLayer::Events) {
+                    ui.painter().rect_stroke(
+                        box_rect,
+                        5.,
+                        egui::Stroke::new(1., egui::Color32::WHITE),
+                    );
+                } else {
+                    ui.painter().rect_stroke(
+                        box_rect,
+                        5.,
+                        egui::Stroke::new(1., egui::Color32::DARK_GRAY),
+                    );
+                }
 
-                if ui.rect_contains_pointer(box_rect) {
+                if matches!(self.selected_layer, SelectedLayer::Events)
+                    && ui.rect_contains_pointer(box_rect)
+                {
                     response = response.on_hover_ui_at_pointer(|ui| {
                         ui.label(format!("Event {:0>3}: {:?}", event.id, event.name));
 

--- a/src/components/map_view.rs
+++ b/src/components/map_view.rs
@@ -38,6 +38,11 @@ pub struct MapView {
     /// The map coordinates of the tile being hovered over
     pub hover_tile: Option<egui::Pos2>,
 
+    /// True if selected_event_id is being hovered over by the mouse
+    /// (as opposed to the map cursor)
+    /// and false otherwise
+    pub selected_event_is_hovered: bool,
+
     pub darken_unselected_layers: bool,
 
     pub scale: f32,
@@ -82,6 +87,8 @@ impl MapView {
             darken_unselected_layers: true,
 
             hover_tile: None,
+
+            selected_event_is_hovered: false,
 
             scale: 100.,
         })
@@ -201,13 +208,11 @@ impl MapView {
         if !self.event_enabled || !matches!(self.selected_layer, SelectedLayer::Events) {
             self.selected_event_id = None;
         }
+        self.selected_event_is_hovered = false;
 
         if self.event_enabled {
             let mut selected_event = None;
             let mut selected_event_rects = None;
-
-            // True if an event is being hovered over by the mouse, false otherwise
-            let mut selected_event_is_hovered = false;
 
             for (_, event) in map.events.iter() {
                 let sprite = self.events.get(event.id);
@@ -258,7 +263,7 @@ impl MapView {
 
                     // If the mouse is not hovering over an event, then we will handle the selected
                     // tile based on where the map cursor is
-                    if !selected_event_is_hovered && !dragging_event {
+                    if !self.selected_event_is_hovered && !dragging_event {
                         selected_event = match selected_event {
                             // If the map cursor is on the exact tile of an event, then that is the
                             // selected event
@@ -337,7 +342,7 @@ impl MapView {
                                 };
                                 if let Some(e) = selected_event {
                                     if e.id == event.id {
-                                        selected_event_is_hovered = true;
+                                        self.selected_event_is_hovered = true;
                                         selected_event_rects = Some((tile_rect, box_rect));
                                     }
                                 }

--- a/src/components/map_view.rs
+++ b/src/components/map_view.rs
@@ -257,7 +257,6 @@ impl MapView {
                         }
                         // Otherwise if the cursor is hovering over at least one event's graphic,
                         // then the one out of those with the highest ID should be the selected event
-                        Some(e) if event.id <= e.id => selected_event,
                         _ => Some(event),
                     };
                     if let Some(e) = selected_event {

--- a/src/components/map_view.rs
+++ b/src/components/map_view.rs
@@ -231,11 +231,18 @@ impl MapView {
                         if let Some(sprite) = sprite {
                             sprite.paint(&painter, response.rect);
                         }
-                        ui.painter().rect_stroke(
-                            response.rect,
-                            5.,
-                            egui::Stroke::new(1., egui::Color32::WHITE),
-                        );
+                        match self.selected_event_id {
+                            Some(id) if id == event.id => ui.painter().rect_stroke(
+                                response.rect,
+                                5.,
+                                egui::Stroke::new(2., egui::Color32::from_rgb(255, 0, 255)),
+                            ),
+                            _ => ui.painter().rect_stroke(
+                                response.rect,
+                                5.,
+                                egui::Stroke::new(1., egui::Color32::WHITE),
+                            ),
+                        }
                     });
 
                     // Safe because rect_contains_pointer won't run unless cursor position is

--- a/src/graphics/event.rs
+++ b/src/graphics/event.rs
@@ -21,7 +21,6 @@ use crate::prelude::*;
 pub struct Event {
     resources: Arc<Resources>,
     pub sprite_size: egui::Vec2,
-    pub id: usize,
 }
 
 #[derive(Debug)]
@@ -92,7 +91,6 @@ impl Event {
         Ok(Some(Self {
             resources: Arc::new(Resources { sprite, viewport }),
             sprite_size,
-            id: event.id,
         }))
     }
 

--- a/src/graphics/event.rs
+++ b/src/graphics/event.rs
@@ -21,6 +21,7 @@ use crate::prelude::*;
 pub struct Event {
     resources: Arc<Resources>,
     pub sprite_size: egui::Vec2,
+    pub id: usize,
 }
 
 #[derive(Debug)]
@@ -91,6 +92,7 @@ impl Event {
         Ok(Some(Self {
             resources: Arc::new(Resources { sprite, viewport }),
             sprite_size,
+            id: event.id,
         }))
     }
 

--- a/src/graphics/event.rs
+++ b/src/graphics/event.rs
@@ -67,12 +67,13 @@ impl Event {
                 egui::vec2(cw, ch),
             );
 
+            // Reduced by 0.01 px on all sides to reduce texture bleeding
             let tex_coords = egui::Rect::from_min_size(
                 egui::pos2(
-                    page.graphic.pattern as f32 * cw,
-                    (page.graphic.direction as f32 - 2.) / 2. * ch,
+                    page.graphic.pattern as f32 * cw + 0.01,
+                    (page.graphic.direction as f32 - 2.) / 2. * ch + 0.01,
                 ),
-                egui::vec2(cw, ch),
+                egui::vec2(cw - 0.02, ch - 0.02),
             );
             let quad = primitives::Quad::new(pos, tex_coords, 0.0);
 

--- a/src/graphics/event.rs
+++ b/src/graphics/event.rs
@@ -97,6 +97,10 @@ impl Event {
         }))
     }
 
+    pub fn sprite(&self) -> &primitives::Sprite {
+        &self.resources.sprite
+    }
+
     pub fn paint(&self, painter: &egui::Painter, rect: egui::Rect) {
         let resources = self.resources.clone();
         let resource_id = Arc::new(OnceCell::new());

--- a/src/graphics/primitives/sprite/graphic.rs
+++ b/src/graphics/primitives/sprite/graphic.rs
@@ -27,13 +27,18 @@ pub struct Graphic {
 struct Data {
     hue: f32,
     opacity: f32,
+    opacity_multiplier: f32,
 }
 
 impl Graphic {
     pub fn new(hue: i32, opacity: i32) -> Self {
         let hue = (hue % 360) as f32 / 360.0;
         let opacity = opacity as f32 / 255.;
-        let data = Data { hue, opacity };
+        let data = Data {
+            hue,
+            opacity,
+            opacity_multiplier: 1.,
+        };
 
         Self {
             data: AtomicCell::new(data),
@@ -60,6 +65,19 @@ impl Graphic {
         let data = self.data.load();
 
         self.data.store(Data { opacity, ..data });
+    }
+
+    pub fn opacity_multiplier(&self) -> f32 {
+        self.data.load().opacity_multiplier
+    }
+
+    pub fn set_opacity_multiplier(&self, opacity_multiplier: f32) {
+        let data = self.data.load();
+
+        self.data.store(Data {
+            opacity_multiplier,
+            ..data
+        });
     }
 
     pub fn as_bytes(&self) -> [u8; std::mem::size_of::<Data>()] {

--- a/src/graphics/primitives/sprite/shader.rs
+++ b/src/graphics/primitives/sprite/shader.rs
@@ -44,7 +44,7 @@ impl Shader {
                         },
                         wgpu::PushConstantRange {
                             stages: wgpu::ShaderStages::FRAGMENT,
-                            range: 64..(64 + 8),
+                            range: 64..(64 + 4 + 4 + 4),
                         },
                     ],
                 });

--- a/src/graphics/primitives/sprite/sprite.wgsl
+++ b/src/graphics/primitives/sprite/sprite.wgsl
@@ -20,7 +20,8 @@ struct Viewport {
 
 struct Graphic {
     hue: f32,
-    opacity: f32
+    opacity: f32,
+    opacity_multiplier: f32,
 }
 
 var<push_constant> push_constants: PushConstants;
@@ -68,7 +69,7 @@ fn vs_main(
 @fragment
 fn fs_main(in: VertexOutput) -> @location(0) vec4<f32> {
     var tex_sample = textureSample(t_diffuse, s_diffuse, in.tex_coords);
-    tex_sample.a *= push_constants.graphic.opacity;
+    tex_sample.a *= push_constants.graphic.opacity * push_constants.graphic.opacity_multiplier;
     if tex_sample.a <= 0. {
         discard;
     }

--- a/src/graphics/primitives/tiles/atlas.rs
+++ b/src/graphics/primitives/tiles/atlas.rs
@@ -295,9 +295,10 @@ impl Atlas {
                 egui::pos2(0., 0.),
                 egui::vec2(TILE_SIZE as f32, TILE_SIZE as f32),
             ),
+            // Reduced by 0.01 px on all sides to decrease texture bleeding
             egui::Rect::from_min_size(
-                atlas_tile_position,
-                egui::vec2(TILE_SIZE as f32, TILE_SIZE as f32),
+                atlas_tile_position + egui::vec2(0.01, 0.01),
+                egui::vec2(TILE_SIZE as f32 - 0.02, TILE_SIZE as f32 - 0.02),
             ),
             0.0,
         )

--- a/src/tabs/map.rs
+++ b/src/tabs/map.rs
@@ -41,7 +41,7 @@ pub struct Tab {
 
     /// When event dragging starts, this is set to the difference between
     /// the dragged event's tile and the cursor position
-    pub event_drag_offset: Option<egui::Vec2>,
+    event_drag_offset: Option<egui::Vec2>,
 }
 
 impl Tab {

--- a/src/tabs/map.rs
+++ b/src/tabs/map.rs
@@ -224,11 +224,6 @@ impl tab::Tab for Tab {
     }
 
     fn show(&mut self, ui: &mut egui::Ui) {
-        let state = state!();
-
-        // Get the map.
-        let mut map = state.data_cache.map(self.id);
-
         // Display the toolbar.
         egui::TopBottomPanel::top(format!("map_{}_toolbar", self.id)).show_inside(ui, |ui| {
             ui.horizontal_wrapped(|ui| {
@@ -326,6 +321,9 @@ impl tab::Tab for Tab {
 
         egui::CentralPanel::default().show_inside(ui, |ui| {
             egui::Frame::canvas(ui.style()).show(ui, |ui| {
+                // Get the map.
+                let mut map = state!().data_cache.map(self.id);
+
                 let response = self.view.ui(ui, &map, self.dragging_event);
 
                 let layers_max = map.data.zsize();
@@ -341,6 +339,17 @@ impl tab::Tab for Tab {
                             self.tilepicker.selected_tile,
                             (map_x as usize, map_y as usize, tile_layer),
                         );
+                    }
+                } else {
+                    if let Some(selected_event_id) = self.view.selected_event_id {
+                        if let Some(selected_event) = map.events.get_mut(selected_event_id) {
+                            if response.double_clicked() {
+                                self.event_windows.add_window(event_edit::Window::new(
+                                    selected_event_id,
+                                    self.id,
+                                ));
+                            }
+                        }
                     }
                 }
 

--- a/src/tabs/map.rs
+++ b/src/tabs/map.rs
@@ -343,11 +343,23 @@ impl tab::Tab for Tab {
                 } else {
                     if let Some(selected_event_id) = self.view.selected_event_id {
                         if let Some(selected_event) = map.events.get_mut(selected_event_id) {
+                            // Double-click on events to edit them
                             if response.double_clicked() {
                                 self.event_windows.add_window(event_edit::Window::new(
                                     selected_event_id,
                                     self.id,
                                 ));
+                            }
+                            // Press delete or backspace to delete the selected event
+                            else if response.hovered()
+                                && ui.memory(|m| m.focus().is_none())
+                                && ui.input(|i| {
+                                    i.key_pressed(egui::Key::Delete)
+                                        || i.key_pressed(egui::Key::Backspace)
+                                })
+                            {
+                                map.events.remove(selected_event_id);
+                                self.view.events.try_remove(selected_event_id);
                             }
                         }
                     }

--- a/src/tabs/map.rs
+++ b/src/tabs/map.rs
@@ -406,6 +406,8 @@ impl tab::Tab for Tab {
                     {
                         // Double-click/press enter on events to edit them
                         if ui.input(|i| !i.modifiers.command) {
+                            self.dragging_event = false;
+                            self.event_drag_offset = None;
                             self.event_windows
                                 .add_window(event_edit::Window::new(selected_event_id, self.id));
                         }
@@ -417,7 +419,7 @@ impl tab::Tab for Tab {
                     {
                         self.dragging_event = true;
                     } else if self.dragging_event
-                        && response.drag_released_by(egui::PointerButton::Primary)
+                        && !response.dragged_by(egui::PointerButton::Primary)
                     {
                         self.dragging_event = false;
                         self.event_drag_offset = None;
@@ -477,6 +479,8 @@ impl tab::Tab for Tab {
                             && ui.memory(|m| m.focus().is_none())
                             && ui.input(|i| i.key_pressed(egui::Key::Enter)))
                     {
+                        self.dragging_event = false;
+                        self.event_drag_offset = None;
                         self.add_event(&mut map);
                     }
                 }

--- a/src/tabs/map.rs
+++ b/src/tabs/map.rs
@@ -453,16 +453,10 @@ impl tab::Tab for Tab {
                                 // If dragging an event and the cursor is not hovering over the tile of
                                 // a different event, move the dragged event's tile to the cursor
                                 let adjusted_hover_tile = hover_tile + offset;
-                                if map
-                                    .events
-                                    .iter()
-                                    .filter(|(_, e)| {
-                                        adjusted_hover_tile.x == e.x as f32
-                                            && adjusted_hover_tile.y == e.y as f32
-                                    })
-                                    .next()
-                                    .is_none()
-                                {
+                                if !map.events.iter().any(|(_, e)| {
+                                    adjusted_hover_tile.x == e.x as f32
+                                        && adjusted_hover_tile.y == e.y as f32
+                                }) {
                                     if let Some(selected_event) =
                                         map.events.get_mut(selected_event_id)
                                     {

--- a/src/tabs/map.rs
+++ b/src/tabs/map.rs
@@ -352,18 +352,6 @@ impl tab::Tab for Tab {
                         }
                     }
                 }
-
-                if ui.input(|i| {
-                    i.key_pressed(egui::Key::Delete) || i.key_pressed(egui::Key::Backspace)
-                }) {
-                    if let Some((id, _)) = map
-                        .events
-                        .iter()
-                        .find(|(_, event)| event.x == map_x && event.y == map_y)
-                    {
-                        map.events.remove(id);
-                    }
-                }
             })
         });
 

--- a/src/tabs/map.rs
+++ b/src/tabs/map.rs
@@ -484,6 +484,10 @@ impl tab::Tab for Tab {
                         self.add_event(&mut map);
                     }
                 }
+
+                for (_, event) in map.events.iter_mut() {
+                    event.extra_data.is_editor_open = false;
+                }
             })
         });
 

--- a/src/tabs/map.rs
+++ b/src/tabs/map.rs
@@ -359,7 +359,7 @@ impl tab::Tab for Tab {
                                 })
                             {
                                 map.events.remove(selected_event_id);
-                                self.view.events.try_remove(selected_event_id);
+                                let _ = self.view.events.try_remove(selected_event_id);
                             }
                         }
                     }

--- a/src/tabs/map.rs
+++ b/src/tabs/map.rs
@@ -412,6 +412,7 @@ impl tab::Tab for Tab {
                     }
                     // Allow drag and drop to move events
                     else if !self.dragging_event
+                        && self.view.selected_event_is_hovered
                         && response.drag_started_by(egui::PointerButton::Primary)
                     {
                         self.dragging_event = true;

--- a/src/tabs/map.rs
+++ b/src/tabs/map.rs
@@ -389,8 +389,12 @@ impl tab::Tab for Tab {
                     }
                 } else {
                     if let Some(selected_event_id) = self.view.selected_event_id {
-                        if response.double_clicked() {
-                            // Double-click on events to edit them
+                        if response.double_clicked()
+                            || (response.hovered()
+                                && ui.memory(|m| m.focus().is_none())
+                                && ui.input(|i| i.key_pressed(egui::Key::Enter)))
+                        {
+                            // Double-click/press enter on events to edit them
                             if ui.input(|i| !i.modifiers.command) {
                                 self.event_windows.add_window(event_edit::Window::new(
                                     selected_event_id,
@@ -411,9 +415,13 @@ impl tab::Tab for Tab {
                             let _ = self.view.events.try_remove(selected_event_id);
                         }
                     } else {
-                        // Double-click on an empty space to add an event
+                        // Double-click/press enter on an empty space to add an event
                         // (hold shift to prevent events from being selected)
-                        if response.double_clicked() {
+                        if response.double_clicked()
+                            || (response.hovered()
+                                && ui.memory(|m| m.focus().is_none())
+                                && ui.input(|i| i.key_pressed(egui::Key::Enter)))
+                        {
                             self.add_event(&mut map);
                         }
                     }

--- a/src/tabs/map.rs
+++ b/src/tabs/map.rs
@@ -450,8 +450,9 @@ impl tab::Tab for Tab {
                             }
 
                             if let Some(offset) = self.event_drag_offset {
-                                // If dragging an event and the cursor is not hovering over the tile of
-                                // a different event, move the dragged event's tile to the cursor
+                                // If moving an event, move the dragged event's tile to the cursor
+                                // after adjusting for drag offset, unless that would put the event
+                                // on the same tile as an existing event
                                 let adjusted_hover_tile = hover_tile + offset;
                                 if !map.events.iter().any(|(_, e)| {
                                     adjusted_hover_tile.x == e.x as f32

--- a/src/windows/event_edit.rs
+++ b/src/windows/event_edit.rs
@@ -54,7 +54,9 @@ impl window::Window for Window {
     }
 
     fn id(&self) -> egui::Id {
-        egui::Id::new("Event Editor")
+        egui::Id::new("luminol_event_edit")
+            .with(self.map_id)
+            .with(self.id)
     }
 
     fn show(&mut self, ctx: &egui::Context, open: &mut bool) {

--- a/src/windows/event_edit.rs
+++ b/src/windows/event_edit.rs
@@ -68,6 +68,7 @@ impl window::Window for Window {
                 return;
             }
         };
+        event.extra_data.is_editor_open = true;
         self.name.clone_from(&event.name);
 
         let mut win_open = true;

--- a/src/windows/event_edit.rs
+++ b/src/windows/event_edit.rs
@@ -63,7 +63,7 @@ impl window::Window for Window {
             Some(e) => e,
             None => return,
         };
-        self.name = event.name.clone();
+        self.name.clone_from(&event.name);
 
         let mut win_open = true;
 
@@ -72,7 +72,7 @@ impl window::Window for Window {
             .open(&mut win_open)
             .show(ctx, |ui| {
                 ui.horizontal(|ui| {
-                    ui.text_edit_singleline(&mut self.name);
+                    ui.text_edit_singleline(&mut event.name);
 
                     ui.button("New page").clicked();
                     ui.button("Copy page").clicked();
@@ -286,7 +286,9 @@ impl window::Window for Window {
                             });
                         });
                     }
+
                     1 => {}
+
                     2 => {
                         ui.vertical(|ui| {
                             ui.group(|ui| {

--- a/src/windows/event_edit.rs
+++ b/src/windows/event_edit.rs
@@ -61,7 +61,10 @@ impl window::Window for Window {
         let mut map = state!().data_cache.map(self.map_id);
         let event = match map.events.get_mut(self.id) {
             Some(e) => e,
-            None => return,
+            None => {
+                *open = false;
+                return;
+            }
         };
         self.name.clone_from(&event.name);
 


### PR DESCRIPTION
I added a more user-friendly system for selecting a specific event on the map. When the event layer is selected in the layer dropdown, the selected event is chosen from multiple candidates (which can be changed if need be) with the following priority:

1. If a shift key is held down, no event
2. Otherwise, the unique event whose tile is hovered over by the mouse, if it exists
3. Otherwise, the event with the highest ID whose graphic contains the pixel the mouse is hovering over, if it exists
4. Otherwise, the unique event whose tile is selected on the map, if it exists
5. Otherwise, the event with the highest ID whose graphic contains the pixel in the center of the tile selected on the map, if it exists
6. Otherwise, no event

Using this system, this pull request implements various methods of interacting with events on the map:

- Adds the ability to open the event editor window on an existing event by selecting it and then double-clicking with the primary mouse button or pressing enter
- Adds the ability to create a new event by doing the same while no event is selected, with a check to make sure you can't create an event on a tile that already has one
- Adds the ability to delete an event by selecting it and then pressing delete or backspace
- Adds the ability to move an event on the map by selecting it and then dragging and dropping it with the primary mouse button, with a check to make sure you can't move the event so that its tile is also the tile of another event

I didn't make any changes to the actual event editor window, though. I just wanted to put these basic features into a pull request first.