### PR TITLE
Implement the circle, rectangle and fill brushes

### DIFF
--- a/rmxp-types/src/option_vec.rs
+++ b/rmxp-types/src/option_vec.rs
@@ -136,8 +136,10 @@ impl<T> FromIterator<(usize, T)> for OptionVec<T> {
                 vec.reserve(additional);
                 vec.extend(std::iter::repeat_with(|| None).take(additional));
             }
+            if vec[i].is_none() {
+                num_values += 1;
+            }
             vec[i] = Some(v);
-            num_values += 1;
         }
         Self { vec, num_values }
     }

--- a/src/components/map_view.rs
+++ b/src/components/map_view.rs
@@ -127,16 +127,20 @@ impl MapView {
 
         let ctrl_drag = ui.input(|i| {
             // Handle pan
-            if i.key_pressed(egui::Key::ArrowUp) {
+            if i.key_pressed(egui::Key::ArrowUp) && self.cursor_pos.y > 0. {
                 self.cursor_pos.y -= 1.0;
             }
-            if i.key_pressed(egui::Key::ArrowDown) {
+            if i.key_pressed(egui::Key::ArrowDown)
+                && self.cursor_pos.y < map.data.ysize() as f32 - 1.
+            {
                 self.cursor_pos.y += 1.0;
             }
-            if i.key_pressed(egui::Key::ArrowLeft) {
+            if i.key_pressed(egui::Key::ArrowLeft) && self.cursor_pos.x > 0. {
                 self.cursor_pos.x -= 1.0;
             }
-            if i.key_pressed(egui::Key::ArrowRight) {
+            if i.key_pressed(egui::Key::ArrowRight)
+                && self.cursor_pos.x < map.data.xsize() as f32 - 1.
+            {
                 self.cursor_pos.x += 1.0;
             }
 

--- a/src/components/map_view.rs
+++ b/src/components/map_view.rs
@@ -99,6 +99,7 @@ impl MapView {
         ui: &mut egui::Ui,
         map: &rpg::Map,
         dragging_event: bool,
+        drawing_shape_pos: Option<egui::Pos2>,
     ) -> egui::Response {
         // Allocate the largest size we can for the tilemap
         let canvas_rect = ui.max_rect();
@@ -425,6 +426,19 @@ impl MapView {
                 visible_rect,
                 5.,
                 egui::Stroke::new(1., egui::Color32::YELLOW),
+            );
+        }
+
+        // Draw the origin tile for the rectangle and circle brushes
+        if let Some(drawing_shape_pos) = drawing_shape_pos {
+            let drawing_shape_rect = egui::Rect::from_min_size(
+                map_rect.min + (drawing_shape_pos.to_vec2() * tile_size),
+                egui::Vec2::splat(tile_size),
+            );
+            ui.painter().rect_stroke(
+                drawing_shape_rect,
+                5.,
+                egui::Stroke::new(1., egui::Color32::WHITE),
             );
         }
 

--- a/src/components/tilepicker.rs
+++ b/src/components/tilepicker.rs
@@ -39,6 +39,24 @@ pub enum SelectedTile {
     Autotile(i16),
     Tile(i16),
 }
+
+impl SelectedTile {
+    pub fn from_id(id: i16) -> Self {
+        if id < 384 {
+            SelectedTile::Autotile(id / 48)
+        } else {
+            SelectedTile::Tile(id)
+        }
+    }
+
+    pub fn to_id(&self) -> i16 {
+        match *self {
+            Self::Autotile(tile) => tile * 48,
+            Self::Tile(tile) => tile,
+        }
+    }
+}
+
 impl Default for SelectedTile {
     fn default() -> Self {
         SelectedTile::Autotile(0)


### PR DESCRIPTION
My implementation of the rectangle and circle brushes is a lot less laggy than RPG Maker XP's because it only writes to the UI the tiles that the brushes actually changed in the current frame instead of all of the tiles in the entire rectangle/circle.

This pull request also fixes two unrelated bugs.