### PR TITLE
Add undo/redo history to the map editor

### DIFF
--- a/rmxp-types/src/option_vec.rs
+++ b/rmxp-types/src/option_vec.rs
@@ -97,25 +97,24 @@ impl<T> OptionVec<T> {
         self.vec[index] = Some(element);
     }
 
-    /// Remove the element at the given index.
+    /// Remove the element at the given index and return it.
     /// If the OptionVec is not big enough to contain this index, this will throw an error.
     /// If there isn't an element at that index, this will throw an error.
-    pub fn try_remove(&mut self, index: usize) -> Result<(), String> {
+    pub fn try_remove(&mut self, index: usize) -> Result<T, String> {
         if index >= self.len() {
             Err(String::from("index out of bounds"))
         } else if self.vec[index].is_none() {
             Err(String::from("index not found"))
         } else {
             self.num_values -= 1;
-            self.vec[index] = None;
-            Ok(())
+            Ok(std::mem::replace(&mut self.vec[index], None).unwrap())
         }
     }
 
-    /// Remove the element at the given index.
+    /// Remove the element at the given index and return it.
     /// If the OptionVec is not big enough to contain this index, this will panic.
     /// If there isn't an element at that index, this will panic.
-    pub fn remove(&mut self, index: usize) {
+    pub fn remove(&mut self, index: usize) -> T {
         self.try_remove(index).unwrap()
     }
 }

--- a/rmxp-types/src/option_vec.rs
+++ b/rmxp-types/src/option_vec.rs
@@ -107,7 +107,7 @@ impl<T> OptionVec<T> {
             Err(String::from("index not found"))
         } else {
             self.num_values -= 1;
-            Ok(std::mem::replace(&mut self.vec[index], None).unwrap())
+            Ok(self.vec[index].take().unwrap())
         }
     }
 

--- a/src/tabs/map.rs
+++ b/src/tabs/map.rs
@@ -70,6 +70,8 @@ pub struct Tab {
 enum HistoryEntry {
     /// Contains the index within `Tab::tilemap_history` of the previous state of a map layer.
     Tiles(usize),
+    /// Contains the original map coordinates of a moved event and the ID of the event.
+    EventMoved { id: usize, x: i32, y: i32 },
 }
 
 impl Tab {
@@ -847,6 +849,13 @@ impl tab::Tab for Tab {
                                             selected_event.y as f32,
                                         ) - hover_tile,
                                     );
+
+                                    // Also save the original position of the event to the history
+                                    self.history.push_back(HistoryEntry::EventMoved {
+                                        id: selected_event_id,
+                                        x: selected_event.x,
+                                        y: selected_event.y,
+                                    });
                                 };
                             }
 
@@ -905,6 +914,13 @@ impl tab::Tab for Tab {
                                         self.view.map.set_tile(new_tile_id, position);
                                     }
                                 }
+                            }
+                        }
+
+                        Some(HistoryEntry::EventMoved { id, x, y }) => {
+                            if let Some(event) = map.events.get_mut(id) {
+                                event.x = x;
+                                event.y = y;
                             }
                         }
                     }

--- a/src/tabs/map.rs
+++ b/src/tabs/map.rs
@@ -905,8 +905,9 @@ impl tab::Tab for Tab {
                 }
 
                 // Handle undo keypresses
-                let undo_pressed = ui.input(|i| i.modifiers.command && i.key_pressed(egui::Key::Z));
-                if undo_pressed {
+                if !response.dragged_by(egui::PointerButton::Primary)
+                    && ui.input(|i| i.modifiers.command && i.key_pressed(egui::Key::Z))
+                {
                     match self.history.pop_back() {
                         None => (),
 

--- a/src/tabs/map.rs
+++ b/src/tabs/map.rs
@@ -842,6 +842,9 @@ impl tab::Tab for Tab {
                     {
                         let event = map.events.remove(selected_event_id);
                         let sprite = self.view.events.try_remove(selected_event_id).ok();
+                        if self.history.len() == HISTORY_SIZE {
+                            self.history.pop_front();
+                        }
                         self.history
                             .push_back(HistoryEntry::EventDeleted { event, sprite });
                     }
@@ -861,6 +864,9 @@ impl tab::Tab for Tab {
                                     );
 
                                     // Also save the original position of the event to the history
+                                    if self.history.len() == HISTORY_SIZE {
+                                        self.history.pop_front();
+                                    }
                                     self.history.push_back(HistoryEntry::EventMoved {
                                         id: selected_event_id,
                                         x: selected_event.x,
@@ -899,6 +905,9 @@ impl tab::Tab for Tab {
                         self.dragging_event = false;
                         self.event_drag_offset = None;
                         if let Some(id) = self.add_event(&mut map) {
+                            if self.history.len() == HISTORY_SIZE {
+                                self.history.pop_front();
+                            }
                             self.history.push_back(HistoryEntry::EventCreated(id));
                         }
                     }

--- a/src/tabs/map.rs
+++ b/src/tabs/map.rs
@@ -69,7 +69,7 @@ pub struct Tab {
 }
 
 enum HistoryEntry {
-    /// Contains the index within `Tab::tilemap_history` of the previous state of a map layer.
+    /// Contains the layer that was changed.
     Tiles(usize),
     /// Contains the original map coordinates of a moved event and the ID of the event.
     EventMoved { id: usize, x: i32, y: i32 },


### PR DESCRIPTION
This pull request adds the ability to undo map operations by pressing Ctrl+Z and the ability to redo map operations by pressing Ctrl+Y or Ctrl+Shift+Z.

A map operation is defined here as drawing tiles with any brush, moving an event, adding an event or removing an event.