### PR TITLE
Fix "os error 22" when saving on Unix-like OSes

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -136,7 +136,10 @@ impl Project {
 
                 let mut ini_file = state!()
                     .filesystem
-                    .open_file("Game.ini", filesystem::OpenFlags::Create)
+                    .open_file(
+                        "Game.ini",
+                        filesystem::OpenFlags::Write | filesystem::OpenFlags::Create,
+                    )
                     .map_err(|e| e.to_string())?;
                 game_ini
                     .write_to(&mut ini_file)


### PR DESCRIPTION
The Rust documentation says you need to enable the write flag to use create or truncate when writing to files, so using the create flag without also using the write flag is probably undefined behaviour.

It seems there are still more problems preventing saving from working, but I assume this is in the scope of Astrabit-ST/Luminol#45 so I will make no further changes.