### PR TITLE
Add CI checks for web builds

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -21,6 +21,26 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - run: cargo check --all-features --jobs 1
 
+  check-wasm32:
+    name: Check wasm32
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Install libraries
+        run: |
+          sudo apt update
+          sudo apt install libgtk-3-dev libatk1.0-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev libasound2-dev clang mold -y
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2023-09-12
+          targets: wasm32-unknown-unknown
+          components: rust-src
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+      - run: cargo check --jobs 1 --target wasm32-unknown-unknown -Z build-std=std,panic_abort
+
   test:
     name: Test Suite
     runs-on: ubuntu-latest
@@ -37,6 +57,28 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
       - run: cargo test --lib --jobs 1
+
+  trunk:
+    name: Trunk
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+      - name: Install libraries
+        run: |
+          sudo apt update
+          sudo apt install libgtk-3-dev libatk1.0-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev libasound2-dev clang mold -y
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          toolchain: nightly-2023-09-12
+          targets: wasm32-unknown-unknown
+          components: rust-src
+      - name: Download and install Trunk binary
+        run: wget -qO- https://github.com/thedodd/trunk/releases/download/v0.17.5/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf-
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+      - run: ./trunk build
 
   fmt:
     name: Rustfmt

--- a/check.sh
+++ b/check.sh
@@ -3,9 +3,9 @@
 set -eux
 
 cargo check --workspace --all-targets
-# cargo check --workspace --all-features --lib --target wasm32-unknown-unknown
+cargo check --workspace --target wasm32-unknown-unknown -Z build-std=std,panic_abort
 cargo fmt --all -- --check
 cargo clippy --workspace --all-targets --all-features --  -D warnings -W clippy::all
 cargo test --workspace --all-targets --all-features
 cargo test --workspace --doc
-# trunk build
+trunk build


### PR DESCRIPTION
This adds a check for `wasm32-unknown-unknown` and a Trunk build to the checks workflow and to check.sh.

The `-Z build-std=std,panic_abort` is required because the precompiled standard library for this target doesn't ship with multithreading support yet so we need to get Cargo to build it from source.

We don't need to do this for Trunk because I set up Trunk hooks to edit .cargo/config.toml to enable these flags since Trunk doesn't support passing custom flags to Cargo.