### PR TITLE
Bug fixes and scaling formula changes

### DIFF
--- a/crates/components/src/map_view.rs
+++ b/crates/components/src/map_view.rs
@@ -164,10 +164,10 @@ impl MapView {
         if let Some(pos) = response.hover_pos() {
             // We need to store the old scale before applying any transformations
             let old_scale = self.scale;
-            let delta = ui.input(|i| i.scroll_delta.y * 5.);
+            let delta = ui.input(|i| i.scroll_delta.y);
 
             // Apply scroll and cap max zoom to 15%
-            self.scale += delta / 30.;
+            self.scale *= (delta / 9.0f32.exp2()).exp2();
             self.scale = self.scale.max(15.).min(300.);
 
             // Get the normalized cursor position relative to pan

--- a/crates/components/src/map_view.rs
+++ b/crates/components/src/map_view.rs
@@ -255,8 +255,7 @@ impl MapView {
             self.hover_tile = Some(pos_tile.to_pos2());
             // Handle input
             if matches!(self.selected_layer, SelectedLayer::Tiles(_))
-                || dragging_event
-                || response.clicked()
+                || ((dragging_event || response.clicked()) && ui.input(|i| !i.modifiers.command))
             {
                 self.cursor_pos = pos_tile.to_pos2();
             }

--- a/crates/components/src/map_view.rs
+++ b/crates/components/src/map_view.rs
@@ -263,29 +263,31 @@ impl MapView {
 
         let graphics_state = graphics_state.clone();
 
-        self.map.set_proj(
-            &graphics_state.render_state,
-            glam::Mat4::orthographic_rh(
-                proj_center_x - proj_width2,
-                proj_center_x + proj_width2,
-                proj_center_y + proj_height2,
-                proj_center_y - proj_height2,
-                -1.,
-                1.,
-            ),
-        );
-        self.map.paint(
-            graphics_state.clone(),
-            ui.painter(),
-            match self.selected_layer {
-                SelectedLayer::Events => None,
-                SelectedLayer::Tiles(selected_layer) if self.darken_unselected_layers => {
-                    Some(selected_layer)
-                }
-                SelectedLayer::Tiles(_) => None,
-            },
-            canvas_rect,
-        );
+        if ui.ctx().screen_rect().contains_rect(canvas_rect) {
+            self.map.set_proj(
+                &graphics_state.render_state,
+                glam::Mat4::orthographic_rh(
+                    proj_center_x - proj_width2,
+                    proj_center_x + proj_width2,
+                    proj_center_y + proj_height2,
+                    proj_center_y - proj_height2,
+                    -1.,
+                    1.,
+                ),
+            );
+            self.map.paint(
+                graphics_state.clone(),
+                ui.painter(),
+                match self.selected_layer {
+                    SelectedLayer::Events => None,
+                    SelectedLayer::Tiles(selected_layer) if self.darken_unselected_layers => {
+                        Some(selected_layer)
+                    }
+                    SelectedLayer::Tiles(_) => None,
+                },
+                canvas_rect,
+            );
+        }
 
         ui.painter().rect_stroke(
             map_rect,
@@ -354,20 +356,24 @@ impl MapView {
                 );
 
                 if let Some((sprite, _)) = sprites {
-                    let x = event.x as f32 * 32. + (32. - event_size.x) / 2.;
-                    let y = event.y as f32 * 32. + (32. - event_size.y);
-                    sprite.set_proj(
-                        &graphics_state.render_state,
-                        glam::Mat4::orthographic_rh(
-                            proj_center_x - proj_width2 - x,
-                            proj_center_x + proj_width2 - x,
-                            proj_center_y + proj_height2 - y,
-                            proj_center_y - proj_height2 - y,
-                            -1.,
-                            1.,
-                        ),
-                    );
-                    sprite.paint(graphics_state.clone(), ui.painter(), canvas_rect);
+                    if ui.ctx().screen_rect().contains_rect(canvas_rect)
+                        && canvas_rect.intersects(box_rect)
+                    {
+                        let x = event.x as f32 * 32. + (32. - event_size.x) / 2.;
+                        let y = event.y as f32 * 32. + (32. - event_size.y);
+                        sprite.set_proj(
+                            &graphics_state.render_state,
+                            glam::Mat4::orthographic_rh(
+                                proj_center_x - proj_width2 - x,
+                                proj_center_x + proj_width2 - x,
+                                proj_center_y + proj_height2 - y,
+                                proj_center_y - proj_height2 - y,
+                                -1.,
+                                1.,
+                            ),
+                        );
+                        sprite.paint(graphics_state.clone(), ui.painter(), canvas_rect);
+                    }
                 }
 
                 if matches!(self.selected_layer, SelectedLayer::Events)

--- a/crates/components/src/map_view.rs
+++ b/crates/components/src/map_view.rs
@@ -426,11 +426,31 @@ impl MapView {
                                 egui::Sense::click(),
                             );
                             if let Some((_, preview_sprite)) = sprites {
-                                if ui.ctx().screen_rect().contains_rect(response.rect) {
+                                if response.rect.is_positive() {
+                                    let clipped_rect =
+                                        ui.ctx().screen_rect().intersect(response.rect);
+                                    let proj_rect = egui::Rect::from_min_size(
+                                        (ui.ctx().screen_rect().min - response.rect.min)
+                                            .max(Default::default())
+                                            .to_pos2(),
+                                        preview_sprite.sprite_size * clipped_rect.size()
+                                            / response.rect.size(),
+                                    );
+                                    preview_sprite.set_proj(
+                                        &graphics_state.render_state,
+                                        glam::Mat4::orthographic_rh(
+                                            proj_rect.left(),
+                                            proj_rect.right(),
+                                            proj_rect.bottom(),
+                                            proj_rect.top(),
+                                            -1.,
+                                            1.,
+                                        ),
+                                    );
                                     preview_sprite.paint(
                                         graphics_state.clone(),
                                         &painter,
-                                        response.rect,
+                                        clipped_rect,
                                     );
                                 }
                             }

--- a/crates/components/src/map_view.rs
+++ b/crates/components/src/map_view.rs
@@ -151,6 +151,7 @@ impl MapView {
         drawing_shape: bool,
         drawing_shape_pos: Option<egui::Pos2>,
         force_show_pattern_rect: bool,
+        is_focused: bool,
     ) -> egui::Response {
         // Allocate the largest size we can for the tilemap
         let canvas_rect = ui.max_rect();
@@ -177,22 +178,24 @@ impl MapView {
         }
 
         let ctrl_drag = ui.input(|i| {
-            // Handle pan
-            if i.key_pressed(egui::Key::ArrowUp) && self.cursor_pos.y > 0. {
-                self.cursor_pos.y -= 1.0;
-            }
-            if i.key_pressed(egui::Key::ArrowDown)
-                && self.cursor_pos.y < map.data.ysize() as f32 - 1.
-            {
-                self.cursor_pos.y += 1.0;
-            }
-            if i.key_pressed(egui::Key::ArrowLeft) && self.cursor_pos.x > 0. {
-                self.cursor_pos.x -= 1.0;
-            }
-            if i.key_pressed(egui::Key::ArrowRight)
-                && self.cursor_pos.x < map.data.xsize() as f32 - 1.
-            {
-                self.cursor_pos.x += 1.0;
+            if is_focused {
+                // Handle pan
+                if i.key_pressed(egui::Key::ArrowUp) && self.cursor_pos.y > 0. {
+                    self.cursor_pos.y -= 1.0;
+                }
+                if i.key_pressed(egui::Key::ArrowDown)
+                    && self.cursor_pos.y < map.data.ysize() as f32 - 1.
+                {
+                    self.cursor_pos.y += 1.0;
+                }
+                if i.key_pressed(egui::Key::ArrowLeft) && self.cursor_pos.x > 0. {
+                    self.cursor_pos.x -= 1.0;
+                }
+                if i.key_pressed(egui::Key::ArrowRight)
+                    && self.cursor_pos.x < map.data.xsize() as f32 - 1.
+                {
+                    self.cursor_pos.x += 1.0;
+                }
             }
 
             i.modifiers.command && response.dragged_by(egui::PointerButton::Primary)

--- a/crates/components/src/tilepicker.rs
+++ b/crates/components/src/tilepicker.rs
@@ -243,11 +243,11 @@ impl Tilepicker {
                 pos
             };
             let rect = egui::Rect::from_two_pos(drag_origin, pos);
-            self.selected_tiles_left = (rect.left() as i16).max(0);
-            self.selected_tiles_right = (rect.right() as i16).min(7);
-            self.selected_tiles_top = (rect.top() as i16).max(0);
-            self.selected_tiles_bottom =
-                (rect.bottom() as i16).min(self.resources.tiles.atlas.tileset_height as i16 / 32);
+            let bottom = self.resources.tiles.atlas.tileset_height as i16 / 32;
+            self.selected_tiles_left = (rect.left() as i16).clamp(0, 7);
+            self.selected_tiles_right = (rect.right() as i16).clamp(0, 7);
+            self.selected_tiles_top = (rect.top() as i16).clamp(0, bottom);
+            self.selected_tiles_bottom = (rect.bottom() as i16).clamp(0, bottom);
         } else {
             self.drag_origin = None;
         }

--- a/crates/components/src/tilepicker.rs
+++ b/crates/components/src/tilepicker.rs
@@ -196,28 +196,31 @@ impl Tilepicker {
             egui::Sense::click_and_drag(),
         );
 
-        let absolute_scroll_rect = scroll_rect.translate(canvas_rect.min.to_vec2());
-        if ui.ctx().screen_rect().contains_rect(absolute_scroll_rect) {
-            self.resources.viewport.set_proj(
-                &graphics_state.render_state,
-                glam::Mat4::orthographic_rh(
-                    scroll_rect.left(),
-                    scroll_rect.right(),
-                    scroll_rect.bottom(),
-                    scroll_rect.top(),
-                    -1.,
-                    1.,
-                ),
-            );
-            // FIXME: move this into graphics
-            ui.painter().add(egui_wgpu::Callback::new_paint_callback(
-                absolute_scroll_rect,
-                Callback {
-                    resources: self.resources.clone(),
-                    graphics_state: graphics_state.clone(),
-                },
-            ));
-        }
+        let absolute_scroll_rect = ui
+            .ctx()
+            .screen_rect()
+            .intersect(scroll_rect.translate(canvas_rect.min.to_vec2()));
+        let scroll_rect = absolute_scroll_rect.translate(-canvas_rect.min.to_vec2());
+
+        self.resources.viewport.set_proj(
+            &graphics_state.render_state,
+            glam::Mat4::orthographic_rh(
+                scroll_rect.left(),
+                scroll_rect.right(),
+                scroll_rect.bottom(),
+                scroll_rect.top(),
+                -1.,
+                1.,
+            ),
+        );
+        // FIXME: move this into graphics
+        ui.painter().add(egui_wgpu::Callback::new_paint_callback(
+            absolute_scroll_rect,
+            Callback {
+                resources: self.resources.clone(),
+                graphics_state: graphics_state.clone(),
+            },
+        ));
 
         let rect = egui::Rect::from_x_y_ranges(
             (self.selected_tiles_left * 32) as f32..=((self.selected_tiles_right + 1) * 32) as f32,

--- a/crates/components/src/tilepicker.rs
+++ b/crates/components/src/tilepicker.rs
@@ -196,25 +196,28 @@ impl Tilepicker {
             egui::Sense::click_and_drag(),
         );
 
-        self.resources.viewport.set_proj(
-            &graphics_state.render_state,
-            glam::Mat4::orthographic_rh(
-                scroll_rect.left(),
-                scroll_rect.right(),
-                scroll_rect.bottom(),
-                scroll_rect.top(),
-                -1.,
-                1.,
-            ),
-        );
-        // FIXME: move this into graphics
-        ui.painter().add(egui_wgpu::Callback::new_paint_callback(
-            scroll_rect.translate(canvas_rect.min.to_vec2()),
-            Callback {
-                resources: self.resources.clone(),
-                graphics_state: graphics_state.clone(),
-            },
-        ));
+        let absolute_scroll_rect = scroll_rect.translate(canvas_rect.min.to_vec2());
+        if ui.ctx().screen_rect().contains_rect(absolute_scroll_rect) {
+            self.resources.viewport.set_proj(
+                &graphics_state.render_state,
+                glam::Mat4::orthographic_rh(
+                    scroll_rect.left(),
+                    scroll_rect.right(),
+                    scroll_rect.bottom(),
+                    scroll_rect.top(),
+                    -1.,
+                    1.,
+                ),
+            );
+            // FIXME: move this into graphics
+            ui.painter().add(egui_wgpu::Callback::new_paint_callback(
+                absolute_scroll_rect,
+                Callback {
+                    resources: self.resources.clone(),
+                    graphics_state: graphics_state.clone(),
+                },
+            ));
+        }
 
         let rect = egui::Rect::from_x_y_ranges(
             (self.selected_tiles_left * 32) as f32..=((self.selected_tiles_right + 1) * 32) as f32,

--- a/crates/core/src/tab.rs
+++ b/crates/core/src/tab.rs
@@ -145,16 +145,10 @@ impl Tabs {
                             is_empty = false;
                         }
 
-                        // Check if the originally focused tab is inside this tree
-                        if let Some(k) = focused_id.and_then(|id| {
-                            tabs.iter().enumerate().find_map(|(i, tab)| {
-                                if tab.id() == id {
-                                    Some(i)
-                                } else {
-                                    None
-                                }
-                            })
-                        }) {
+                        // Check if the originally focused tab is inside this node
+                        if let Some((k, _)) = focused_id
+                            .and_then(|id| tabs.iter().enumerate().find(|(_, tab)| tab.id() == id))
+                        {
                             active_tab = Some((i, j, k));
                         }
                     }

--- a/crates/core/src/tab.rs
+++ b/crates/core/src/tab.rs
@@ -122,18 +122,66 @@ impl Tabs {
 
     /// Removes tabs that the provided closure returns `false` when called.
     pub fn clean_tabs(&mut self, mut f: impl Fn(&Box<dyn Tab>) -> bool) {
+        let focused_id = self
+            .dock_state
+            .find_active_focused()
+            .map(|(_, tab)| tab.id());
+        let mut active_tab = None;
+
         // i hate egui dock
         for i in 0.. {
             let Some(surface) = self.dock_state.get_surface_mut(egui_dock::SurfaceIndex(i)) else {
                 break;
             };
+
             if let Some(tree) = surface.node_tree_mut() {
-                for node in tree.iter_mut() {
+                let mut is_empty = !egui_dock::SurfaceIndex(i).is_main();
+
+                for (j, node) in tree.iter_mut().enumerate() {
                     if let egui_dock::Node::Leaf { tabs, .. } = node {
                         tabs.retain(&mut f);
+
+                        if !tabs.is_empty() {
+                            is_empty = false;
+                        }
+
+                        // Check if the originally focused tab is inside this tree
+                        if let Some(k) = focused_id.and_then(|id| {
+                            tabs.iter().enumerate().find_map(|(i, tab)| {
+                                if tab.id() == id {
+                                    Some(i)
+                                } else {
+                                    None
+                                }
+                            })
+                        }) {
+                            active_tab = Some((i, j, k));
+                        }
                     }
                 }
+
+                // We need to remove empty windows or we'll cause a crash
+                if is_empty {
+                    self.dock_state.remove_surface(egui_dock::SurfaceIndex(i));
+                }
             }
+        }
+
+        // If the previously focused tab hasn't been removed, refocus it since the index may have
+        // changed, otherwise the application may crash due to out-of-bounds vector access
+        if let Some((i, j, k)) = active_tab {
+            self.dock_state.set_active_tab((
+                egui_dock::SurfaceIndex(i),
+                egui_dock::NodeIndex(j),
+                egui_dock::TabIndex(k),
+            ));
+        }
+        // Otherwise we need to unfocus all tabs, again to prevent a crash
+        else {
+            self.dock_state.set_focused_node_and_surface((
+                egui_dock::SurfaceIndex(usize::MAX),
+                egui_dock::NodeIndex(usize::MAX),
+            ));
         }
     }
 

--- a/crates/core/src/tab.rs
+++ b/crates/core/src/tab.rs
@@ -75,8 +75,12 @@ impl Tabs {
         ui: &mut egui::Ui,
         update_state: &mut crate::UpdateState<'_>,
     ) {
+        let mut style = egui_dock::Style::from_egui(ui.style());
+        style.overlay.surface_fade_opacity = 1.;
+
         egui_dock::DockArea::new(&mut self.dock_state)
             .id(self.id)
+            .style(style)
             .show_inside(ui, &mut TabViewer { update_state });
     }
 
@@ -84,16 +88,7 @@ impl Tabs {
     pub fn ui(&mut self, ui: &mut egui::Ui, update_state: &mut crate::UpdateState) {
         let mut edit_tabs = EditTabs::default();
         let mut update_state = update_state.reborrow_with_edit_tabs(&mut edit_tabs);
-
-        egui_dock::DockArea::new(&mut self.dock_state)
-            .id(self.id)
-            .show_inside(
-                ui,
-                &mut TabViewer {
-                    update_state: &mut update_state,
-                },
-            );
-
+        self.ui_without_edit(ui, &mut update_state);
         self.process_edit_tabs(edit_tabs);
     }
 

--- a/crates/core/src/tab.rs
+++ b/crates/core/src/tab.rs
@@ -182,6 +182,12 @@ impl<'a, 'res> egui_dock::TabViewer for TabViewer<'a, 'res> {
     fn force_close(&mut self, tab: &mut Self::Tab) -> bool {
         tab.force_close()
     }
+
+    fn scroll_bars(&self, _tab: &Self::Tab) -> [bool; 2] {
+        // We need to disable scroll bars for at least the map editor because otherwise it'll start
+        // jiggling when the screen or tab is resized. We're not making that type of game.
+        [false, false]
+    }
 }
 
 /// A tab trait.

--- a/crates/core/src/tab.rs
+++ b/crates/core/src/tab.rs
@@ -27,6 +27,7 @@ pub struct Tabs {
     dock_state: egui_dock::DockState<Box<dyn Tab>>,
 
     id: egui::Id,
+    allowed_in_windows: bool,
 }
 
 #[derive(Default)]
@@ -42,20 +43,27 @@ struct TabViewer<'a, 'res> {
     // FIXME: variance
     update_state: &'a mut crate::UpdateState<'res>,
     focused_id: Option<egui::Id>,
+    allowed_in_windows: bool,
 }
 
 impl Tabs {
-    pub fn new(id: impl std::hash::Hash) -> Self {
+    pub fn new(id: impl std::hash::Hash, allowed_in_windows: bool) -> Self {
         Self {
             id: egui::Id::new(id),
+            allowed_in_windows,
             dock_state: egui_dock::DockState::new(Vec::with_capacity(4)),
         }
     }
 
     /// Create a new Tab viewer without any tabs.
-    pub fn new_with_tabs(id: impl std::hash::Hash, tabs: Vec<impl Tab + 'static>) -> Self {
+    pub fn new_with_tabs(
+        id: impl std::hash::Hash,
+        tabs: Vec<impl Tab + 'static>,
+        allowed_in_windows: bool,
+    ) -> Self {
         Self {
             id: egui::Id::new(id),
+            allowed_in_windows,
             dock_state: egui_dock::DockState::new(
                 tabs.into_iter().map(|t| Box::new(t) as Box<_>).collect(),
             ),
@@ -97,6 +105,7 @@ impl Tabs {
                         &mut TabViewer {
                             update_state,
                             focused_id,
+                            allowed_in_windows: self.allowed_in_windows,
                         },
                     );
             });
@@ -236,6 +245,10 @@ impl<'a, 'res> egui_dock::TabViewer for TabViewer<'a, 'res> {
         // We need to disable scroll bars for at least the map editor because otherwise it'll start
         // jiggling when the screen or tab is resized. We're not making that type of game.
         [false, false]
+    }
+
+    fn allowed_in_windows(&self, _tab: &mut Self::Tab) -> bool {
+        self.allowed_in_windows
     }
 }
 

--- a/crates/core/src/tab.rs
+++ b/crates/core/src/tab.rs
@@ -76,23 +76,30 @@ impl Tabs {
         ui: &mut egui::Ui,
         update_state: &mut crate::UpdateState<'_>,
     ) {
-        let mut style = egui_dock::Style::from_egui(ui.style());
-        style.overlay.surface_fade_opacity = 1.;
+        // This scroll area with hidden scrollbars is a hacky workaround for
+        // https://github.com/Adanos020/egui_dock/issues/90
+        // which, for us, seems to manifest when the user moves tabs around
+        egui::ScrollArea::vertical()
+            .scroll_bar_visibility(egui::scroll_area::ScrollBarVisibility::AlwaysHidden)
+            .show(ui, |ui| {
+                let mut style = egui_dock::Style::from_egui(ui.style());
+                style.overlay.surface_fade_opacity = 1.;
 
-        let focused_id = ui
-            .memory(|m| m.focus().is_none())
-            .then_some(self.dock_state.find_active_focused().map(|(_, t)| t.id()))
-            .flatten();
-        egui_dock::DockArea::new(&mut self.dock_state)
-            .id(self.id)
-            .style(style)
-            .show_inside(
-                ui,
-                &mut TabViewer {
-                    update_state,
-                    focused_id,
-                },
-            );
+                let focused_id = ui
+                    .memory(|m| m.focus().is_none())
+                    .then_some(self.dock_state.find_active_focused().map(|(_, t)| t.id()))
+                    .flatten();
+                egui_dock::DockArea::new(&mut self.dock_state)
+                    .id(self.id)
+                    .style(style)
+                    .show_inside(
+                        ui,
+                        &mut TabViewer {
+                            update_state,
+                            focused_id,
+                        },
+                    );
+            });
     }
 
     /// Display all tabs.

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -59,10 +59,10 @@ macro_rules! tab_enum {
                 }
             }
 
-            fn show(&mut self, ui: &mut egui::Ui, update_state: &mut luminol_core::UpdateState<'_>) {
+            fn show(&mut self, ui: &mut egui::Ui, update_state: &mut luminol_core::UpdateState<'_>, is_focused: bool) {
                 match self {
                     $(
-                        Self::$variant(v) => v.show(ui, update_state),
+                        Self::$variant(v) => v.show(ui, update_state, is_focused),
                     )*
                 }
             }

--- a/crates/ui/src/tabs/map/brush.rs
+++ b/crates/ui/src/tabs/map/brush.rs
@@ -72,20 +72,23 @@ impl super::Tab {
                 }
             }
 
-            luminol_core::Pencil::Fill
-                if initial_tile == self.tilepicker.get_tile_from_offset(0, 0) => {}
             luminol_core::Pencil::Fill => {
+                let drawing_shape_pos = if let Some(drawing_shape_pos) = self.drawing_shape_pos {
+                    drawing_shape_pos
+                } else {
+                    self.drawing_shape_pos = Some(self.view.cursor_pos);
+                    self.view.cursor_pos
+                };
+
                 // Use depth-first search to find all of the orthogonally
                 // contiguous matching tiles
                 let mut stack = vec![(map_x, map_y, tile_layer); 1];
-                let initial_x = map_x;
-                let initial_y = map_y;
                 while let Some(position) = stack.pop() {
                     self.set_tile(
                         map,
                         self.tilepicker.get_tile_from_offset(
-                            map_x as i16 - initial_x as i16,
-                            map_y as i16 - initial_y as i16,
+                            position.0 as i16 - drawing_shape_pos.x as i16,
+                            position.1 as i16 - drawing_shape_pos.y as i16,
                         ),
                         position,
                     );

--- a/crates/ui/src/tabs/map/brush.rs
+++ b/crates/ui/src/tabs/map/brush.rs
@@ -22,6 +22,7 @@
 // terms of the Steamworks API by Valve Corporation, the licensors of this
 // Program grant you additional permission to convey the resulting work.
 
+use itertools::Itertools;
 use std::usize;
 
 impl super::Tab {
@@ -50,25 +51,23 @@ impl super::Tab {
                     self.drawing_shape_pos = Some(self.view.cursor_pos);
                     self.view.cursor_pos
                 };
-                for y in 0..height {
-                    for x in 0..width {
-                        // Skip out-of-bounds tiles
-                        if ((x == -1 && map_x == 0) || (x == 1 && map_x + 1 == map.data.xsize()))
-                            || ((y == -1 && map_y == 0)
-                                || (y == 1 && map_y + 1 == map.data.ysize()))
-                        {
-                            continue;
-                        }
+                for (y, x) in (0..height).cartesian_product(0..width) {
+                    let absolute_x = map_x + x as usize;
+                    let absolute_y = map_y + y as usize;
 
-                        self.set_tile(
-                            map,
-                            self.tilepicker.get_tile_from_offset(
-                                x + (self.view.cursor_pos.x - drawing_shape_pos.x) as i16,
-                                y + (self.view.cursor_pos.y - drawing_shape_pos.y) as i16,
-                            ),
-                            (map_x + x as usize, map_y + y as usize, tile_layer),
-                        );
+                    // Skip out-of-bounds tiles
+                    if absolute_x >= map.data.xsize() || absolute_y >= map.data.ysize() {
+                        continue;
                     }
+
+                    self.set_tile(
+                        map,
+                        self.tilepicker.get_tile_from_offset(
+                            x + (self.view.cursor_pos.x - drawing_shape_pos.x) as i16,
+                            y + (self.view.cursor_pos.y - drawing_shape_pos.y) as i16,
+                        ),
+                        (absolute_x, absolute_y, tile_layer),
+                    );
                 }
             }
 

--- a/crates/ui/src/tabs/map/mod.rs
+++ b/crates/ui/src/tabs/map/mod.rs
@@ -153,7 +153,7 @@ impl luminol_core::Tab for Tab {
         &mut self,
         ui: &mut egui::Ui,
         update_state: &mut luminol_core::UpdateState<'_>,
-        _is_focused: bool,
+        is_focused: bool,
     ) {
         // Display the toolbar.
         egui::TopBottomPanel::top(format!("map_{}_toolbar", self.id)).show_inside(ui, |ui| {
@@ -274,6 +274,7 @@ impl luminol_core::Tab for Tab {
                     self.drawing_shape,
                     self.drawing_shape_pos,
                     matches!(update_state.toolbar.pencil, luminol_core::Pencil::Pen),
+                    is_focused,
                 );
 
                 let layers_max = map.data.zsize();

--- a/crates/ui/src/tabs/map/mod.rs
+++ b/crates/ui/src/tabs/map/mod.rs
@@ -149,7 +149,12 @@ impl luminol_core::Tab for Tab {
         self.force_close
     }
 
-    fn show(&mut self, ui: &mut egui::Ui, update_state: &mut luminol_core::UpdateState<'_>) {
+    fn show(
+        &mut self,
+        ui: &mut egui::Ui,
+        update_state: &mut luminol_core::UpdateState<'_>,
+        _is_focused: bool,
+    ) {
         // Display the toolbar.
         egui::TopBottomPanel::top(format!("map_{}_toolbar", self.id)).show_inside(ui, |ui| {
             ui.horizontal_wrapped(|ui| {

--- a/crates/ui/src/tabs/map/mod.rs
+++ b/crates/ui/src/tabs/map/mod.rs
@@ -169,6 +169,7 @@ impl luminol_core::Tab for Tab {
                 ui.add(
                     egui::Slider::new(&mut self.view.scale, 15.0..=300.)
                         .text("Scale")
+                        .logarithmic(true)
                         .fixed_decimals(0),
                 );
 

--- a/crates/ui/src/tabs/map/mod.rs
+++ b/crates/ui/src/tabs/map/mod.rs
@@ -342,9 +342,7 @@ impl luminol_core::Tab for Tab {
                     }
                 } else if let Some(selected_event_id) = self.view.selected_event_id {
                     if response.double_clicked()
-                        || (response.hovered()
-                            && ui.memory(|m| m.focus().is_none())
-                            && ui.input(|i| i.key_pressed(egui::Key::Enter)))
+                        || (is_focused && ui.input(|i| i.key_pressed(egui::Key::Enter)))
                     {
                         // Double-click/press enter on events to edit them
                         if ui.input(|i| !i.modifiers.command) {
@@ -368,8 +366,7 @@ impl luminol_core::Tab for Tab {
                     }
 
                     // Press delete or backspace to delete the selected event
-                    if response.hovered()
-                        && ui.memory(|m| m.focus().is_none())
+                    if is_focused
                         && ui.input(|i| {
                             i.key_pressed(egui::Key::Delete) || i.key_pressed(egui::Key::Backspace)
                         })
@@ -434,9 +431,7 @@ impl luminol_core::Tab for Tab {
                     // Double-click/press enter on an empty space to add an event
                     // (hold shift to prevent events from being selected)
                     if response.double_clicked()
-                        || (response.hovered()
-                            && ui.memory(|m| m.focus().is_none())
-                            && ui.input(|i| i.key_pressed(egui::Key::Enter)))
+                        || (is_focused && ui.input(|i| i.key_pressed(egui::Key::Enter)))
                     {
                         self.dragging_event = false;
                         self.event_drag_offset = None;
@@ -452,14 +447,16 @@ impl luminol_core::Tab for Tab {
 
                 // Handle undo/redo keypresses
                 let is_dragged_by_primary = response.dragged_by(egui::PointerButton::Primary);
-                let is_undo_pressed = ui.input(|i| {
-                    i.modifiers.command && !i.modifiers.shift && i.key_pressed(egui::Key::Z)
-                });
-                let is_redo_pressed = ui.input(|i| {
-                    i.modifiers.command
-                        && (i.modifiers.shift || i.key_pressed(egui::Key::Y))
-                        && (!i.modifiers.shift || i.key_pressed(egui::Key::Z))
-                });
+                let is_undo_pressed = is_focused
+                    && ui.input(|i| {
+                        i.modifiers.command && !i.modifiers.shift && i.key_pressed(egui::Key::Z)
+                    });
+                let is_redo_pressed = is_focused
+                    && ui.input(|i| {
+                        i.modifiers.command
+                            && (i.modifiers.shift || i.key_pressed(egui::Key::Y))
+                            && (!i.modifiers.shift || i.key_pressed(egui::Key::Z))
+                    });
                 if !is_dragged_by_primary && (is_undo_pressed || is_redo_pressed) {
                     let new_entry = match if is_undo_pressed {
                         self.history.pop_back()

--- a/crates/ui/src/tabs/map/mod.rs
+++ b/crates/ui/src/tabs/map/mod.rs
@@ -431,10 +431,19 @@ impl luminol_core::Tab for Tab {
                             // after adjusting for drag offset, unless that would put the event
                             // on the same tile as an existing event
                             let adjusted_hover_tile = hover_tile + info.offset;
-                            if !map.events.iter().any(|(_, e)| {
-                                adjusted_hover_tile.x == e.x as f32
-                                    && adjusted_hover_tile.y == e.y as f32
-                            }) {
+                            if egui::Rect::from_min_size(
+                                egui::pos2(0., 0.),
+                                egui::vec2(
+                                    map.data.xsize() as f32 - 0.5,
+                                    map.data.ysize() as f32 - 0.5,
+                                ),
+                            )
+                            .contains(adjusted_hover_tile)
+                                && !map.events.iter().any(|(_, e)| {
+                                    adjusted_hover_tile.x == e.x as f32
+                                        && adjusted_hover_tile.y == e.y as f32
+                                })
+                            {
                                 if let Some(selected_event) = map.events.get_mut(selected_event_id)
                                 {
                                     selected_event.x = adjusted_hover_tile.x as i32;

--- a/crates/ui/src/tabs/map/mod.rs
+++ b/crates/ui/src/tabs/map/mod.rs
@@ -247,7 +247,7 @@ impl luminol_core::Tab for Tab {
         // Display the tilepicker.
         let spacing = ui.spacing();
         let tilepicker_default_width = 256.
-            + 3. * spacing.window_margin.left
+            + spacing.indent
             + spacing.scroll_bar_inner_margin
             + spacing.scroll_bar_width
             + spacing.scroll_bar_outer_margin;

--- a/crates/ui/src/tabs/map/mod.rs
+++ b/crates/ui/src/tabs/map/mod.rs
@@ -28,6 +28,18 @@ use std::{cell::RefMut, collections::HashMap, collections::VecDeque};
 
 const HISTORY_SIZE: usize = 50;
 
+struct EventDragInfo {
+    /// ID of the event being dragged
+    id: usize,
+    /// Original x position of the event at the start of the drag
+    x: i32,
+    /// Original y position of the event at the start of the drag
+    y: i32,
+    /// Difference between the dragged event's tile and the cursor position, at the start of the
+    /// drag
+    offset: egui::Vec2,
+}
+
 use crate::windows::event_edit;
 
 use itertools::Itertools;
@@ -43,14 +55,11 @@ pub struct Tab {
     pub view: luminol_components::MapView,
     pub tilepicker: luminol_components::Tilepicker,
 
-    dragging_event: bool,
     drawing_shape: bool,
     event_windows: luminol_core::Windows,
     force_close: bool,
 
-    /// When event dragging starts, this is set to the difference between
-    /// the dragged event's tile and the cursor position
-    event_drag_offset: Option<egui::Vec2>,
+    event_drag_info: Option<EventDragInfo>,
 
     layer_cache: Vec<i16>,
 
@@ -114,12 +123,11 @@ impl Tab {
             view,
             tilepicker,
 
-            dragging_event: false,
             drawing_shape: false,
             event_windows: luminol_core::Windows::default(),
             force_close: false,
 
-            event_drag_offset: None,
+            event_drag_info: None,
 
             layer_cache: vec![0; map.data.xsize() * map.data.ysize()],
 
@@ -270,7 +278,7 @@ impl luminol_core::Tab for Tab {
                     &update_state.graphics,
                     &map,
                     &self.tilepicker,
-                    self.dragging_event,
+                    self.event_drag_info.is_some(),
                     self.drawing_shape,
                     self.drawing_shape_pos,
                     matches!(update_state.toolbar.pencil, luminol_core::Pencil::Pen),
@@ -281,9 +289,38 @@ impl luminol_core::Tab for Tab {
                 let map_x = self.view.cursor_pos.x as i32;
                 let map_y = self.view.cursor_pos.y as i32;
 
-                if self.dragging_event && self.view.selected_event_id.is_none() {
-                    self.dragging_event = false;
-                    self.event_drag_offset = None;
+                let is_delete_pressed = is_focused
+                    && ui.input(|i| {
+                        i.key_pressed(egui::Key::Delete) || i.key_pressed(egui::Key::Backspace)
+                    });
+
+                // If the user stopped dragging an event or the user tried to delete an event while
+                // dragging it
+                if self.event_drag_info.as_ref().is_some_and(|info| {
+                    is_delete_pressed
+                        || !response.dragged_by(egui::PointerButton::Primary)
+                        || !self.view.selected_event_id.is_some_and(|id| info.id == id)
+                }) {
+                    let info = self.event_drag_info.take().unwrap();
+
+                    // If the event has moved from its original position, save the original
+                    // position to the history (we need to check if it has moved because otherwise
+                    // it'll also be saved if the user just clicks or double-clicks the event)
+                    if map
+                        .events
+                        .get(info.id)
+                        .is_some_and(|event| event.x != info.x || event.y != info.y)
+                    {
+                        self.redo_history.clear();
+                        if self.history.len() == HISTORY_SIZE {
+                            self.history.pop_front();
+                        }
+                        self.history.push_back(HistoryEntry::EventMoved {
+                            id: info.id,
+                            x: info.x,
+                            y: info.y,
+                        });
+                    }
                 }
 
                 if !response.dragged_by(egui::PointerButton::Primary) {
@@ -346,31 +383,13 @@ impl luminol_core::Tab for Tab {
                     {
                         // Double-click/press enter on events to edit them
                         if ui.input(|i| !i.modifiers.command) {
-                            self.dragging_event = false;
-                            self.event_drag_offset = None;
                             self.event_windows
                                 .add_window(event_edit::Window::new(selected_event_id, self.id));
                         }
                     }
-                    // Allow drag and drop to move events
-                    else if !self.dragging_event
-                        && self.view.selected_event_is_hovered
-                        && response.drag_started_by(egui::PointerButton::Primary)
-                    {
-                        self.dragging_event = true;
-                    } else if self.dragging_event
-                        && !response.dragged_by(egui::PointerButton::Primary)
-                    {
-                        self.dragging_event = false;
-                        self.event_drag_offset = None;
-                    }
 
                     // Press delete or backspace to delete the selected event
-                    if is_focused
-                        && ui.input(|i| {
-                            i.key_pressed(egui::Key::Delete) || i.key_pressed(egui::Key::Backspace)
-                        })
-                    {
+                    if is_delete_pressed {
                         let event = map.events.remove(selected_event_id);
                         let sprites = self.view.events.try_remove(selected_event_id).ok();
                         self.redo_history.clear();
@@ -382,47 +401,43 @@ impl luminol_core::Tab for Tab {
                     }
 
                     if let Some(hover_tile) = self.view.hover_tile {
-                        if self.dragging_event {
+                        // Allow drag and drop to move events
+                        if self.event_drag_info.is_none()
+                            && self.view.selected_event_is_hovered
+                            && !response.double_clicked()
+                            && response.drag_started_by(egui::PointerButton::Primary)
+                        {
                             if let Some(selected_event) = map.events.get(selected_event_id) {
                                 // If we just started dragging an event, save the offset between the
                                 // cursor and the event's tile so that the event will be dragged
                                 // with that offset from the cursor
-                                if self.event_drag_offset.is_none() {
-                                    self.event_drag_offset = Some(
-                                        egui::Pos2::new(
+                                if self.event_drag_info.is_none() {
+                                    self.event_drag_info = Some(EventDragInfo {
+                                        id: selected_event.id,
+                                        x: selected_event.x,
+                                        y: selected_event.y,
+                                        offset: egui::Pos2::new(
                                             selected_event.x as f32,
                                             selected_event.y as f32,
                                         ) - hover_tile,
-                                    );
-
-                                    // Also save the original position of the event to the history
-                                    self.redo_history.clear();
-                                    if self.history.len() == HISTORY_SIZE {
-                                        self.history.pop_front();
-                                    }
-                                    self.history.push_back(HistoryEntry::EventMoved {
-                                        id: selected_event_id,
-                                        x: selected_event.x,
-                                        y: selected_event.y,
                                     });
                                 };
                             }
+                        }
 
-                            if let Some(offset) = self.event_drag_offset {
-                                // If moving an event, move the dragged event's tile to the cursor
-                                // after adjusting for drag offset, unless that would put the event
-                                // on the same tile as an existing event
-                                let adjusted_hover_tile = hover_tile + offset;
-                                if !map.events.iter().any(|(_, e)| {
-                                    adjusted_hover_tile.x == e.x as f32
-                                        && adjusted_hover_tile.y == e.y as f32
-                                }) {
-                                    if let Some(selected_event) =
-                                        map.events.get_mut(selected_event_id)
-                                    {
-                                        selected_event.x = adjusted_hover_tile.x as i32;
-                                        selected_event.y = adjusted_hover_tile.y as i32;
-                                    }
+                        if let Some(info) = &self.event_drag_info {
+                            // If moving an event, move the dragged event's tile to the cursor
+                            // after adjusting for drag offset, unless that would put the event
+                            // on the same tile as an existing event
+                            let adjusted_hover_tile = hover_tile + info.offset;
+                            if !map.events.iter().any(|(_, e)| {
+                                adjusted_hover_tile.x == e.x as f32
+                                    && adjusted_hover_tile.y == e.y as f32
+                            }) {
+                                if let Some(selected_event) = map.events.get_mut(selected_event_id)
+                                {
+                                    selected_event.x = adjusted_hover_tile.x as i32;
+                                    selected_event.y = adjusted_hover_tile.y as i32;
                                 }
                             }
                         }
@@ -433,8 +448,6 @@ impl luminol_core::Tab for Tab {
                     if response.double_clicked()
                         || (is_focused && ui.input(|i| i.key_pressed(egui::Key::Enter)))
                     {
-                        self.dragging_event = false;
-                        self.event_drag_offset = None;
                         if let Some(id) = self.add_event(&mut map) {
                             self.redo_history.clear();
                             if self.history.len() == HISTORY_SIZE {

--- a/crates/ui/src/tabs/started.rs
+++ b/crates/ui/src/tabs/started.rs
@@ -52,7 +52,12 @@ impl luminol_core::Tab for Tab {
         egui::Id::new("luminol_started_tab")
     }
 
-    fn show(&mut self, ui: &mut egui::Ui, update_state: &mut luminol_core::UpdateState<'_>) {
+    fn show(
+        &mut self,
+        ui: &mut egui::Ui,
+        update_state: &mut luminol_core::UpdateState<'_>,
+        _is_focused: bool,
+    ) {
         ui.label(
             egui::RichText::new("Luminol")
                 .size(40.)

--- a/crates/ui/src/windows/common_event_edit.rs
+++ b/crates/ui/src/windows/common_event_edit.rs
@@ -33,7 +33,7 @@ pub struct Window {
 impl Default for Window {
     fn default() -> Self {
         Self {
-            tabs: luminol_core::Tabs::new("common_event_tabs"),
+            tabs: luminol_core::Tabs::new("common_event_tabs", false),
             selected_id: 0,
         }
     }

--- a/crates/ui/src/windows/common_event_edit.rs
+++ b/crates/ui/src/windows/common_event_edit.rs
@@ -123,7 +123,12 @@ impl luminol_core::Tab for CommonEventTab {
         egui::Id::new("luminol_common_event").with(self.event.id)
     }
 
-    fn show(&mut self, ui: &mut egui::Ui, update_state: &mut luminol_core::UpdateState<'_>) {
+    fn show(
+        &mut self,
+        ui: &mut egui::Ui,
+        update_state: &mut luminol_core::UpdateState<'_>,
+        _is_focused: bool,
+    ) {
         ui.horizontal(|ui| {
             let trigger_types = ["None", "Autorun", "Parallel"];
             egui::ComboBox::new(format!("common_event_{}_trigger", self.event.id), "Trigger")

--- a/crates/ui/src/windows/script_edit.rs
+++ b/crates/ui/src/windows/script_edit.rs
@@ -140,7 +140,12 @@ impl luminol_core::Tab for ScriptTab {
         egui::Id::new("luminol_script_edit").with(self.index)
     }
 
-    fn show(&mut self, ui: &mut egui::Ui, update_state: &mut luminol_core::UpdateState<'_>) {
+    fn show(
+        &mut self,
+        ui: &mut egui::Ui,
+        update_state: &mut luminol_core::UpdateState<'_>,
+        _is_focused: bool,
+    ) {
         // FIXME
 
         ui.horizontal(|ui| {

--- a/crates/ui/src/windows/script_edit.rs
+++ b/crates/ui/src/windows/script_edit.rs
@@ -30,7 +30,7 @@ pub struct Window {
 impl Default for Window {
     fn default() -> Self {
         Self {
-            tabs: luminol_core::Tabs::new("script_editor"),
+            tabs: luminol_core::Tabs::new("script_editor", false),
         }
     }
 }

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -48,6 +48,7 @@ web-sys = { version = "0.3", features = [
 
     "Event",
     "MouseEvent",
+    "WheelEvent",
 
     "DedicatedWorkerGlobalScope",
     "WorkerGlobalScope",

--- a/crates/web/src/web_worker_runner.rs
+++ b/crates/web/src/web_worker_runner.rs
@@ -537,7 +537,8 @@ pub fn setup_main_thread_hooks(
         let f = {
             let custom_event_tx = custom_event_tx.clone();
             let window = window.clone();
-            let canvas_id = canvas.id();
+            let document = document.clone();
+            let canvas = canvas.clone();
             move || {
                 if PANIC_LOCK.get().is_some() {
                     return;
@@ -548,12 +549,12 @@ pub fn setup_main_thread_hooks(
                 } else {
                     1.
                 };
+                let width = window.inner_width().unwrap().as_f64().unwrap() as u32;
+                let height = window.inner_height().unwrap().as_f64().unwrap() as u32;
+                let _ = canvas.set_attribute("width", width.to_string().as_str());
+                let _ = canvas.set_attribute("height", height.to_string().as_str());
                 let _ = custom_event_tx.send(WebWorkerRunnerEvent(
-                    WebWorkerRunnerEventInner::ScreenResize(
-                        window.inner_width().unwrap().as_f64().unwrap() as u32,
-                        window.inner_height().unwrap().as_f64().unwrap() as u32,
-                        pixel_ratio,
-                    ),
+                    WebWorkerRunnerEventInner::ScreenResize(width, height, pixel_ratio),
                 ));
             }
         };

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -174,6 +174,7 @@ impl App {
             tabs: luminol_core::Tabs::new_with_tabs(
                 "luminol_main_tabs",
                 vec![luminol_ui::tabs::started::Tab::default()],
+                true,
             ),
             global_config,
             project_config,


### PR DESCRIPTION
This pull request contains some general quality improvements for the tilemap, mostly related to how it interacts with egui_dock's tabs and with very small screen sizes. See the commit messages for more details. For example, there was a problem before where if the user had multiple map editors open in a splitscreen configuration, the arrow keys would control the cursor on all of the visible maps simultaneously. ~~I updated egui_dock from 0.6.3 to 0.7.3 to fix a different tab-related bug that would've been hard to manually fix~~ The egui_dock upgrade that this pull request originally did was already performed by #45.

Additionally, there are changes to how zooming on the map works. It now scales at a perceptually uniform speed regardless of the current zoom instead of scaling faster when zoomed out and slower when zoomed in (including when using the scale slider!) and when using the slider it now zooms around the center of the *visible* part of the map instead of the entire map.