### PR TITLE
Reduce map rerender interval to once every 16 frames at 60 FPS

### DIFF
--- a/src/components/tilepicker.rs
+++ b/src/components/tilepicker.rs
@@ -137,7 +137,8 @@ impl Tilepicker {
             self.ani_time = Some(time);
         }
 
-        ui.ctx().request_repaint_after(Duration::from_millis(16));
+        ui.ctx()
+            .request_repaint_after(Duration::from_secs_f64(16. / 60.));
 
         let (canvas_rect, response) = ui.allocate_exact_size(
             egui::vec2(256., self.resources.tiles.atlas.tileset_height as f32 + 32.),

--- a/src/graphics/map.rs
+++ b/src/graphics/map.rs
@@ -135,7 +135,7 @@ impl Map {
 
         painter
             .ctx()
-            .request_repaint_after(Duration::from_millis(16));
+            .request_repaint_after(Duration::from_secs_f64(16. / 60.));
 
         let resources = self.resources.clone();
         let resource_id = Arc::new(OnceCell::new());


### PR DESCRIPTION
This changes the map editor's duration for automatically rerendering the map editor when not being interacted with, from once every 16 milliseconds to once every 16/60 seconds to reduce idle-time GPU usage.