### PR TITLE
Tilepicker scrollbar fix

### DIFF
--- a/crates/core/src/tab.rs
+++ b/crates/core/src/tab.rs
@@ -236,6 +236,10 @@ impl<'a, 'res> egui_dock::TabViewer for TabViewer<'a, 'res> {
         tab.name(self.update_state).into()
     }
 
+    fn id(&mut self, tab: &mut Self::Tab) -> egui::Id {
+        tab.id()
+    }
+
     fn ui(&mut self, ui: &mut egui::Ui, tab: &mut Self::Tab) {
         let id = tab.id();
         ui.push_id(id, |ui| {

--- a/crates/ui/src/tabs/map/mod.rs
+++ b/crates/ui/src/tabs/map/mod.rs
@@ -286,11 +286,7 @@ impl luminol_core::Tab for Tab {
 
         // Display the tilepicker.
         let spacing = ui.spacing();
-        let tilepicker_default_width = 256.
-            + spacing.indent
-            + spacing.scroll.bar_inner_margin
-            + spacing.scroll.bar_width
-            + spacing.scroll.bar_outer_margin;
+        let tilepicker_default_width = 256. + spacing.indent;
         egui::SidePanel::left(format!("map_{}_tilepicker", self.id))
             .default_width(tilepicker_default_width)
             .max_width(tilepicker_default_width)


### PR DESCRIPTION
**Connections**

**Description**
In egui 0.24, the scrollbars no longer take up any space by default and only appear when you hover over where the scrollbar is supposed to be. So since Astrabit-ST/Luminol#75, the tilepicker width was incorrectly including the width of the scrollbar in the width calculation, making the tilepicker too wide. This removes the width of the scrollbar from the tilepicker width formula so that the tilepicker default width and maximum width are calculated correctly.

I also fixed another issue where the tilepicker's scroll position changes when the current map is modified. This was happening because egui_dock was using the title of the tab to derive the ID of the tab instead of using the `id` function in the tab trait.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo build --release` 
- [ ] If applicable, run `trunk build --release`