### PR TITLE
Fix deadlock when panning the map editor with Ctrl+drag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,10 @@ anyhow = "1.0"
 puffin = "0.18"
 raw-window-handle = "0.5.0"
 
-parking_lot = { version = "0.12.1", features = ["deadlock_detection"] }
+parking_lot = { version = "0.12.1", features = [
+    "nightly", # This is required for parking_lot to work properly in WebAssembly builds with atomics support
+    "deadlock_detection",
+] }
 once_cell = "1.18.0"
 crossbeam = "0.8.2"
 dashmap = "5.5.3"

--- a/crates/components/src/map_view.rs
+++ b/crates/components/src/map_view.rs
@@ -222,8 +222,8 @@ impl MapView {
                 }
             }
 
-            i.modifiers.command && response.dragged_by(egui::PointerButton::Primary)
-        });
+            i.modifiers.command
+        }) && response.dragged_by(egui::PointerButton::Primary);
 
         let panning_map_view = response.dragged_by(egui::PointerButton::Middle) || ctrl_drag;
 


### PR DESCRIPTION
**Description**
This pull request fixes a deadlock that occurs when panning the map by holding down the Control key and dragging with the primary mouse button. This was most likely introduced by the upgrade to egui 0.24.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo build --release` 
- [x] If applicable, run `trunk build --release`