### PR TITLE
Use fragile to remove Send + Sync impls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,6 +1877,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fragile"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+
+[[package]]
 name = "futures"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3032,6 +3038,7 @@ version = "0.4.0"
 dependencies = [
  "color-eyre",
  "egui",
+ "fragile",
  "glam",
  "indextree",
  "itertools",
@@ -3207,6 +3214,7 @@ dependencies = [
  "crossbeam",
  "dashmap",
  "egui",
+ "fragile",
  "glam",
  "image 0.24.7",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ puffin = "0.18"
 raw-window-handle = "0.5.0"
 
 parking_lot = { version = "0.12.1", features = [
-    "nightly", # This is required for parking_lot to work properly in WebAssembly builds with atomics support
+    "nightly",            # This is required for parking_lot to work properly in WebAssembly builds with atomics support
     "deadlock_detection",
 ] }
 once_cell = "1.18.0"
@@ -113,6 +113,7 @@ oneshot = "0.1.6"
 futures-lite = "2.1.0"
 async-std = "1.12.0"
 pin-project = "1"
+fragile = "2.0"
 
 poll-promise = { version = "0.3.0" }
 

--- a/crates/components/Cargo.toml
+++ b/crates/components/Cargo.toml
@@ -43,3 +43,5 @@ color-eyre.workspace = true
 qp-trie.workspace = true
 indextree = "4.6.0"
 lexical-sort = "0.3.1"
+
+fragile.workspace = true

--- a/crates/graphics/Cargo.toml
+++ b/crates/graphics/Cargo.toml
@@ -40,3 +40,5 @@ camino.workspace = true
 
 luminol-data.workspace = true
 luminol-filesystem.workspace = true
+
+fragile.workspace = true


### PR DESCRIPTION
**Description**
There were a couple of unsafe Send + Sync impls to get around the fact that wgpu types are !Send + !Sync on web (due to containing references into the JS heap). This PR replaces these impls with the fragile crate, which prevents types being accessed outside the thread that created them.

**Testing**
Tested opening maps in webassembly and native builds.

<!-- 
Thanks for filing a pull request! The codeowners file will automatically request reviews.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo build --release` 
- [x] If applicable, run `trunk build --release`