### PR TITLE
Lazy path cache

### DIFF
--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -48,6 +48,7 @@ iter-read = "1.0.1"
 async_io_stream = "0.3.3"
 
 qp-trie.workspace = true
+slab.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 winreg = "0.51.0"

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -59,7 +59,6 @@ async-fs = "2.1.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 once_cell.workspace = true
-slab.workspace = true
 
 luminol-web = { version = "0.4.0", path = "../web/" }
 

--- a/crates/filesystem/src/path_cache.rs
+++ b/crates/filesystem/src/path_cache.rs
@@ -343,7 +343,10 @@ where
         let path = path.as_ref();
         let c = format!("While removing directory {path:?} in a path cache");
         cache.regen(&self.fs, path).wrap_err_with(|| c.clone())?;
-        let path = cache.desensitize(path).ok_or(Error::NotExist)?;
+        let path = cache
+            .desensitize(path)
+            .ok_or(Error::NotExist)
+            .wrap_err_with(|| c.clone())?;
 
         self.fs.remove_dir(&path).wrap_err_with(|| c.clone())?;
 
@@ -364,7 +367,10 @@ where
         let path = path.as_ref();
         let c = format!("While removing file {path:?} in a path cache");
         cache.regen(&self.fs, path).wrap_err_with(|| c.clone())?;
-        let path = cache.desensitize(path).ok_or(Error::NotExist)?;
+        let path = cache
+            .desensitize(path)
+            .ok_or(Error::NotExist)
+            .wrap_err_with(|| c.clone())?;
 
         self.fs.remove_file(&path).wrap_err_with(|| c.clone())?;
 
@@ -380,7 +386,10 @@ where
         let path = path.as_ref();
         let c = format!("While reading the contents of the directory {path:?} in a path cache");
         cache.regen(&self.fs, path).wrap_err_with(|| c.clone())?;
-        let path = cache.desensitize(path).ok_or(Error::NotExist)?;
+        let path = cache
+            .desensitize(path)
+            .ok_or(Error::NotExist)
+            .wrap_err_with(|| c.clone())?;
         self.fs.read_dir(path).wrap_err_with(|| c.clone())
     }
 }

--- a/crates/filesystem/src/path_cache.rs
+++ b/crates/filesystem/src/path_cache.rs
@@ -65,8 +65,7 @@ impl Cache {
             node = n.next.and_then(|next| self.cactus.get(next));
         }
 
-        vec.reverse();
-        vec.iter().join("/").into()
+        vec.iter().rev().join("/").into()
     }
 
     /// Gets the original, case-sensitive version of the given case-insensitive path from the underlying

--- a/crates/filesystem/src/path_cache.rs
+++ b/crates/filesystem/src/path_cache.rs
@@ -92,15 +92,29 @@ impl Cache {
 
         // Get the longest prefix of the path that is in the trie, convert it to lowercase and
         // remove file extensions
-        let mut lower_string = String::with_capacity(path.as_str().bytes().len());
-        lower_string.push_str(prefix.as_str());
+        let mut lower_string = prefix.to_string();
+        if let Some(additional) = path
+            .as_str()
+            .bytes()
+            .len()
+            .checked_sub(lower_string.bytes().len())
+        {
+            lower_string.reserve(additional);
+        }
 
         // This is the same thing as `lower_string` except with the actual letter casing from the
         // filesystem and without removing file extensions
-        let original =
-            cactus_index.map_or_else(Default::default, |i| self.get_path_from_cactus_index(i));
-        let mut original_string = String::with_capacity(path.as_str().bytes().len());
-        original_string.push_str(original.as_str());
+        let mut original_string = cactus_index.map_or_else(Default::default, |i| {
+            self.get_path_from_cactus_index(i).to_string()
+        });
+        if let Some(additional) = path
+            .as_str()
+            .bytes()
+            .len()
+            .checked_sub(original_string.bytes().len())
+        {
+            original_string.reserve(additional);
+        }
 
         // Iterate over the remaining path components that aren't present in
         // `lower_string`/`original_string`

--- a/crates/filesystem/src/path_cache.rs
+++ b/crates/filesystem/src/path_cache.rs
@@ -15,25 +15,169 @@
 // You should have received a copy of the GNU General Public License
 // along with Luminol.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{DirEntry, Error, Metadata, OpenFlags, Result};
 use color_eyre::eyre::WrapErr;
+use itertools::Itertools;
+
+use crate::{DirEntry, Error, FileSystem as FileSystemTrait, Metadata, OpenFlags, Result};
+
+const TRIE_SUFFIX: &str = "\0";
 
 #[derive(Debug, Clone)]
+struct CactusNode {
+    /// The path component stored in this cactus stack node.
+    value: String,
+    /// The index of the next node within the cactus stack, or `None` if there is no next node.
+    next: Option<usize>,
+    /// One more than the number of times you need to follow `next` until you get `None`.
+    len: usize,
+}
+
+/// This cache stores the lowercased versions of paths and their corresponding original paths.
+/// Given a lowercased path, for example "data/mapinfos", you can find the original path by first
+/// appending a forward slash followed by `TRIE_SUFFIX` to the end of the path, then looking up the
+/// file at that path in `trie`. This gives you the index of a node in `cactus`, which stores the
+/// original path. To recover the original path, follow the chain of cactus stack nodes by
+/// following the `next` field on the nodes. This gives you the path components of the original
+/// path in reverse order.
+#[derive(Debug, Default, Clone)]
+struct Cache {
+    trie: crate::FileSystemTrie<usize>,
+    cactus: slab::Slab<CactusNode>,
+}
+
+#[derive(Debug)]
 pub struct FileSystem<F> {
     fs: F,
-    cache: dashmap::DashMap<camino::Utf8PathBuf, camino::Utf8PathBuf>,
+    cache: parking_lot::RwLock<Cache>,
+}
+
+impl Cache {
+    fn get_path_from_cactus_index(&self, index: usize) -> camino::Utf8PathBuf {
+        let Some(node) = self.cactus.get(index) else {
+            return Default::default();
+        };
+
+        let mut vec = Vec::with_capacity(node.len);
+
+        let mut node = Some(node);
+        while let Some(n) = node {
+            vec.push(&n.value);
+            node = n.next.and_then(|next| self.cactus.get(next));
+        }
+
+        vec.reverse();
+        vec.iter().join("/").into()
+    }
+
+    /// Gets the original, case-sensitive version of the given case-insensitive path from the underlying
+    /// filesystem and puts it into the cache.
+    /// This method memoizes: if we want to insert "this/is/a/path" and the cache already contains
+    /// the case-sensitive version of the path "this/is", we will only scan the underlying filesystem
+    /// for the case-sensitive names of the remaining two components in the path.
+    fn regen(
+        &mut self,
+        fs: &impl FileSystemTrait,
+        path: impl AsRef<camino::Utf8Path>,
+    ) -> crate::Result<()> {
+        let mut path = to_lowercase(path);
+        path.set_extension("");
+        if self.trie.contains_dir(&path) {
+            return Ok(());
+        }
+
+        let prefix = self.trie.get_dir_prefix(&path);
+        let mut cactus_index = (!prefix.as_str().is_empty())
+            .then(|| *self.trie.get_file(with_trie_suffix(prefix)).unwrap());
+        let mut len = prefix.iter().count();
+
+        // Get the longest prefix of the path that is in the trie, convert it to lowercase and
+        // remove file extensions
+        let mut lower_string = String::with_capacity(path.as_str().bytes().len());
+        lower_string.push_str(prefix.as_str());
+
+        // This is the same thing as `lower_string` except with the actual letter casing from the
+        // filesystem and without removing file extensions
+        let original =
+            cactus_index.map_or_else(Default::default, |i| self.get_path_from_cactus_index(i));
+        let mut original_string = String::with_capacity(path.as_str().bytes().len());
+        original_string.push_str(original.as_str());
+
+        // Iterate over the remaining path components that aren't present in
+        // `lower_string`/`original_string`
+        for name in path.strip_prefix(prefix).unwrap().iter() {
+            let entries = fs
+                .read_dir(&original_string)
+                .wrap_err("While regenerating cache for path {path:?}")?;
+            len += 1;
+
+            let mut original_name = None;
+            let mut new_cactus_index = 0;
+            for entry in entries.into_iter() {
+                let entry_name = camino::Utf8Path::new(entry.file_name())
+                    .file_stem()
+                    .unwrap_or(entry.file_name())
+                    .to_lowercase();
+                let index = self.cactus.insert(CactusNode {
+                    value: entry.file_name().to_string(),
+                    next: cactus_index,
+                    len,
+                });
+                self.trie.create_file(
+                    if lower_string.is_empty() {
+                        with_trie_suffix(&entry_name)
+                    } else {
+                        format!("{lower_string}/{entry_name}/{TRIE_SUFFIX}").into()
+                    },
+                    index,
+                );
+                if entry_name == name {
+                    original_name = Some(entry.file_name().to_string());
+                    new_cactus_index = index;
+                }
+            }
+
+            let Some(original_name) = original_name else {
+                return Ok(());
+            };
+            if !lower_string.is_empty() {
+                lower_string.push('/');
+            }
+            lower_string.push_str(name);
+            if !original_string.is_empty() {
+                original_string.push('/');
+            }
+            original_string.push_str(&original_name);
+            cactus_index = Some(new_cactus_index);
+        }
+
+        Ok(())
+    }
+
+    /// Gets the case-sensitive version of the given case-insensitive path from the cache.
+    /// The path has to already exist in the cache; you need to use `.regen` to insert paths into
+    /// the cache before this can get them.
+    fn desensitize(&self, path: impl AsRef<camino::Utf8Path>) -> Option<camino::Utf8PathBuf> {
+        let path = path.as_ref();
+        if path.as_str().is_empty() {
+            return Some(Default::default());
+        }
+        let mut path = to_lowercase(path);
+        path.set_extension("");
+        self.trie
+            .get_file(with_trie_suffix(&path))
+            .map(|i| self.get_path_from_cactus_index(*i))
+    }
 }
 
 impl<F> FileSystem<F>
 where
-    F: crate::FileSystem,
+    F: FileSystemTrait,
 {
     pub fn new(fs: F) -> Result<Self> {
         let this = FileSystem {
             fs,
-            cache: dashmap::DashMap::new(),
+            cache: Default::default(),
         };
-        this.regen_cache()?;
         Ok(this)
     }
 
@@ -41,73 +185,35 @@ where
         &self.fs
     }
 
-    pub fn regen_cache(&self) -> Result<()> {
-        let c = "While regenerating path cache";
-
-        fn read_dir_recursive(
-            fs: &(impl crate::FileSystem + ?Sized),
-            path: impl AsRef<camino::Utf8Path>,
-            mut f: impl FnMut(&camino::Utf8Path),
-        ) -> Result<()> {
-            fn internal(
-                fs: &(impl crate::FileSystem + ?Sized),
-                path: impl AsRef<camino::Utf8Path>,
-                f: &mut impl FnMut(&camino::Utf8Path),
-            ) -> Result<()> {
-                // In web builds, RTPs are currently to be placed in the "RTP" subdirectory of
-                // the project root directory, so this is to avoid loading the contents of
-                // those directories twice
-                let skip = matches!(path.as_ref().iter().next_back(), Some("RTP"));
-
-                for entry in fs.read_dir(path)? {
-                    f(entry.path());
-                    if !skip && !entry.metadata().is_file {
-                        internal(fs, entry.path(), f)?;
-                    }
-                }
-                Ok(())
-            }
-            internal(fs, path, &mut f)
-        }
-
-        self.cache.clear();
-        read_dir_recursive(&self.fs, "", |path| {
-            let mut lowercase = to_lowercase(path);
-            lowercase.set_extension("");
-
-            self.cache.insert(lowercase, path.to_path_buf());
-        })
-        .wrap_err(c)
-    }
-
     pub fn debug_ui(&self, ui: &mut egui::Ui) {
+        let cache = self.cache.read();
+
         egui::ScrollArea::vertical()
             .id_source("luminol_path_cache_debug_ui")
             .show_rows(
                 ui,
                 ui.text_style_height(&egui::TextStyle::Body),
-                self.cache.len(),
+                cache.cactus.len(),
                 |ui, rows| {
-                    for (_, item) in self
-                        .cache
-                        .iter()
+                    for (_, (key, index)) in cache
+                        .trie
+                        .iter_prefix("")
+                        .unwrap()
                         .enumerate()
                         .filter(|(index, _)| rows.contains(index))
                     {
+                        let Some(key) = key.as_str().strip_suffix(&format!("/{TRIE_SUFFIX}"))
+                        else {
+                            continue;
+                        };
                         ui.horizontal(|ui| {
-                            ui.label(item.key().as_str());
+                            ui.label(key);
                             ui.label("➡");
-                            ui.label(item.value().as_str());
+                            ui.label(cache.get_path_from_cactus_index(*index).as_str());
                         });
                     }
                 },
             );
-    }
-
-    pub fn desensitize(&self, path: impl AsRef<camino::Utf8Path>) -> Option<camino::Utf8PathBuf> {
-        let mut path = to_lowercase(path);
-        path.set_extension("");
-        self.cache.get(&path).as_deref().cloned()
     }
 }
 
@@ -115,9 +221,18 @@ pub fn to_lowercase(p: impl AsRef<camino::Utf8Path>) -> camino::Utf8PathBuf {
     p.as_ref().as_str().to_lowercase().into()
 }
 
-impl<F> crate::FileSystem for FileSystem<F>
+fn with_trie_suffix(path: impl AsRef<camino::Utf8Path>) -> camino::Utf8PathBuf {
+    let path = path.as_ref();
+    if path.as_str().is_empty() {
+        TRIE_SUFFIX.into()
+    } else {
+        format!("{path}/{TRIE_SUFFIX}").into()
+    }
+}
+
+impl<F> FileSystemTrait for FileSystem<F>
 where
-    F: crate::FileSystem,
+    F: FileSystemTrait,
 {
     type File = F::File;
 
@@ -126,24 +241,46 @@ where
         path: impl AsRef<camino::Utf8Path>,
         flags: OpenFlags,
     ) -> Result<Self::File> {
+        let mut cache = self.cache.write();
         let path = path.as_ref();
         let c = format!("While opening file {path:?} in a path cache");
-        if flags.contains(OpenFlags::Create) {
-            let mut lower_path = to_lowercase(path);
-            lower_path.set_extension("");
-            self.cache.insert(lower_path, path.to_path_buf());
+        cache.regen(&self.fs, path).wrap_err_with(|| c.clone())?;
+
+        if flags.contains(OpenFlags::Create) && cache.desensitize(path).is_none() {
+            let path = cache
+                .desensitize(
+                    path.parent()
+                        .ok_or(Error::NotExist)
+                        .wrap_err_with(|| c.clone())?,
+                )
+                .ok_or(Error::NotExist)
+                .wrap_err_with(|| c.clone())?;
+            let file = self
+                .fs
+                .open_file(&path, flags)
+                .wrap_err_with(|| c.clone())?;
+            cache.regen(&self.fs, &path).wrap_err_with(|| c.clone())?;
+            Ok(file)
+        } else {
+            self.fs
+                .open_file(
+                    cache
+                        .desensitize(path)
+                        .ok_or(Error::NotExist)
+                        .wrap_err_with(|| c.clone())?,
+                    flags,
+                )
+                .wrap_err_with(|| c.clone())
         }
-        let path = self
-            .desensitize(path)
-            .ok_or(Error::NotExist)
-            .wrap_err_with(|| c.clone())?;
-        self.fs.open_file(path, flags).wrap_err_with(|| c.clone())
     }
 
     fn metadata(&self, path: impl AsRef<camino::Utf8Path>) -> Result<Metadata> {
+        let mut cache = self.cache.write();
         let path = path.as_ref();
         let c = format!("While getting metadata for {path:?} in a path cache");
-        let path = self
+        cache.regen(&self.fs, path).wrap_err_with(|| c.clone())?;
+
+        let path = cache
             .desensitize(path)
             .ok_or(Error::NotExist)
             .wrap_err_with(|| c.clone())?;
@@ -155,65 +292,95 @@ where
         from: impl AsRef<camino::Utf8Path>,
         to: impl AsRef<camino::Utf8Path>,
     ) -> Result<()> {
+        let mut cache = self.cache.write();
         let c = format!(
             "While renaming {:?} to {:?} in a path cache",
             from.as_ref(),
             to.as_ref()
         );
-        let from = self
+        cache
+            .regen(&self.fs, from.as_ref())
+            .wrap_err_with(|| c.clone())?;
+        let from = cache
             .desensitize(from)
             .ok_or(Error::NotExist)
             .wrap_err_with(|| c.clone())?;
         let to = to.as_ref().to_path_buf();
 
+        if cache.trie.contains_dir(&from) {
+            return Err(Error::NotSupported.into());
+        }
+
         self.fs.rename(&from, &to).wrap_err_with(|| c.clone())?;
 
-        self.cache.remove(&from);
-        self.cache.insert(to_lowercase(&to), to);
+        let index = cache.trie.remove_file(&from).unwrap();
+        cache.trie.create_file(to_lowercase(&to), index);
 
         Ok(())
     }
 
     fn exists(&self, path: impl AsRef<camino::Utf8Path>) -> Result<bool> {
-        Ok(self.desensitize(path).is_some())
+        let mut cache = self.cache.write();
+        let path = path.as_ref();
+        let c = format!("While checking if {path:?} exists in a path cache");
+        cache.regen(&self.fs, path).wrap_err_with(|| c.clone())?;
+        Ok(cache.desensitize(path).is_some())
     }
 
     fn create_dir(&self, path: impl AsRef<camino::Utf8Path>) -> Result<()> {
-        let path = path.as_ref().to_path_buf();
+        let mut cache = self.cache.write();
+        let path = path.as_ref();
         let c = format!("While creating directory {path:?} in a path cache");
+        cache.regen(&self.fs, path).wrap_err_with(|| c.clone())?;
 
-        self.fs.create_dir(&path).wrap_err_with(|| c.clone())?;
-
-        self.cache.insert(to_lowercase(&path), path);
+        self.fs.create_dir(path).wrap_err_with(|| c.clone())?;
 
         Ok(())
     }
 
     fn remove_dir(&self, path: impl AsRef<camino::Utf8Path>) -> Result<()> {
-        let path = self.desensitize(path).ok_or(Error::NotExist)?;
+        let mut cache = self.cache.write();
+        let path = path.as_ref();
         let c = format!("While removing directory {path:?} in a path cache");
+        cache.regen(&self.fs, path).wrap_err_with(|| c.clone())?;
+        let path = cache.desensitize(path).ok_or(Error::NotExist)?;
 
         self.fs.remove_dir(&path).wrap_err_with(|| c.clone())?;
 
-        self.cache.remove(&to_lowercase(path));
+        let mut vec = Vec::new();
+        for (_, index) in cache.trie.iter_prefix(&path).unwrap() {
+            vec.push(*index);
+        }
+        for index in vec {
+            cache.cactus.remove(index);
+        }
+        cache.trie.remove_dir(&path);
 
         Ok(())
     }
 
     fn remove_file(&self, path: impl AsRef<camino::Utf8Path>) -> Result<()> {
-        let path = self.desensitize(path).ok_or(Error::NotExist)?;
+        let mut cache = self.cache.write();
+        let path = path.as_ref();
         let c = format!("While removing file {path:?} in a path cache");
+        cache.regen(&self.fs, path).wrap_err_with(|| c.clone())?;
+        let path = cache.desensitize(path).ok_or(Error::NotExist)?;
 
         self.fs.remove_file(&path).wrap_err_with(|| c.clone())?;
 
-        self.cache.remove(&to_lowercase(path));
+        let index = *cache.trie.get_file(&path).unwrap();
+        cache.cactus.remove(index);
+        cache.trie.remove_file(&path);
 
         Ok(())
     }
 
     fn read_dir(&self, path: impl AsRef<camino::Utf8Path>) -> Result<Vec<DirEntry>> {
-        let path = self.desensitize(path).ok_or(Error::NotExist)?;
+        let mut cache = self.cache.write();
+        let path = path.as_ref();
         let c = format!("While reading the contents of the directory {path:?} in a path cache");
+        cache.regen(&self.fs, path).wrap_err_with(|| c.clone())?;
+        let path = cache.desensitize(path).ok_or(Error::NotExist)?;
         self.fs.read_dir(path).wrap_err_with(|| c.clone())
     }
 }


### PR DESCRIPTION
**Description**
This changes the path cache to only cache paths when they are accessed instead of performing a full recursive directory search as soon as a project is loaded.

Making the path cache lazy in this way is beneficial mostly to web builds but also just to people with really slow storage, because it prevents the path cache from recursively searching directories that are never used, such as the .git directory in projects that use Git for version control, or the Audio directory if the sound test window is never used. This also prevents errors if the user doesn't have permission to access some of the files in the project directory that aren't used by Luminol.

The project loading should be significantly faster in Firefox in #88 when combined with this pull request and should also be a little faster in Chromium.

The lazy path cache is implemented by, whenever the user wants to access a path, first finding the longest path in the cache that is a prefix of the desired path and then searching the filesystem for and caching the missing suffix if applicable. Since the hash table previously used by the path cache doesn't efficiently support this longest common prefix operation, I've replaced the hash table with a trie. The trie doesn't use hashing at all, so it should also be faster than the hash table.

**Testing**
Try loading and editing a bunch of projects as a general stress test of this new path cache and make sure there are no errors that weren't there before. You can check the Filesystem Debug window under the Debug menu in the top bar to make sure that the caching is actually lazy.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo build --release` 
- [x] If applicable, run `trunk build --release`