### PR TITLE
Fix id_vec IDs not being incremented during serialization

### DIFF
--- a/crates/data/src/helpers/id_vec.rs
+++ b/crates/data/src/helpers/id_vec.rs
@@ -54,7 +54,7 @@ where
     let mut seq = serializer.serialize_seq(Some(values.len()))?;
 
     for value in values {
-        seq.serialize_element(value)?;
+        seq.serialize_element(&(*value + 1))?;
     }
 
     seq.end()


### PR DESCRIPTION
**Connections**
- Closes #82

**Description**
This pull request changes the serializer for id_vec to increment IDs by 1 since the deserializer decrements them by 1.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown`
- [x] Run `cargo build --release` 
- [ ] If applicable, run `trunk build --release`