### PR TITLE
Per-project UI persistence

### DIFF
--- a/crates/components/src/sound_tab.rs
+++ b/crates/components/src/sound_tab.rs
@@ -116,7 +116,15 @@ impl SoundTab {
             // Group together so it looks nicer.
             ui.group(|ui| {
                 egui::ScrollArea::both()
-                    .id_source(self.source)
+                    .id_source((
+                        update_state
+                            .project_config
+                            .as_ref()
+                            .expect("project not loaded")
+                            .project
+                            .persistence_id,
+                        self.source,
+                    ))
                     .auto_shrink([false, false])
                     // Show only visible rows.
                     .show_rows(

--- a/crates/config/src/project.rs
+++ b/crates/config/src/project.rs
@@ -45,6 +45,7 @@ pub struct Project {
     pub editor_ver: RMVer,
     pub playtest_exe: String,
     pub prefer_rgssad: bool,
+    pub persistence_id: u64,
 }
 
 impl Default for Project {
@@ -57,6 +58,7 @@ impl Default for Project {
             editor_ver: RMVer::XP,
             playtest_exe: "game".to_string(),
             prefer_rgssad: false,
+            persistence_id: 0,
         }
     }
 }

--- a/crates/filesystem/src/project.rs
+++ b/crates/filesystem/src/project.rs
@@ -107,9 +107,17 @@ impl FileSystem {
         let project = match self
             .read_to_string(".luminol/config")
             .ok()
-            .and_then(|s| ron::from_str(&s).ok())
+            .and_then(|s| ron::from_str::<luminol_config::project::Project>(&s).ok())
         {
-            Some(c) => c,
+            Some(config) if config.persistence_id != 0 => config,
+            Some(mut config) => {
+                while config.persistence_id == 0 {
+                    config.persistence_id = rand::random();
+                }
+                self.write(".luminol/config", ron::to_string(&config).wrap_err(c)?)
+                    .wrap_err(c)?;
+                config
+            }
             None => {
                 let Some(editor_ver) = self.detect_rm_ver() else {
                     return Err(Error::UnableToDetectRMVer).wrap_err(c);

--- a/crates/ui/src/tabs/map/mod.rs
+++ b/crates/ui/src/tabs/map/mod.rs
@@ -291,11 +291,20 @@ impl luminol_core::Tab for Tab {
             .default_width(tilepicker_default_width)
             .max_width(tilepicker_default_width)
             .show_inside(ui, |ui| {
-                egui::ScrollArea::both().show_viewport(ui, |ui, rect| {
-                    self.tilepicker
-                        .ui(update_state, ui, rect, self.view.map.coll_enabled);
-                    ui.separator();
-                });
+                egui::ScrollArea::both()
+                    .id_source(
+                        update_state
+                            .project_config
+                            .as_ref()
+                            .expect("project not loaded")
+                            .project
+                            .persistence_id,
+                    )
+                    .show_viewport(ui, |ui, rect| {
+                        self.tilepicker
+                            .ui(update_state, ui, rect, self.view.map.coll_enabled);
+                        ui.separator();
+                    });
             });
 
         egui::CentralPanel::default().show_inside(ui, |ui| {

--- a/crates/ui/src/windows/items.rs
+++ b/crates/ui/src/windows/items.rs
@@ -69,6 +69,12 @@ impl luminol_core::Window for Window {
     ) {
         let change_maximum_text = "Change maximum...";
 
+        let p = update_state
+            .project_config
+            .as_ref()
+            .expect("project not loaded")
+            .project
+            .persistence_id;
         let mut items = update_state.data.items();
         let animations = update_state.data.animations();
         let common_events = update_state.data.common_events();
@@ -115,6 +121,7 @@ impl luminol_core::Window for Window {
                                 |ui| {
                                     ui.label("Items");
                                     egui::ScrollArea::both()
+                                        .id_source(p)
                                         .min_scrolled_width(
                                             button_width + ui.spacing().item_spacing.x,
                                         )
@@ -203,7 +210,7 @@ impl luminol_core::Window for Window {
                                 ..Default::default()
                             },
                             |ui| {
-                                egui::ScrollArea::vertical().show(ui, |ui| {
+                                egui::ScrollArea::vertical().id_source(p).show(ui, |ui| {
                                     ui.set_width(ui.available_width());
                                     ui.set_min_width(
                                         2. * (ui.spacing().slider_width

--- a/crates/ui/src/windows/map_picker.rs
+++ b/crates/ui/src/windows/map_picker.rs
@@ -94,6 +94,14 @@ impl luminol_core::Window for Window {
             .open(&mut window_open)
             .show(ctx, |ui| {
                 egui::ScrollArea::both()
+                    .id_source(
+                        update_state
+                            .project_config
+                            .as_ref()
+                            .expect("project not loaded")
+                            .project
+                            .persistence_id,
+                    )
                     .auto_shrink([false; 2])
                     .show(ui, |ui| {
                         // Aquire the data cache.

--- a/crates/ui/src/windows/script_edit.rs
+++ b/crates/ui/src/windows/script_edit.rs
@@ -60,6 +60,14 @@ impl luminol_core::Window for Window {
             .show(ctx, |ui| {
                 egui::SidePanel::left("script_edit_script_panel").show_inside(ui, |ui| {
                     egui::ScrollArea::both()
+                        .id_source(
+                            update_state
+                                .project_config
+                                .as_ref()
+                                .expect("project not loaded")
+                                .project
+                                .persistence_id,
+                        )
                         .auto_shrink([false; 2])
                         .show(ui, |ui| {
                             let mut scripts = update_state.data.scripts();
@@ -185,16 +193,25 @@ impl luminol_core::Tab for ScriptTab {
             ui.fonts(|f| f.layout_job(layout_job))
         };
 
-        egui::ScrollArea::vertical().show(ui, |ui| {
-            ui.add(
-                egui::TextEdit::multiline(&mut self.script_text)
-                    .code_editor()
-                    .desired_rows(10)
-                    .lock_focus(true)
-                    .desired_width(f32::INFINITY)
-                    .layouter(&mut layouter),
-            );
-        });
+        egui::ScrollArea::vertical()
+            .id_source(
+                update_state
+                    .project_config
+                    .as_ref()
+                    .expect("project not loaded")
+                    .project
+                    .persistence_id,
+            )
+            .show(ui, |ui| {
+                ui.add(
+                    egui::TextEdit::multiline(&mut self.script_text)
+                        .code_editor()
+                        .desired_rows(10)
+                        .lock_focus(true)
+                        .desired_width(f32::INFINITY)
+                        .layouter(&mut layouter),
+                );
+            });
     }
 
     fn force_close(&mut self) -> bool {


### PR DESCRIPTION
**Description**
This pull request changes the IDs of the scrollbars in windows and tabs that require filesystem access so that the scrollbar positions are persisted per project instead of globally for all projects. It does this by storing a new randomly generated unsigned 64-bit integer, `persistence_id`, in the project config at .luminol/config and using this to make the IDs of the scrollbars different for each project.

This pull request also changes the map editor to persist its position and scale for each map in order to be consistent with how the scrollbar in the tilepicker persists its position. Like the scrollbars, this pull request makes sure that the position and scale are persisted separately for each project so that maps with the same ID in different projects don't share persistent state.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo build --release` 
- [x] If applicable, run `trunk build --release`