### PR TITLE
feat(graphics): Add a wgpu debug info window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3338,6 +3338,7 @@ dependencies = [
  "strip-ansi-escapes",
  "strum",
  "target-triple",
+ "wgpu",
  "zip",
 ]
 

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -54,5 +54,7 @@ itertools.workspace = true
 
 color-eyre.workspace = true
 
+wgpu.workspace = true
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 luminol-term = { version = "0.4.0", path = "../term/" }

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -186,7 +186,8 @@ window_enum! {
         FilesystemDebug(windows::misc::FilesystemDebug),
         NewProject(windows::new_project::Window),
         ScriptEdit(windows::script_edit::Window),
-        SoundTest(windows::sound_test::Window)
+        SoundTest(windows::sound_test::Window),
+        WgpuDebug(windows::misc::WgpuDebugInfo)
     }
 }
 #[cfg(target_arch = "wasm32")]

--- a/crates/ui/src/windows/misc.rs
+++ b/crates/ui/src/windows/misc.rs
@@ -148,25 +148,33 @@ impl luminol_core::Window for WgpuDebugInfo {
                 ui.heading("Adapter info");
                 ui.separator();
 
+                ui.add_space(16.);
                 ui.label(format!("{:#?}", self.adapter_info));
+                ui.add_space(16.);
 
                 ui.heading("Device features");
                 ui.separator();
 
+                ui.add_space(16.);
                 for (name, _) in self.adapter_features.iter_names() {
                     ui.label(name);
                 }
+                ui.add_space(16.);
 
                 ui.heading("Device limits");
                 ui.separator();
 
+                ui.add_space(16.);
                 ui.label(format!("{:#?}", self.adapter_limits));
+                ui.add_space(16.);
 
                 ui.heading("Downlevel capabilities");
                 ui.separator();
 
+                ui.add_space(16.);
                 ui.label(format!("{:#?}", self.downlevel_caps.shader_model));
-                ui.separator();
+                ui.add_space(16.);
+
                 for (name, _) in self.downlevel_caps.flags.iter_names() {
                     ui.label(name);
                 }

--- a/src/app/top_bar.rs
+++ b/src/app/top_bar.rs
@@ -341,6 +341,12 @@ impl TopBar {
             if ui.button("Log").clicked() {
                 self.show_log = true;
             }
+
+            if ui.button("WGPU Debug Info").clicked() {
+                update_state
+                    .edit_windows
+                    .add_window(luminol_ui::windows::misc::WgpuDebugInfo::new(update_state));
+            }
         });
 
         #[cfg(not(target_arch = "wasm32"))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -316,9 +316,11 @@ fn main() {
                     ..wgpu::Limits::default()
                 },
             }),
+            power_preference: wgpu::util::power_preference_from_env().unwrap_or_default(),
             ..Default::default()
         },
         persist_window: true,
+
         ..Default::default()
     };
 


### PR DESCRIPTION
**Description**

This is a pretty simple PR that adds a window displaying debug info about the current WGPU adapter.
There's been a few times where I've needed to check what adapter wgpu is using and its properties and this PR would make that process a lot easier.

<!-- 
Thanks for filing a pull request! The codeowners file will automatically request reviews.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo build --release` 
- [ ] If applicable, run `trunk build --release`