### PR TITLE
Implement grid shader

### DIFF
--- a/crates/components/src/map_view.rs
+++ b/crates/components/src/map_view.rs
@@ -229,6 +229,8 @@ impl MapView {
 
         self.previous_scale = self.scale;
 
+        let grid_inner_thickness = if self.scale >= 90. { 1. } else { 0. };
+
         let ctrl_drag = ui.input(|i| {
             if is_focused {
                 // Handle pan
@@ -571,8 +573,12 @@ impl MapView {
             self.selected_event_id = selected_event.map(|e| e.id);
 
             // Draw the fog and collision layers
-            self.map
-                .paint_overlay(graphics_state.clone(), ui.painter(), canvas_rect);
+            self.map.paint_overlay(
+                graphics_state.clone(),
+                ui.painter(),
+                grid_inner_thickness,
+                canvas_rect,
+            );
 
             // Draw white rectangles on the border of all events
             while let Some(rect) = self.event_rects.pop() {
@@ -596,8 +602,12 @@ impl MapView {
             }
         } else {
             // Draw the fog and collision layers
-            self.map
-                .paint_overlay(graphics_state.clone(), ui.painter(), canvas_rect);
+            self.map.paint_overlay(
+                graphics_state.clone(),
+                ui.painter(),
+                grid_inner_thickness,
+                canvas_rect,
+            );
         }
 
         // Do we display the visible region?

--- a/crates/components/src/map_view.rs
+++ b/crates/components/src/map_view.rs
@@ -229,7 +229,7 @@ impl MapView {
 
         self.previous_scale = self.scale;
 
-        let grid_inner_thickness = if self.scale >= 90. { 1. } else { 0. };
+        let grid_inner_thickness = if self.scale >= 50. { 1. } else { 0. };
 
         let ctrl_drag = ui.input(|i| {
             if is_focused {

--- a/crates/components/src/tilepicker.rs
+++ b/crates/components/src/tilepicker.rs
@@ -26,6 +26,9 @@ pub struct Tilepicker {
     pub selected_tiles_right: i16,
     pub selected_tiles_bottom: i16,
 
+    pub coll_enabled: bool,
+    pub grid_enabled: bool,
+
     drag_origin: Option<egui::Pos2>,
 
     resources: Arc<Resources>,
@@ -45,6 +48,7 @@ struct Callback {
     graphics_state: Fragile<Arc<luminol_graphics::GraphicsState>>,
 
     coll_enabled: bool,
+    grid_enabled: bool,
 }
 
 impl luminol_egui_wgpu::CallbackTrait for Callback {
@@ -65,7 +69,9 @@ impl luminol_egui_wgpu::CallbackTrait for Callback {
             resources.collision.draw(graphics_state, render_pass);
         }
 
-        resources.grid.draw(graphics_state, &info, render_pass);
+        if self.grid_enabled {
+            resources.grid.draw(graphics_state, &info, render_pass);
+        }
     }
 }
 
@@ -180,6 +186,8 @@ impl Tilepicker {
             selected_tiles_top: 0,
             selected_tiles_right: 0,
             selected_tiles_bottom: 0,
+            coll_enabled: false,
+            grid_enabled: true,
             drag_origin: None,
         })
     }
@@ -200,7 +208,6 @@ impl Tilepicker {
         update_state: &luminol_core::UpdateState<'_>,
         ui: &mut egui::Ui,
         scroll_rect: egui::Rect,
-        coll_enabled: bool,
     ) -> egui::Response {
         let time = ui.ctx().input(|i| i.time);
         let graphics_state = update_state.graphics.clone();
@@ -249,7 +256,8 @@ impl Tilepicker {
                 Callback {
                     resources: Fragile::new(self.resources.clone()),
                     graphics_state: Fragile::new(graphics_state.clone()),
-                    coll_enabled,
+                    coll_enabled: self.coll_enabled,
+                    grid_enabled: self.grid_enabled,
                 },
             ));
 

--- a/crates/graphics/src/grid/display.rs
+++ b/crates/graphics/src/grid/display.rs
@@ -76,13 +76,14 @@ impl Display {
             viewport_size.width_px as f32,
             viewport_size.height_px as f32,
         ];
+        let pixels_per_point = info.pixels_per_point.max(1.);
         let data = self.data.load();
         if data.viewport_size_in_pixels != viewport_size
-            || data.pixels_per_point != info.pixels_per_point
+            || data.pixels_per_point != pixels_per_point
         {
             self.data.store(Data {
                 viewport_size_in_pixels: viewport_size,
-                pixels_per_point: info.pixels_per_point,
+                pixels_per_point,
                 ..data
             });
             self.regen_buffer(render_state);

--- a/crates/graphics/src/grid/display.rs
+++ b/crates/graphics/src/grid/display.rs
@@ -31,7 +31,7 @@ pub struct Display {
 pub struct Data {
     viewport_size_in_pixels: [f32; 2],
     pixels_per_point: f32,
-    _padding: u32,
+    inner_thickness_in_points: f32,
 }
 
 impl Display {
@@ -39,7 +39,7 @@ impl Display {
         let display = Data {
             viewport_size_in_pixels: [0., 0.],
             pixels_per_point: 1.,
-            _padding: 0,
+            inner_thickness_in_points: 1.,
         };
 
         let uniform = (!graphics_state.push_constants_supported()).then(|| {
@@ -64,6 +64,21 @@ impl Display {
 
     pub fn as_buffer(&self) -> Option<&wgpu::Buffer> {
         self.uniform.as_ref()
+    }
+
+    pub fn set_inner_thickness(
+        &self,
+        render_state: &luminol_egui_wgpu::RenderState,
+        inner_thickness_in_points: f32,
+    ) {
+        let data = self.data.load();
+        if data.inner_thickness_in_points != inner_thickness_in_points {
+            self.data.store(Data {
+                inner_thickness_in_points,
+                ..data
+            });
+            self.regen_buffer(render_state);
+        }
     }
 
     pub(super) fn update_viewport_size(

--- a/crates/graphics/src/grid/display.rs
+++ b/crates/graphics/src/grid/display.rs
@@ -31,7 +31,7 @@ pub struct Display {
 pub struct Data {
     viewport_size_in_pixels: [f32; 2],
     pixels_per_point: f32,
-    line_thickness_in_points: f32,
+    _padding: u32,
 }
 
 impl Display {
@@ -39,7 +39,7 @@ impl Display {
         let display = Data {
             viewport_size_in_pixels: [0., 0.],
             pixels_per_point: 1.,
-            line_thickness_in_points: 1.,
+            _padding: 0,
         };
 
         let uniform = (!graphics_state.push_constants_supported()).then(|| {
@@ -55,21 +55,6 @@ impl Display {
         Display {
             data: AtomicCell::new(display),
             uniform,
-        }
-    }
-
-    pub fn set_line_thickness(
-        &self,
-        graphics_state: &GraphicsState,
-        line_thickness_in_points: f32,
-    ) {
-        let data = self.data.load();
-        if data.line_thickness_in_points != line_thickness_in_points {
-            self.data.store(Data {
-                line_thickness_in_points,
-                ..data
-            });
-            self.regen_buffer(&graphics_state.render_state);
         }
     }
 

--- a/crates/graphics/src/grid/display.rs
+++ b/crates/graphics/src/grid/display.rs
@@ -1,0 +1,128 @@
+// Copyright (C) 2023 Lily Lyons
+//
+// This file is part of Luminol.
+//
+// Luminol is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Luminol is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Luminol.  If not, see <http://www.gnu.org/licenses/>.
+
+use crossbeam::atomic::AtomicCell;
+use wgpu::util::DeviceExt;
+
+use crate::{BindGroupLayoutBuilder, GraphicsState};
+
+#[derive(Debug)]
+pub struct Display {
+    data: AtomicCell<Data>,
+    uniform: Option<wgpu::Buffer>,
+}
+
+#[repr(C, align(16))]
+#[derive(Copy, Clone, Debug, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct Data {
+    viewport_size_in_pixels: [f32; 2],
+    pixels_per_point: f32,
+    line_thickness_in_points: f32,
+}
+
+impl Display {
+    pub fn new(graphics_state: &GraphicsState) -> Self {
+        let display = Data {
+            viewport_size_in_pixels: [0., 0.],
+            pixels_per_point: 1.,
+            line_thickness_in_points: 1.,
+        };
+
+        let uniform = (!graphics_state.push_constants_supported()).then(|| {
+            graphics_state.render_state.device.create_buffer_init(
+                &wgpu::util::BufferInitDescriptor {
+                    label: Some("grid display buffer"),
+                    contents: bytemuck::bytes_of(&display),
+                    usage: wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::UNIFORM,
+                },
+            )
+        });
+
+        Display {
+            data: AtomicCell::new(display),
+            uniform,
+        }
+    }
+
+    pub fn set_line_thickness(
+        &self,
+        graphics_state: &GraphicsState,
+        line_thickness_in_points: f32,
+    ) {
+        let data = self.data.load();
+        if data.line_thickness_in_points != line_thickness_in_points {
+            self.data.store(Data {
+                line_thickness_in_points,
+                ..data
+            });
+            self.regen_buffer(&graphics_state.render_state);
+        }
+    }
+
+    pub fn as_bytes(&self) -> [u8; std::mem::size_of::<Data>()] {
+        bytemuck::cast(self.data.load())
+    }
+
+    pub fn as_buffer(&self) -> Option<&wgpu::Buffer> {
+        self.uniform.as_ref()
+    }
+
+    pub(super) fn update_viewport_size(
+        &self,
+        render_state: &luminol_egui_wgpu::RenderState,
+        info: &egui::PaintCallbackInfo,
+    ) {
+        let viewport_size = info.viewport_in_pixels();
+        let viewport_size = [
+            viewport_size.width_px as f32,
+            viewport_size.height_px as f32,
+        ];
+        let data = self.data.load();
+        if data.viewport_size_in_pixels != viewport_size
+            || data.pixels_per_point != info.pixels_per_point
+        {
+            self.data.store(Data {
+                viewport_size_in_pixels: viewport_size,
+                pixels_per_point: info.pixels_per_point,
+                ..data
+            });
+            self.regen_buffer(render_state);
+        }
+    }
+
+    fn regen_buffer(&self, render_state: &luminol_egui_wgpu::RenderState) {
+        if let Some(uniform) = &self.uniform {
+            render_state
+                .queue
+                .write_buffer(uniform, 0, bytemuck::bytes_of(&self.data.load()));
+        }
+    }
+}
+
+pub fn add_to_bind_group_layout(
+    layout_builder: &mut BindGroupLayoutBuilder,
+) -> &mut BindGroupLayoutBuilder {
+    layout_builder.append(
+        wgpu::ShaderStages::FRAGMENT,
+        wgpu::BindingType::Buffer {
+            ty: wgpu::BufferBindingType::Uniform,
+            has_dynamic_offset: false,
+            min_binding_size: None,
+        },
+        None,
+    )
+}

--- a/crates/graphics/src/grid/display.rs
+++ b/crates/graphics/src/grid/display.rs
@@ -76,7 +76,7 @@ impl Display {
             viewport_size.width_px as f32,
             viewport_size.height_px as f32,
         ];
-        let pixels_per_point = info.pixels_per_point.max(1.);
+        let pixels_per_point = info.pixels_per_point.max(1.).floor();
         let data = self.data.load();
         if data.viewport_size_in_pixels != viewport_size
             || data.pixels_per_point != pixels_per_point

--- a/crates/graphics/src/grid/grid.wgsl
+++ b/crates/graphics/src/grid/grid.wgsl
@@ -1,0 +1,75 @@
+struct VertexInput {
+    @location(0) position: vec2<f32>,
+}
+
+struct InstanceInput {
+    @location(1) tile_position: vec2<f32>,
+}
+
+struct VertexOutput {
+    @builtin(position) clip_position: vec4<f32>,
+    @location(0) position: vec2<f32>,
+    // The fragment shader sees this as the position of the provoking vertex,
+    // which is set to the vertex at the right angle of every triangle
+    @location(1) @interpolate(flat) vertex_position: vec2<f32>,
+}
+
+struct Viewport {
+    proj: mat4x4<f32>,
+}
+
+struct Display {
+    viewport_size_in_pixels: vec2<f32>,
+    pixels_per_point: f32,
+    line_thickness_in_points: f32,
+}
+
+#if USE_PUSH_CONSTANTS == true
+struct PushConstants {
+    viewport: Viewport,
+    display: Display,
+}
+var<push_constant> push_constants: PushConstants;
+#else
+@group(0) @binding(0)
+var<uniform> viewport: Viewport;
+@group(0) @binding(1)
+var<uniform> display: Display;
+#endif
+
+@vertex
+fn vs_main(vertex: VertexInput, instance: InstanceInput) -> VertexOutput {
+    var out: VertexOutput;
+
+#if USE_PUSH_CONSTANTS == true
+    let viewport = push_constants.viewport;
+#endif
+
+    out.position = (viewport.proj * vec4<f32>((vertex.position + instance.tile_position) * 32., 0., 1.)).xy;
+    out.vertex_position = out.position;
+    out.clip_position = vec4<f32>(out.position, 0., 1.);
+    return out;
+}
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+#if USE_PUSH_CONSTANTS == true
+    let display = push_constants.display;
+#endif
+
+    if display.viewport_size_in_pixels.x == 0. || display.viewport_size_in_pixels.y == 0. {
+        discard;
+    }
+
+    var alpha: f32;
+
+    let diff = abs(input.position - input.vertex_position) * (display.viewport_size_in_pixels / 2.);
+    let line_thickness_in_pixels = display.line_thickness_in_points * display.pixels_per_point;
+    if diff.x <= line_thickness_in_pixels || diff.y <= line_thickness_in_pixels {
+        alpha = 1.;
+    } else {
+        alpha = 0.;
+    }
+
+    return vec4<f32>(0.5, 0.5, 0.5, alpha * 0.2);
+}

--- a/crates/graphics/src/grid/grid.wgsl
+++ b/crates/graphics/src/grid/grid.wgsl
@@ -21,7 +21,6 @@ struct Viewport {
 struct Display {
     viewport_size_in_pixels: vec2<f32>,
     pixels_per_point: f32,
-    line_thickness_in_points: f32,
 }
 
 #if USE_PUSH_CONSTANTS == true
@@ -61,15 +60,22 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
         discard;
     }
 
+    var color: f32;
     var alpha: f32;
 
     let diff = abs(input.position - input.vertex_position) * (display.viewport_size_in_pixels / 2.);
-    let line_thickness_in_pixels = display.line_thickness_in_points * display.pixels_per_point;
-    if diff.x <= line_thickness_in_pixels || diff.y <= line_thickness_in_pixels {
-        alpha = 1.;
+
+    if diff.x <= 2.002 * display.pixels_per_point || diff.y <= 2.002 * display.pixels_per_point {
+        if diff.x < 1.001 * display.pixels_per_point || diff.y < 1.001 * display.pixels_per_point {
+            color = 0.1;
+        } else {
+            color = 0.7;
+        }
+        alpha = 0.25;
     } else {
+        color = 0.;
         alpha = 0.;
     }
 
-    return vec4<f32>(0.5, 0.5, 0.5, alpha * 0.2);
+    return vec4<f32>(color, color, color, alpha);
 }

--- a/crates/graphics/src/grid/grid.wgsl
+++ b/crates/graphics/src/grid/grid.wgsl
@@ -21,6 +21,7 @@ struct Viewport {
 struct Display {
     viewport_size_in_pixels: vec2<f32>,
     pixels_per_point: f32,
+    inner_thickness_in_points: f32,
 }
 
 #if USE_PUSH_CONSTANTS == true
@@ -65,8 +66,11 @@ fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
 
     let diff = abs(input.position - input.vertex_position) * (display.viewport_size_in_pixels / 2.);
 
-    if diff.x <= 2.002 * display.pixels_per_point || diff.y <= 2.002 * display.pixels_per_point {
-        if diff.x < 1.001 * display.pixels_per_point || diff.y < 1.001 * display.pixels_per_point {
+    let adjusted_outer_thickness = 1.001 * display.pixels_per_point;
+    let adjusted_inner_thickness = display.inner_thickness_in_points * adjusted_outer_thickness;
+
+    if diff.x < adjusted_outer_thickness + adjusted_inner_thickness || diff.y < adjusted_outer_thickness + adjusted_inner_thickness {
+        if diff.x < adjusted_inner_thickness || diff.y < adjusted_inner_thickness {
             color = 0.1;
         } else {
             color = 0.7;

--- a/crates/graphics/src/grid/instance.rs
+++ b/crates/graphics/src/grid/instance.rs
@@ -50,7 +50,7 @@ impl Instances {
                     usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
                 });
 
-        let vertices = Self::calculate_vertices();
+        let vertices = Self::calculate_vertices(render_state);
         let vertex_buffer =
             render_state
                 .device
@@ -78,27 +78,52 @@ impl Instances {
             .collect_vec()
     }
 
-    fn calculate_vertices() -> [Vertex; 6] {
-        [
-            Vertex {
-                position: glam::vec2(0., 0.), // Provoking vertex
-            },
-            Vertex {
-                position: glam::vec2(1., 0.),
-            },
-            Vertex {
-                position: glam::vec2(0., 1.),
-            },
-            Vertex {
-                position: glam::vec2(1., 1.), // Provoking vertex
-            },
-            Vertex {
-                position: glam::vec2(0., 1.),
-            },
-            Vertex {
-                position: glam::vec2(1., 0.),
-            },
-        ]
+    fn calculate_vertices(render_state: &luminol_egui_wgpu::RenderState) -> [Vertex; 6] {
+        // OpenGL and WebGL use the last vertex in each triangle as the provoking vertex, and
+        // Direct3D, Metal, Vulkan and WebGPU use the first vertex in each triangle
+        if render_state.adapter.get_info().backend == wgpu::Backend::Gl {
+            [
+                Vertex {
+                    position: glam::vec2(1., 0.),
+                },
+                Vertex {
+                    position: glam::vec2(0., 1.),
+                },
+                Vertex {
+                    position: glam::vec2(0., 0.), // Provoking vertex
+                },
+                Vertex {
+                    position: glam::vec2(0., 1.),
+                },
+                Vertex {
+                    position: glam::vec2(1., 0.),
+                },
+                Vertex {
+                    position: glam::vec2(1., 1.), // Provoking vertex
+                },
+            ]
+        } else {
+            [
+                Vertex {
+                    position: glam::vec2(0., 0.), // Provoking vertex
+                },
+                Vertex {
+                    position: glam::vec2(1., 0.),
+                },
+                Vertex {
+                    position: glam::vec2(0., 1.),
+                },
+                Vertex {
+                    position: glam::vec2(1., 1.), // Provoking vertex
+                },
+                Vertex {
+                    position: glam::vec2(0., 1.),
+                },
+                Vertex {
+                    position: glam::vec2(1., 0.),
+                },
+            ]
+        }
     }
 
     pub fn draw<'rpass>(&'rpass self, render_pass: &mut wgpu::RenderPass<'rpass>) {

--- a/crates/graphics/src/grid/instance.rs
+++ b/crates/graphics/src/grid/instance.rs
@@ -1,0 +1,129 @@
+// Copyright (C) 2023 Lily Lyons
+//
+// This file is part of Luminol.
+//
+// Luminol is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Luminol is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Luminol.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::Vertex;
+use itertools::Itertools;
+use wgpu::util::DeviceExt;
+
+#[derive(Debug)]
+pub struct Instances {
+    instance_buffer: wgpu::Buffer,
+    vertex_buffer: wgpu::Buffer,
+
+    map_width: usize,
+    map_height: usize,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct Instance {
+    position: [f32; 2],
+}
+
+impl Instances {
+    pub fn new(
+        render_state: &luminol_egui_wgpu::RenderState,
+        map_width: usize,
+        map_height: usize,
+    ) -> Self {
+        let instances = Self::calculate_instances(map_width, map_height);
+        let instance_buffer =
+            render_state
+                .device
+                .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                    label: Some("tilemap grid instance buffer"),
+                    contents: bytemuck::cast_slice(&instances),
+                    usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+                });
+
+        let vertices = Self::calculate_vertices();
+        let vertex_buffer =
+            render_state
+                .device
+                .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                    label: Some("tilemap grid vertex buffer"),
+                    contents: bytemuck::cast_slice(&vertices),
+                    usage: wgpu::BufferUsages::VERTEX | wgpu::BufferUsages::COPY_DST,
+                });
+
+        Self {
+            instance_buffer,
+            vertex_buffer,
+
+            map_width,
+            map_height,
+        }
+    }
+
+    fn calculate_instances(map_width: usize, map_height: usize) -> Vec<Instance> {
+        (0..map_height)
+            .cartesian_product(0..map_width)
+            .map(|(map_y, map_x)| Instance {
+                position: [map_x as f32, map_y as f32],
+            })
+            .collect_vec()
+    }
+
+    fn calculate_vertices() -> [Vertex; 6] {
+        [
+            Vertex {
+                position: glam::vec2(0., 0.), // Provoking vertex
+            },
+            Vertex {
+                position: glam::vec2(1., 0.),
+            },
+            Vertex {
+                position: glam::vec2(0., 1.),
+            },
+            Vertex {
+                position: glam::vec2(1., 1.), // Provoking vertex
+            },
+            Vertex {
+                position: glam::vec2(0., 1.),
+            },
+            Vertex {
+                position: glam::vec2(1., 0.),
+            },
+        ]
+    }
+
+    pub fn draw<'rpass>(&'rpass self, render_pass: &mut wgpu::RenderPass<'rpass>) {
+        render_pass.set_vertex_buffer(0, self.vertex_buffer.slice(..));
+
+        // Calculate the start and end index of the buffer, as well as the amount of instances.
+        let start_index = 0;
+        let end_index = self.map_width * self.map_height;
+        let count = (end_index - start_index) as u32;
+
+        // Convert the indexes into actual offsets.
+        let start = (start_index * std::mem::size_of::<Instance>()) as wgpu::BufferAddress;
+        let end = (end_index * std::mem::size_of::<Instance>()) as wgpu::BufferAddress;
+
+        render_pass.set_vertex_buffer(1, self.instance_buffer.slice(start..end));
+
+        render_pass.draw(0..6, 0..count);
+    }
+
+    pub const fn desc() -> wgpu::VertexBufferLayout<'static> {
+        const ARRAY: &[wgpu::VertexAttribute] = &wgpu::vertex_attr_array![1 => Float32x2];
+        wgpu::VertexBufferLayout {
+            array_stride: std::mem::size_of::<Instance>() as wgpu::BufferAddress,
+            step_mode: wgpu::VertexStepMode::Instance,
+            attributes: ARRAY,
+        }
+    }
+}

--- a/crates/graphics/src/grid/mod.rs
+++ b/crates/graphics/src/grid/mod.rs
@@ -1,0 +1,122 @@
+// Copyright (C) 2023 Lily Lyons
+//
+// This file is part of Luminol.
+//
+// Luminol is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Luminol is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Luminol.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+
+use crate::{
+    viewport::{self, Viewport},
+    BindGroupBuilder, BindGroupLayoutBuilder, GraphicsState,
+};
+
+use display::Display;
+use instance::Instances;
+use vertex::Vertex;
+
+pub mod display;
+mod instance;
+pub(crate) mod shader;
+mod vertex;
+
+#[derive(Debug)]
+pub struct Grid {
+    pub instances: Instances,
+    pub display: display::Display,
+    pub viewport: Arc<Viewport>,
+
+    pub bind_group: Option<wgpu::BindGroup>,
+}
+
+impl Grid {
+    pub fn new(
+        graphics_state: &GraphicsState,
+        viewport: Arc<Viewport>,
+        map_width: usize,
+        map_height: usize,
+    ) -> Self {
+        let instances = Instances::new(&graphics_state.render_state, map_width, map_height);
+        let display = Display::new(graphics_state);
+
+        let bind_group = (!graphics_state.push_constants_supported()).then(|| {
+            let mut bind_group_builder = BindGroupBuilder::new();
+            bind_group_builder.append_buffer(viewport.as_buffer().unwrap());
+            bind_group_builder.append_buffer(display.as_buffer().unwrap());
+            bind_group_builder.build(
+                &graphics_state.render_state.device,
+                Some("grid bind group"),
+                &graphics_state.bind_group_layouts.grid,
+            )
+        });
+
+        Self {
+            instances,
+            display,
+            viewport,
+            bind_group,
+        }
+    }
+
+    pub fn draw<'rpass>(
+        &'rpass self,
+        graphics_state: &'rpass GraphicsState,
+        info: &egui::PaintCallbackInfo,
+        render_pass: &mut wgpu::RenderPass<'rpass>,
+    ) {
+        #[repr(C)]
+        #[derive(Clone, Copy, bytemuck::Pod, bytemuck::Zeroable)]
+        struct VertexPushConstant {
+            viewport: [u8; 64],
+            display: [u8; 16],
+        }
+
+        render_pass.push_debug_group("tilemap grid renderer");
+        render_pass.set_pipeline(&graphics_state.pipelines.grid);
+
+        if let Some(bind_group) = &self.bind_group {
+            render_pass.set_bind_group(0, bind_group, &[])
+        } else {
+            render_pass.set_push_constants(
+                wgpu::ShaderStages::VERTEX,
+                0,
+                &self.viewport.as_bytes(),
+            );
+            render_pass.set_push_constants(
+                wgpu::ShaderStages::FRAGMENT,
+                64,
+                &self.display.as_bytes(),
+            );
+        }
+
+        self.display
+            .update_viewport_size(&graphics_state.render_state, info);
+
+        self.instances.draw(render_pass);
+        render_pass.pop_debug_group();
+    }
+}
+
+pub fn create_bind_group_layout(
+    render_state: &luminol_egui_wgpu::RenderState,
+) -> wgpu::BindGroupLayout {
+    let mut builder = BindGroupLayoutBuilder::new();
+
+    if !crate::push_constants_supported(render_state) {
+        viewport::add_to_bind_group_layout(&mut builder);
+        display::add_to_bind_group_layout(&mut builder);
+    }
+
+    builder.build(&render_state.device, Some("grid bind group layout"))
+}

--- a/crates/graphics/src/grid/shader.rs
+++ b/crates/graphics/src/grid/shader.rs
@@ -1,0 +1,121 @@
+// Copyright (C) 2023 Lily Lyons
+//
+// This file is part of Luminol.
+//
+// Luminol is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Luminol is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Luminol.  If not, see <http://www.gnu.org/licenses/>.
+
+use super::display;
+use super::instance::Instances;
+use super::Vertex;
+
+pub fn create_render_pipeline(
+    render_state: &luminol_egui_wgpu::RenderState,
+    bind_group_layouts: &crate::BindGroupLayouts,
+) -> wgpu::RenderPipeline {
+    let push_constants_supported = crate::push_constants_supported(render_state);
+
+    let mut composer = naga_oil::compose::Composer::default().with_capabilities(
+        push_constants_supported
+            .then_some(naga::valid::Capabilities::PUSH_CONSTANT)
+            .unwrap_or_default(),
+    );
+
+    let result = composer.make_naga_module(naga_oil::compose::NagaModuleDescriptor {
+        source: include_str!("grid.wgsl"),
+        file_path: "grid.wgsl",
+        shader_type: naga_oil::compose::ShaderType::Wgsl,
+        shader_defs: std::collections::HashMap::from([(
+            "USE_PUSH_CONSTANTS".to_string(),
+            naga_oil::compose::ShaderDefValue::Bool(push_constants_supported),
+        )]),
+        additional_imports: &[],
+    });
+    let module = match result {
+        Ok(module) => module,
+        Err(e) => {
+            let error = e.emit_to_string(&composer);
+            panic!("{error}");
+        }
+    };
+
+    let shader_module = render_state
+        .device
+        .create_shader_module(wgpu::ShaderModuleDescriptor {
+            label: Some("Tilemap Grid Shader Module"),
+            source: wgpu::ShaderSource::Naga(std::borrow::Cow::Owned(module)),
+        });
+
+    let push_constant_ranges: &[_] = if push_constants_supported {
+        &[
+            // Vertex
+            wgpu::PushConstantRange {
+                stages: wgpu::ShaderStages::VERTEX,
+                range: 0..64,
+            },
+            // Fragment
+            wgpu::PushConstantRange {
+                stages: wgpu::ShaderStages::FRAGMENT,
+                range: 64..64 + std::mem::size_of::<display::Data>() as u32,
+            },
+        ]
+    } else {
+        &[]
+    };
+    let label = if push_constants_supported {
+        "Tilemap Grid Render Pipeline Layout (push constants)"
+    } else {
+        "Tilemap Grid Render Pipeline Layout (uniforms)"
+    };
+
+    let grid_bgl: &wgpu::BindGroupLayout = &bind_group_layouts.grid;
+    let bind_group_layout_slice = std::slice::from_ref(&grid_bgl);
+    let bind_group_layouts: &[&wgpu::BindGroupLayout] = if push_constants_supported {
+        &[]
+    } else {
+        bind_group_layout_slice
+    };
+
+    let pipeline_layout =
+        render_state
+            .device
+            .create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+                label: Some(label),
+                bind_group_layouts,
+                push_constant_ranges,
+            });
+
+    render_state
+        .device
+        .create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+            label: Some("Tilemap Grid Render Pipeline"),
+            layout: Some(&pipeline_layout),
+            vertex: wgpu::VertexState {
+                module: &shader_module,
+                entry_point: "vs_main",
+                buffers: &[Vertex::desc(), Instances::desc()],
+            },
+            fragment: Some(wgpu::FragmentState {
+                module: &shader_module,
+                entry_point: "fs_main",
+                targets: &[Some(wgpu::ColorTargetState {
+                    blend: Some(wgpu::BlendState::ALPHA_BLENDING),
+                    ..render_state.target_format.into()
+                })],
+            }),
+            primitive: wgpu::PrimitiveState::default(),
+            depth_stencil: None,
+            multisample: wgpu::MultisampleState::default(),
+            multiview: None,
+        })
+}

--- a/crates/graphics/src/grid/vertex.rs
+++ b/crates/graphics/src/grid/vertex.rs
@@ -1,0 +1,33 @@
+// Copyright (C) 2023 Lily Lyons
+//
+// This file is part of Luminol.
+//
+// Luminol is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Luminol is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Luminol.  If not, see <http://www.gnu.org/licenses/>.
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable, PartialEq)]
+pub struct Vertex {
+    pub position: glam::Vec2,
+}
+
+impl Vertex {
+    const ATTRIBS: [wgpu::VertexAttribute; 1] = wgpu::vertex_attr_array![0 => Float32x2];
+    pub const fn desc<'a>() -> wgpu::VertexBufferLayout<'a> {
+        wgpu::VertexBufferLayout {
+            array_stride: std::mem::size_of::<Vertex>() as wgpu::BufferAddress,
+            step_mode: wgpu::VertexStepMode::Vertex,
+            attributes: &Self::ATTRIBS,
+        }
+    }
+}

--- a/crates/graphics/src/lib.rs
+++ b/crates/graphics/src/lib.rs
@@ -20,6 +20,7 @@ pub mod binding_helpers;
 pub use binding_helpers::{BindGroupBuilder, BindGroupLayoutBuilder};
 
 pub mod collision;
+pub mod grid;
 pub mod quad;
 pub mod sprite;
 pub mod tiles;
@@ -55,12 +56,14 @@ pub struct BindGroupLayouts {
     sprite: wgpu::BindGroupLayout,
     tiles: wgpu::BindGroupLayout,
     collision: wgpu::BindGroupLayout,
+    grid: wgpu::BindGroupLayout,
 }
 
 pub struct Pipelines {
     sprites: std::collections::HashMap<luminol_data::BlendMode, wgpu::RenderPipeline>,
     tiles: wgpu::RenderPipeline,
     collision: wgpu::RenderPipeline,
+    grid: wgpu::RenderPipeline,
 }
 
 impl GraphicsState {
@@ -69,6 +72,7 @@ impl GraphicsState {
             sprite: sprite::create_bind_group_layout(&render_state),
             tiles: tiles::create_bind_group_layout(&render_state),
             collision: collision::create_bind_group_layout(&render_state),
+            grid: grid::create_bind_group_layout(&render_state),
         };
 
         let pipelines = Pipelines {
@@ -78,6 +82,7 @@ impl GraphicsState {
                 &render_state,
                 &bind_group_layouts,
             ),
+            grid: grid::shader::create_render_pipeline(&render_state, &bind_group_layouts),
         };
 
         let texture_loader = texture_loader::Loader::new(render_state.clone());

--- a/crates/graphics/src/map.rs
+++ b/crates/graphics/src/map.rs
@@ -268,8 +268,14 @@ impl Map {
         &mut self,
         graphics_state: Arc<GraphicsState>,
         painter: &egui::Painter,
+        grid_inner_thickness: f32,
         rect: egui::Rect,
     ) {
+        self.resources
+            .grid
+            .display
+            .set_inner_thickness(&graphics_state.render_state, grid_inner_thickness);
+
         painter.add(luminol_egui_wgpu::Callback::new_paint_callback(
             rect,
             OverlayCallback {

--- a/crates/graphics/src/map.rs
+++ b/crates/graphics/src/map.rs
@@ -33,6 +33,7 @@ pub struct Map {
     pub fog_enabled: bool,
     pub pano_enabled: bool,
     pub coll_enabled: bool,
+    pub grid_enabled: bool,
     pub enabled_layers: Vec<bool>,
 }
 
@@ -60,6 +61,7 @@ struct OverlayCallback {
 
     fog_enabled: bool,
     coll_enabled: bool,
+    grid_enabled: bool,
 }
 
 impl luminol_egui_wgpu::CallbackTrait for Callback {
@@ -107,7 +109,9 @@ impl luminol_egui_wgpu::CallbackTrait for OverlayCallback {
             resources.collision.draw(graphics_state, render_pass);
         }
 
-        resources.grid.draw(graphics_state, &info, render_pass);
+        if self.grid_enabled {
+            resources.grid.draw(graphics_state, &info, render_pass);
+        }
     }
 }
 
@@ -192,6 +196,7 @@ impl Map {
             fog_enabled: true,
             pano_enabled: true,
             coll_enabled: false,
+            grid_enabled: true,
             enabled_layers: vec![true; map.data.zsize()],
         })
     }
@@ -273,6 +278,7 @@ impl Map {
 
                 fog_enabled: self.fog_enabled,
                 coll_enabled: self.coll_enabled,
+                grid_enabled: self.grid_enabled,
             },
         ));
     }

--- a/crates/ui/src/tabs/map/mod.rs
+++ b/crates/ui/src/tabs/map/mod.rs
@@ -252,6 +252,10 @@ impl luminol_core::Tab for Tab {
                                 ui.label(egui::RichText::new("Collision").underline());
                                 ui.checkbox(&mut self.view.map.coll_enabled, "👁");
                                 ui.end_row();
+
+                                ui.label(egui::RichText::new("Grid").underline());
+                                ui.checkbox(&mut self.view.map.grid_enabled, "👁");
+                                ui.end_row();
                             });
                     },
                 );
@@ -269,12 +273,6 @@ impl luminol_core::Tab for Tab {
                     "Darken unselected layers",
                 )
                 .on_hover_text("Toggles darkening unselected layers");
-                ui.checkbox(&mut self.view.map.grid_enabled, "Map grid")
-                    .on_hover_text("Toggles the lines on the edges of every tile in the map");
-                ui.checkbox(&mut self.tilepicker.grid_enabled, "Tilepicker grid")
-                    .on_hover_text(
-                        "Toggles the lines on the edges of every tile in the tilepicker",
-                    );
 
                 /*
                 if ui.button("Save map preview").clicked() {
@@ -308,6 +306,7 @@ impl luminol_core::Tab for Tab {
                     )
                     .show_viewport(ui, |ui, rect| {
                         self.tilepicker.coll_enabled = self.view.map.coll_enabled;
+                        self.tilepicker.grid_enabled = self.view.map.grid_enabled;
                         self.tilepicker.ui(update_state, ui, rect);
                         ui.separator();
                     });

--- a/crates/ui/src/tabs/map/mod.rs
+++ b/crates/ui/src/tabs/map/mod.rs
@@ -258,17 +258,23 @@ impl luminol_core::Tab for Tab {
 
                 ui.separator();
 
-                ui.checkbox(&mut self.view.visible_display, "Display Visible Area")
+                ui.checkbox(&mut self.view.visible_display, "Display visible area")
                     .on_hover_text("Display the visible area in-game (640x480)");
                 ui.checkbox(&mut self.view.move_preview, "Preview event move routes")
                     .on_hover_text("Preview event page move routes");
                 ui.checkbox(&mut self.view.snap_to_grid, "Snap to grid")
-                    .on_hover_text("Snap's the viewport to the tile grid");
+                    .on_hover_text("Snaps the viewport to the tile grid");
                 ui.checkbox(
                     &mut self.view.darken_unselected_layers,
                     "Darken unselected layers",
                 )
-                .on_disabled_hover_text("Toggles darkening unselected layers");
+                .on_hover_text("Toggles darkening unselected layers");
+                ui.checkbox(&mut self.view.map.grid_enabled, "Map grid")
+                    .on_hover_text("Toggles the lines on the edges of every tile in the map");
+                ui.checkbox(&mut self.tilepicker.grid_enabled, "Tilepicker grid")
+                    .on_hover_text(
+                        "Toggles the lines on the edges of every tile in the tilepicker",
+                    );
 
                 /*
                 if ui.button("Save map preview").clicked() {
@@ -301,8 +307,8 @@ impl luminol_core::Tab for Tab {
                             .persistence_id,
                     )
                     .show_viewport(ui, |ui, rect| {
-                        self.tilepicker
-                            .ui(update_state, ui, rect, self.view.map.coll_enabled);
+                        self.tilepicker.coll_enabled = self.view.map.coll_enabled;
+                        self.tilepicker.ui(update_state, ui, rect);
                         ui.separator();
                     });
             });


### PR DESCRIPTION
**Connections**
- Closes #100 

**Description**
This pull request implements a shader for drawing grid lines on the map editor and the tilemap.

The lines have a light outline and a dark fill to offer enhanced contrast in a variety of environments. They also scale in thickness with the screen resolution which is important for people with very large screens.

**Testing**
The shader has been tested to work with Vulkan, WebGL and WebGPU by opening a map and observing that no crashes occur.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo build --release` 
- [x] If applicable, run `trunk build --release`