### PR TITLE
Cache eviction

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -19,6 +19,8 @@ rustflags = [
 	"--cfg=web_sys_unstable_apis",
 	"-C",
 	"target-feature=+atomics,+bulk-memory,+mutable-globals",
+	"-C",
+	"link-arg=--max-memory=4294967296",
 	"-Z",
 	"threads=8",
 ]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -404,6 +404,8 @@ impl<'res> UpdateState<'res> {
         self.edit_windows.clean(|w| !w.requires_filesystem());
         self.edit_tabs.clean(|t| !t.requires_filesystem());
         self.audio.clear_sinks(); // audio loads files borrows from the filesystem. unloading while they are playing is a crash
+        self.graphics.atlas_loader.clear();
+        self.graphics.texture_loader.clear();
         self.filesystem.unload_project();
         *self.project_config = None;
         self.data.unload();


### PR DESCRIPTION
**Description**
This pull request clears the atlas cache and texture cache when unloading projects. Not unloading these caches when unloading projects causes maps to display incorrectly if you load a map in a project that has a tileset with the same ID as a tileset in a previously opened project and also results in memory leaks when opening a lot of projects without closing Luminol.

I also noticed that Rust wasm32-unknown-unknown builds with atomics support only have access to 1 gibibyte of memory by default. In practice, the available amount of memory is usually less than half of that because of how dynamic memory allocation works, so I raised the maximum memory in web builds to 4 gibibytes (the maximum for wasm32 and other 32-bit architectures) to prevent cached resources like database entries and loaded audio files from overrunning the memory.

**Testing**
When loading a map in one project and then loading a map in a different project with the same tileset ID as the first map's tileset ID without closing Luminol, the map in the second project should now use the correct tileset instead of using the first map's tileset.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo build --release` 
- [x] If applicable, run `trunk build --release`