### PR TITLE
Web fixes

### DIFF
--- a/.github/workflows/build-steam.yml
+++ b/.github/workflows/build-steam.yml
@@ -14,7 +14,7 @@ jobs:
     name: Build Ubuntu
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install libraries
@@ -34,7 +34,7 @@ jobs:
           cp ${{ github.workspace }}/target/release/luminol ${{ github.workspace }}/artifact
           cp ${{ github.workspace }}/steamworks/redistributable_bin/linux64/libsteam_api.so ${{ github.workspace }}/artifact
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: luminol-linux
           path: ${{ github.workspace }}/artifact/
@@ -43,7 +43,7 @@ jobs:
     name: Build Windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - uses: dtolnay/rust-toolchain@nightly
@@ -59,7 +59,7 @@ jobs:
           cp ${{ github.workspace }}/target/release/luminol.exe ${{ github.workspace }}/artifact
           cp ${{ github.workspace }}/steamworks/redistributable_bin/win64/steam_api64.dll ${{ github.workspace }}/artifact
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: luminol-windows
           path: ${{ github.workspace }}/artifact/
@@ -68,7 +68,7 @@ jobs:
     name: Build MacOS
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - uses: dtolnay/rust-toolchain@nightly
@@ -84,7 +84,7 @@ jobs:
           cp ${{ github.workspace }}/target/release/luminol ${{ github.workspace }}/artifact
           cp ${{ github.workspace }}/steamworks/redistributable_bin/osx/libsteam_api.dylib ${{ github.workspace }}/artifact
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: luminol-mac
           path: ${{ github.workspace }}/artifact/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
           targets: wasm32-unknown-unknown
           components: rust-src
       - name: Download and install Trunk binary
-        run: wget -qO- https://github.com/trunk-rs/trunk/releases/download/v0.18.7/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf- -C ${{ runner.temp }}
+        run: wget -qO- https://github.com/trunk-rs/trunk/releases/download/v0.18.8/trunk-x86_64-unknown-linux-gnu.tar.gz | tar -xzf- -C ${{ runner.temp }}
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
       - name: Build luminol (Release)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build Ubuntu
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install libraries
@@ -32,7 +32,7 @@ jobs:
           mkdir -p ${{ github.workspace }}/artifact
           cp ${{ github.workspace }}/target/release/luminol ${{ github.workspace }}/artifact
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: luminol-linux
           path: ${{ github.workspace }}/artifact/
@@ -41,7 +41,7 @@ jobs:
     name: Build Windows
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - uses: dtolnay/rust-toolchain@nightly
@@ -56,7 +56,7 @@ jobs:
           mkdir -p ${{ github.workspace }}/artifact
           cp ${{ github.workspace }}/target/release/luminol.exe ${{ github.workspace }}/artifact
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: luminol-windows
           path: ${{ github.workspace }}/artifact/
@@ -65,7 +65,7 @@ jobs:
     name: Build MacOS
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - uses: dtolnay/rust-toolchain@nightly
@@ -80,7 +80,7 @@ jobs:
           mkdir -p ${{ github.workspace }}/artifact
           cp ${{ github.workspace }}/target/release/luminol ${{ github.workspace }}/artifact
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: luminol-mac
           path: ${{ github.workspace }}/artifact/
@@ -89,7 +89,7 @@ jobs:
     name: Build Trunk
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install libraries
@@ -108,7 +108,7 @@ jobs:
       - name: Build luminol (Release)
         run: ${{ runner.temp }}/trunk build --release
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: luminol-trunk
           path: ${{ github.workspace }}/dist/

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -18,7 +18,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install libraries
@@ -36,7 +36,7 @@ jobs:
     name: Check wasm32
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install libraries
@@ -56,7 +56,7 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - run: |
@@ -73,7 +73,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install libraries
@@ -92,7 +92,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install libraries

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3235,7 +3235,6 @@ dependencies = [
  "egui",
  "flume",
  "futures-lite 2.1.0",
- "indexed_db_futures",
  "iter-read",
  "itertools",
  "js-sys",
@@ -3346,6 +3345,7 @@ dependencies = [
 name = "luminol-web"
 version = "0.4.0"
 dependencies = [
+ "indexed_db_futures",
  "js-sys",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/assets/sw.js
+++ b/assets/sw.js
@@ -113,21 +113,26 @@ if (typeof window === 'undefined') {
         // Check for the current Luminol build info, and then clear the cache storage if
         // it doesn't match the build info we previously stored in local storage
         if (!window.sessionStorage.getItem("luminolCheckedForUpdate") && window.sessionStorage.getItem("coiReloadedAfterSuccess")) {
-            fetch("./buildinfo.json")
-                .then((response) => {
-                    if (response.status === 200) {
-                        return response.json();
-                    } else {
-                        console.warn("Error checking for Luminol updates: request returned status code", response.status);
-                    }
-                })
+            (
+                window.location.hash === "#dev"
+                    ? Promise.resolve(null)
+                    : fetch("./buildinfo.json")
+                        .then((response) => {
+                            if (response.status === 200) {
+                                return response.json();
+                            } else {
+                                console.warn("Error checking for Luminol updates: request returned status code", response.status);
+                            }
+                        })
+            )
                 .then((info) => {
                     if (info === undefined) {
                         return;
                     }
                     const oldInfo = JSON.parse(window.localStorage.getItem("luminolBuildInfo"));
                     if (
-                        oldInfo === null
+                        info === null
+                            || oldInfo === null
                             || info.epoch !== oldInfo.epoch
                             || info.rev !== oldInfo.rev
                             || info.profile !== oldInfo.profile

--- a/assets/sw.js
+++ b/assets/sw.js
@@ -24,7 +24,7 @@
  * SOFTWARE.
 */
 
-const CACHE_NAME = "luminol";
+const CACHE_NAME = "astrabit.luminol";
 
 let coepCredentialless = false;
 if (typeof window === 'undefined') {

--- a/assets/sw.js
+++ b/assets/sw.js
@@ -132,7 +132,7 @@ if (typeof window === 'undefined') {
                             || info.rev !== oldInfo.rev
                             || info.profile !== oldInfo.profile
                             || info.profile !== "release"
-                            || oldInfo.rev.endsWith("-modified")
+                            || info.rev.endsWith("-modified")
                     ) {
                         !coi.quiet && console.log("New Luminol update detected - clearing cache.");
                         return window.caches.delete(CACHE_NAME).then(() => info);

--- a/assets/sw.js
+++ b/assets/sw.js
@@ -140,11 +140,20 @@ if (typeof window === 'undefined') {
                 })
                 .then((info) => {
                     if (info === undefined) {
-                        return;
+                        return false;
                     }
                     window.sessionStorage.clear();
                     window.localStorage.setItem("luminolBuildInfo", JSON.stringify(info));
                     window.sessionStorage.setItem("luminolCheckedForUpdate", "true");
+                    return window.navigator?.serviceWorker.getRegistration()
+                        .then((registration) => registration?.unregister())
+                        .then(() => true)
+                            ?? true;
+                })
+                .then((shouldRefresh) => {
+                    if (!shouldRefresh) {
+                        return;
+                    }
                     !coi.quiet && console.log("Reloading page to finish clearing cache.");
                     coi.doReload();
                 })

--- a/assets/sw.js
+++ b/assets/sw.js
@@ -26,7 +26,7 @@
 
 const CACHE_NAME = "astrabit.luminol";
 
-let coepCredentialless = false;
+let coepCredentialless = true;
 if (typeof window === 'undefined') {
     self.addEventListener("install", () => self.skipWaiting());
     self.addEventListener("activate", (event) => event.waitUntil(self.clients.claim()));

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -187,7 +187,7 @@ js-sys = "0.3"
 percent-encoding = "2.1"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
-web-sys = { version = "0.3.58", features = [
+web-sys = { version = "0.3.65", features = [ # Needs to be at least 0.3.65 for Luminol to work because that's the first version with a `WorkerGlobalScope.performance` binding
   "BinaryType",
   "Blob",
   "Clipboard",

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -87,7 +87,7 @@ impl AppRunner {
 
         let egui_ctx = egui::Context::default();
         egui_ctx.set_os(egui::os::OperatingSystem::from_user_agent(&user_agent));
-        super::storage::load_memory(&egui_ctx, &worker_options.channels).await;
+        super::storage::load_memory(&egui_ctx).await;
 
         egui_ctx.options_mut(|o| {
             // On web, the browser controls the zoom factor:

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -58,10 +58,11 @@ pub(crate) fn string_from_js_value(value: &JsValue) -> String {
 ///
 /// Monotonically increasing.
 pub fn now_sec() -> f64 {
-    luminol_web::bindings::performance(
-        &luminol_web::bindings::worker().expect("should have a DedicatedWorkerGlobalScope"),
-    )
-    .now()
+    luminol_web::bindings::worker()
+        .expect("should have a DedicatedWorkerGlobalScope")
+        .performance()
+        .unwrap()
+        .now()
         / 1000.0
 }
 

--- a/crates/eframe/src/web/text_agent.rs
+++ b/crates/eframe/src/web/text_agent.rs
@@ -169,7 +169,11 @@ pub fn update_text_agent(state: &super::MainState) -> Option<()> {
         // after we blur it here), otherwise in Firefox, IME composition sometimes causes the IME
         // window to open in the wrong position
         call_after_delay(std::time::Duration::from_millis(0), move || {
-            let _ = input.blur();
+            if input.blur().is_ok() {
+                call_after_delay(std::time::Duration::from_millis(20), move || {
+                    let _ = input.blur();
+                });
+            }
         });
     } else {
         // Holding the runner lock while calling input.blur() causes a panic.
@@ -238,12 +242,7 @@ pub fn move_text_cursor(
             let x = x + (canvas.scroll_left() + canvas.offset_left()) as f32;
             style.set_property("position", "absolute").ok()?;
             style.set_property("top", &format!("{y}px")).ok()?;
-            style.set_property("left", &format!("{x}px")).ok()?;
-
-            // Blur and refocus the text agent (it gets refocused in the "focusout" event listener
-            // after we blur it here), otherwise in Firefox, IME composition sometimes causes the IME
-            // window to open in the wrong position
-            input.blur().ok()
+            style.set_property("left", &format!("{x}px")).ok()
         })
     } else {
         style.set_property("position", "absolute").ok()?;

--- a/crates/eframe/src/web/text_agent.rs
+++ b/crates/eframe/src/web/text_agent.rs
@@ -25,6 +25,9 @@ pub fn install_text_agent(state: &super::MainState) -> Result<(), JsValue> {
     let window = web_sys::window().unwrap();
     let document = window.document().unwrap();
     let body = document.body().expect("document should have a body");
+    if let Some(input) = document.get_element_by_id(AGENT_ID) {
+        input.remove();
+    }
     let input = document
         .create_element("input")?
         .dyn_into::<web_sys::HtmlInputElement>()?;

--- a/crates/eframe/src/web/web_runner.rs
+++ b/crates/eframe/src/web/web_runner.rs
@@ -96,16 +96,12 @@ impl WebRunner {
                     }
 
                     super::WebRunnerOutput::StorageGet(key, oneshot_tx) => {
-                        let _ = oneshot_tx.send(super::storage::local_storage_get(&key));
+                        let _ = oneshot_tx.send(super::storage::storage_get(&key).await.ok());
                     }
 
                     super::WebRunnerOutput::StorageSet(key, value, oneshot_tx) => {
-                        if super::storage::local_storage().is_none() {
-                            let _ = oneshot_tx.send(false);
-                        } else {
-                            super::storage::local_storage_set(&key, &value);
-                            let _ = oneshot_tx.send(true);
-                        }
+                        let _ =
+                            oneshot_tx.send(super::storage::storage_set(&key, value).await.is_ok());
                     }
                 }
             }

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -67,7 +67,6 @@ oneshot.workspace = true
 
 wasm-bindgen = "0.2.87"
 wasm-bindgen-futures = "0.4"
-indexed_db_futures = "0.4.1"
 js-sys = "0.3"
 web-sys = { version = "0.3", features = [
     "Blob",

--- a/crates/filesystem/src/web/util.rs
+++ b/crates/filesystem/src/web/util.rs
@@ -15,9 +15,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Luminol.  If not, see <http://www.gnu.org/licenses/>.
 
-use indexed_db_futures::prelude::*;
 use rand::Rng;
-use std::future::IntoFuture;
 use wasm_bindgen::prelude::*;
 
 /// Casts a `js_sys::Promise` into a future.
@@ -103,34 +101,6 @@ pub(super) fn generate_key() -> String {
         .take(42) // This should be enough to avoid collisions
         .map(char::from)
         .collect()
-}
-
-/// Helper function for performing IndexedDB operations on an `IdbObjectStore` with a given
-/// `IdbTransactionMode`.
-pub(super) async fn idb<R>(
-    mode: IdbTransactionMode,
-    f: impl FnOnce(IdbObjectStore<'_>) -> std::result::Result<R, web_sys::DomException>,
-) -> std::result::Result<R, web_sys::DomException> {
-    let mut db_req = IdbDatabase::open_u32("astrabit.luminol", 1)?;
-
-    // Create store for our directory handles if it doesn't exist
-    db_req.set_on_upgrade_needed(Some(|e: &IdbVersionChangeEvent| {
-        if !e
-            .db()
-            .object_store_names()
-            .any(|n| n == "filesystem.dir_handles")
-        {
-            e.db().create_object_store("filesystem.dir_handles")?;
-        }
-        Ok(())
-    }));
-
-    let db = db_req.into_future().await?;
-    let tx = db.transaction_on_one_with_mode("filesystem.dir_handles", mode)?;
-    let store = tx.object_store("filesystem.dir_handles")?;
-    let r = f(store);
-    tx.await.into_result()?;
-    r
 }
 
 /// Wrapper function for handling filesystem events on the worker thread.

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -18,6 +18,7 @@ workspace = true
 [dependencies]
 wasm-bindgen = "0.2.87"
 wasm-bindgen-futures = "0.4"
+indexed_db_futures = "0.4.1"
 
 js-sys = "0.3"
 web-sys = { version = "0.3", features = [

--- a/crates/web/js/bindings.js
+++ b/crates/web/js/bindings.js
@@ -24,12 +24,6 @@ export function worker() {
     return is_worker() ? self : null;
 }
 
-// A binding for this attribute was added in July 2023 but hasn't made its way into a release of
-// web-sys as of September 2023
-export function performance(worker) {
-    return worker.performance;
-}
-
 export function filesystem_supported() {
     return typeof window?.showOpenFilePicker === 'function'
         && typeof window?.showDirectoryPicker === 'function'

--- a/crates/web/src/bindings.rs
+++ b/crates/web/src/bindings.rs
@@ -19,7 +19,6 @@ use wasm_bindgen::prelude::*;
 #[wasm_bindgen(module = "/js/bindings.js")]
 extern "C" {
     pub fn worker() -> Option<web_sys::DedicatedWorkerGlobalScope>;
-    pub fn performance(worker: &web_sys::DedicatedWorkerGlobalScope) -> web_sys::Performance;
     pub fn filesystem_supported() -> bool;
     #[wasm_bindgen(catch)]
     async fn _show_directory_picker() -> Result<JsValue, JsValue>;

--- a/hooks/trunk_enable_build_std_pre.sh
+++ b/hooks/trunk_enable_build_std_pre.sh
@@ -2,7 +2,10 @@
 set -e
 
 git_version=$(git describe --always --dirty=-modified)
-echo $git_version > $TRUNK_STAGING_DIR/git-rev.txt
+
+# Print build information to buildinfo.json in the root directory of the output folder
+# You can change the "epoch" if you need to make backwards-incompatible changes to the build info
+echo "{\"epoch\":0,\"rev\":\"$git_version\",\"profile\":\"$TRUNK_PROFILE\"}" > $TRUNK_STAGING_DIR/buildinfo.json
 
 # Enable std support for multithreading and set the LUMINOL_VERSION environment variable
 [ ! -f $TRUNK_SOURCE_DIR/.cargo/config.toml.bak ] || mv $TRUNK_SOURCE_DIR/.cargo/config.toml.bak $TRUNK_SOURCE_DIR/.cargo/config.toml

--- a/hooks/trunk_enable_build_std_pre.sh
+++ b/hooks/trunk_enable_build_std_pre.sh
@@ -2,6 +2,7 @@
 set -e
 
 git_version=$(git describe --always --dirty=-modified)
+echo $git_version > $TRUNK_STAGING_DIR/git-rev.txt
 
 # Enable std support for multithreading and set the LUMINOL_VERSION environment variable
 [ ! -f $TRUNK_SOURCE_DIR/.cargo/config.toml.bak ] || mv $TRUNK_SOURCE_DIR/.cargo/config.toml.bak $TRUNK_SOURCE_DIR/.cargo/config.toml

--- a/hooks/trunk_enable_build_std_pre.sh.cmd
+++ b/hooks/trunk_enable_build_std_pre.sh.cmd
@@ -2,6 +2,7 @@
 setlocal
 
 for /f "tokens=*" %%i in ('git describe --always --dirty=-modified') do set git_version=%%i
+echo %git_version% > %TRUNK_STAGING_DIR%\git-rev.txt
 
 :: Enable std support for multithreading and set the LUMINOL_VERSION environment variable
 if exist %TRUNK_SOURCE_DIR%\.cargo\config.toml.bak move %TRUNK_SOURCE_DIR%\.cargo\config.toml.bak %TRUNK_SOURCE_DIR%\.cargo\config.toml

--- a/hooks/trunk_enable_build_std_pre.sh.cmd
+++ b/hooks/trunk_enable_build_std_pre.sh.cmd
@@ -5,7 +5,7 @@ for /f "tokens=*" %%i in ('git describe --always --dirty=-modified') do set git_
 
 :: Print build information to buildinfo.json in the root directory of the output folder
 :: You can change the "epoch" if you need to make backwards-incompatible changes to the build info
-echo {"epoch":0,"rev":"%git_version%","profile":"%TRUNK_PROFILE%"} > %TRUNK_STAGING_DIR%\git-rev.txt
+echo {"epoch":0,"rev":"%git_version%","profile":"%TRUNK_PROFILE%"} > %TRUNK_STAGING_DIR%\buildinfo.json
 
 :: Enable std support for multithreading and set the LUMINOL_VERSION environment variable
 if exist %TRUNK_SOURCE_DIR%\.cargo\config.toml.bak move %TRUNK_SOURCE_DIR%\.cargo\config.toml.bak %TRUNK_SOURCE_DIR%\.cargo\config.toml

--- a/hooks/trunk_enable_build_std_pre.sh.cmd
+++ b/hooks/trunk_enable_build_std_pre.sh.cmd
@@ -2,7 +2,10 @@
 setlocal
 
 for /f "tokens=*" %%i in ('git describe --always --dirty=-modified') do set git_version=%%i
-echo %git_version% > %TRUNK_STAGING_DIR%\git-rev.txt
+
+:: Print build information to buildinfo.json in the root directory of the output folder
+:: You can change the "epoch" if you need to make backwards-incompatible changes to the build info
+echo {"epoch":0,"rev":"%git_version%","profile":"%TRUNK_PROFILE%"} > %TRUNK_STAGING_DIR%\git-rev.txt
 
 :: Enable std support for multithreading and set the LUMINOL_VERSION environment variable
 if exist %TRUNK_SOURCE_DIR%\.cargo\config.toml.bak move %TRUNK_SOURCE_DIR%\.cargo\config.toml.bak %TRUNK_SOURCE_DIR%\.cargo\config.toml


### PR DESCRIPTION
**Description**

This pull request addresses some small problems with web builds.

- Previously, the web build would not update itself when a new version was available, always using the version that was cached in the user's browser instead. Now, the Trunk hooks will create a file named buildinfo.json with information about the current build (the git revision and the build profile), and sw.js will fetch this file from the server every time the user opens the web build and will clear the cache if the fetch succeeded and the fetched build info is different from the cached build info. This allows people to always have an up-to-date version of Luminol when connected to the Internet and to use the cached version when not connected to the Internet. Alternatively, you can put "#dev" at the end of the URL to always bypass the cache.
- There was a problem where some input method editors would sometimes display the composition window in the wrong position in Firefox only. This should be fixed now.
- egui's storage (for saving settings, the list of recent projects, the positions of windows and scroll bars, etc.) is now backed by IndexedDB instead of local storage. Local storage has a 5 mebibyte limit on the amount of data stored and is inaccessible from web workers.
- In bindings.js there was a custom binding for [`WorkerGlobalScope.performance`](https://developer.mozilla.org/en-US/docs/Web/API/performance_property) because web-sys had no binding for this at the time. They've since added one so I've removed the custom binding from bindings.js and replaced it with web-sys's version.
- I updated the versions of Trunk and the checkout and upload-artifact actions in the workflows to match the ones from luminol-website.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo build --release` 
- [x] If applicable, run `trunk build --release`