### PR TITLE
Remove catppuccin-egui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,15 +861,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 
 [[package]]
-name = "catppuccin-egui"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64bd5a6c2c4bd822735e69d27609fe6fc41e8ec7dd0a7c338dedfdf69fd915b6"
-dependencies = [
- "egui",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3315,7 +3306,6 @@ version = "0.4.0"
 dependencies = [
  "async-std",
  "camino",
- "catppuccin-egui",
  "color-eyre",
  "egui",
  "futures-util",

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -28,8 +28,6 @@ luminol-modals.workspace = true
 
 egui.workspace = true
 
-catppuccin-egui = "4.0.0"
-
 camino.workspace = true
 
 strum.workspace = true

--- a/crates/ui/src/windows/appearance.rs
+++ b/crates/ui/src/windows/appearance.rs
@@ -50,21 +50,6 @@ impl luminol_core::Window for Window {
             self.egui_settings_open =
                 ui.button("Egui Settings").clicked() || self.egui_settings_open;
 
-            ui.menu_button("Catppuccin theme", |ui| {
-                if ui.button("Frappe").clicked() {
-                    catppuccin_egui::set_theme(ui.ctx(), catppuccin_egui::FRAPPE);
-                }
-                if ui.button("Latte").clicked() {
-                    catppuccin_egui::set_theme(ui.ctx(), catppuccin_egui::LATTE);
-                }
-                if ui.button("Macchiato").clicked() {
-                    catppuccin_egui::set_theme(ui.ctx(), catppuccin_egui::MACCHIATO);
-                }
-                if ui.button("Mocha").clicked() {
-                    catppuccin_egui::set_theme(ui.ctx(), catppuccin_egui::MOCHA);
-                }
-            });
-
             ui.menu_button("Code Theme", |ui| {
                 for t in luminol_config::SyntectTheme::iter() {
                     ui.radio_value(


### PR DESCRIPTION
**Connections**
A step towards fixing #107 

**Description**
catppuccin-egui has blocked us from updating egui in the past, at this point I think it's necessary to remove it to avoid this again in the future. 

I have a WIP branch that I need to find time to work on that's going to add a basic theme editor- to replace the functionality of catppuccin-egui- but we can remove it in the meantime.

**Testing**
N/A

<!-- 
Thanks for filing a pull request! The codeowners file will automatically request reviews.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo build --release` 
- [ ] If applicable, run `trunk build --release`