### PR TITLE
fix(web): send WebAssembly module to web worker instead of refetching

### DIFF
--- a/assets/worker.js
+++ b/assets/worker.js
@@ -18,8 +18,8 @@
 import wasm_bindgen, { luminol_worker_start } from './luminol.js';
 
 onmessage = async function (e) {
-    const [memory, canvas] = e.data;
+    const [module, memory, canvas] = e.data;
 
-    await wasm_bindgen(undefined, memory);
+    await wasm_bindgen(module, memory);
     await luminol_worker_start(canvas);
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -524,6 +524,7 @@ pub fn luminol_main_start() {
     worker_cell.set(worker.clone()).unwrap();
 
     let message = js_sys::Array::new();
+    message.push(&wasm_bindgen::module());
     message.push(&wasm_bindgen::memory());
     message.push(&offscreen_canvas);
     let transfer = js_sys::Array::new();


### PR DESCRIPTION
**Description**
The web build is supposed to be usable with no Internet connection once the user has visited the page once because it caches itself in the user's browser. However, in my testing, the web build doesn't seem to work in Firefox when not connected to the Internet (like when using airplane mode) or when "Work Offline" in the F10 menu is enabled. This applies even if the web build is being served over localhost, on the same computer that Firefox is running on!

I traced the error to the `wasm_bindgen()` function in main.js and worker.js, inside which a [`fetch()`](https://developer.mozilla.org/en-US/docs/Web/API/fetch) call is used to fetch the WebAssembly module. For some reason, when using Firefox while offline, the `fetch()` call works fine in main.js (on the main thread) but always fails in worker.js (on the worker thread). I'm not sure why it's failing, but the fact that it fails even when serving over localhost makes me suspect it's a Firefox bug.

To work around this, the WebAssembly module is now fetched only in main.js and then cloned and sent to the web worker where it can be used without having to fetch it a second time.

**Testing**
The web build should now work with airplane mode turned on in Chromium-based browsers as well as Firefox.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown`
- [x] Run `cargo build --release` 
- [x] If applicable, run `trunk build --release`