### PR TITLE
Misc bug fixes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,6 +18,6 @@ person(s) who reviewed your changes. This will make sure it gets re-added to the
 
 - [ ] Run `cargo fmt`.
 - [ ] Run `cargo clippy`. If applicable, add:
-  - [ ] `--target wasm32-unknown-unknown`
-- [ ] Run `cargo build --release` 
+  - [ ] `--target wasm32-unknown-unknown -Z build-std=std,panic_abort`
+- [ ] Run `cargo build --release`
 - [ ] If applicable, run `trunk build --release`

--- a/crates/filesystem/src/path_cache.rs
+++ b/crates/filesystem/src/path_cache.rs
@@ -220,38 +220,47 @@ where
     pub fn debug_ui(&self, ui: &mut egui::Ui) {
         let cache = self.cache.read();
 
-        egui::ScrollArea::vertical()
-            .id_source("luminol_path_cache_debug_ui")
-            .show_rows(
-                ui,
-                ui.text_style_height(&egui::TextStyle::Body),
-                cache.cactus.len(),
-                |ui, rows| {
-                    for (_, (key, extension_trie)) in cache
-                        .trie
-                        .iter_prefix("")
-                        .unwrap()
-                        .enumerate()
-                        .filter(|(index, _)| rows.contains(index))
-                    {
-                        let Some(key) = key.as_str().strip_suffix(&format!("/{TRIE_SUFFIX}"))
-                        else {
-                            continue;
-                        };
-                        ui.horizontal(|ui| {
-                            ui.label(key);
-                            ui.label("➡");
-                            ui.label(
-                                cache
-                                    .get_path_from_cactus_index(
-                                        *extension_trie.values().next().unwrap(),
-                                    )
-                                    .as_str(),
-                            );
-                        });
-                    }
-                },
-            );
+        ui.set_width(ui.available_width());
+
+        ui.with_layout(
+            egui::Layout {
+                cross_justify: true,
+                ..*ui.layout()
+            },
+            |ui| {
+                egui::ScrollArea::vertical()
+                    .id_source("luminol_path_cache_debug_ui")
+                    .show_rows(
+                        ui,
+                        ui.text_style_height(&egui::TextStyle::Body),
+                        cache.cactus.len(),
+                        |ui, rows| {
+                            for (_, (key, extension_trie)) in cache
+                                .trie
+                                .iter_prefix("")
+                                .unwrap()
+                                .enumerate()
+                                .filter(|(index, _)| rows.contains(index))
+                            {
+                                let Some(key) =
+                                    key.as_str().strip_suffix(&format!("/{TRIE_SUFFIX}"))
+                                else {
+                                    continue;
+                                };
+                                ui.add(
+                                    egui::Label::new(format!(
+                                        "{key} ➡ {}",
+                                        cache.get_path_from_cactus_index(
+                                            *extension_trie.values().next().unwrap(),
+                                        ),
+                                    ))
+                                    .truncate(true),
+                                );
+                            }
+                        },
+                    );
+            },
+        );
     }
 }
 

--- a/crates/filesystem/src/path_cache.rs
+++ b/crates/filesystem/src/path_cache.rs
@@ -235,24 +235,26 @@ where
                         ui.text_style_height(&egui::TextStyle::Body),
                         cache.cactus.len(),
                         |ui, rows| {
-                            for (_, (key, extension_trie)) in cache
+                            for (_, (key, cactus_index)) in cache
                                 .trie
                                 .iter_prefix("")
                                 .unwrap()
+                                .filter_map(|(mut key, extension_trie)| {
+                                    (key.file_name() == Some(TRIE_SUFFIX)).then(|| {
+                                        key.pop();
+                                        extension_trie
+                                            .values()
+                                            .map(move |&cactus_index| (key.clone(), cactus_index))
+                                    })
+                                })
+                                .flatten()
                                 .enumerate()
-                                .filter(|(index, _)| rows.contains(index))
+                                .filter(|(row, _)| rows.contains(row))
                             {
-                                let Some(key) =
-                                    key.as_str().strip_suffix(&format!("/{TRIE_SUFFIX}"))
-                                else {
-                                    continue;
-                                };
                                 ui.add(
                                     egui::Label::new(format!(
                                         "{key} ➡ {}",
-                                        cache.get_path_from_cactus_index(
-                                            *extension_trie.values().next().unwrap(),
-                                        ),
+                                        cache.get_path_from_cactus_index(cactus_index),
                                     ))
                                     .truncate(true),
                                 );

--- a/crates/filesystem/src/path_cache.rs
+++ b/crates/filesystem/src/path_cache.rs
@@ -220,8 +220,6 @@ where
     pub fn debug_ui(&self, ui: &mut egui::Ui) {
         let cache = self.cache.read();
 
-        ui.set_width(ui.available_width());
-
         ui.with_layout(
             egui::Layout {
                 cross_justify: true,

--- a/crates/filesystem/src/project.rs
+++ b/crates/filesystem/src/project.rs
@@ -177,6 +177,8 @@ impl FileSystem {
     }
 
     pub fn debug_ui(&self, ui: &mut egui::Ui) {
+        ui.set_width(ui.available_width());
+
         match self {
             FileSystem::Unloaded => {
                 ui.label("Unloaded");

--- a/crates/ui/src/windows/archive_manager.rs
+++ b/crates/ui/src/windows/archive_manager.rs
@@ -472,7 +472,11 @@ impl Window {
 
                                                         let _ = luminol_filesystem::archiver::FileSystem::from_buffer_and_files(
                                                             &mut file,
-                                                            version,
+                                                            if version == 2 {
+                                                                1
+                                                            } else {
+                                                                version
+                                                            },
                                                             file_paths.iter().map(|path| {
                                                                 if is_first {
                                                                     is_first = false;

--- a/crates/ui/src/windows/enemies.rs
+++ b/crates/ui/src/windows/enemies.rs
@@ -460,7 +460,8 @@ impl luminol_core::Window for Window {
                                 modified |= columns[1]
                                     .add(luminol_components::Field::new(
                                         "Treasure Probability",
-                                        egui::Slider::new(&mut enemy.treasure_prob, 0..=100),
+                                        egui::Slider::new(&mut enemy.treasure_prob, 0..=100)
+                                            .suffix("%"),
                                     ))
                                     .changed();
                             });
@@ -470,22 +471,6 @@ impl luminol_core::Window for Window {
                                     enemy.item_id = None;
                                     enemy.weapon_id = None;
                                     enemy.armor_id = None;
-                                    ui.add_enabled(
-                                        false,
-                                        luminol_components::Field::new(
-                                            "Treasure",
-                                            |ui: &mut egui::Ui| {
-                                                egui::ComboBox::from_id_source((enemy.id, "none"))
-                                                    .wrap(true)
-                                                    .width(
-                                                        ui.available_width()
-                                                            - ui.spacing().item_spacing.x,
-                                                    )
-                                                    .show_ui(ui, |_ui| {})
-                                                    .response
-                                            },
-                                        ),
-                                    );
                                 }
 
                                 TreasureType::Item => {

--- a/crates/ui/src/windows/items.rs
+++ b/crates/ui/src/windows/items.rs
@@ -226,8 +226,8 @@ impl luminol_core::Window for Window {
                         });
 
                         ui.with_padded_stripe(true, |ui| {
-                            ui.columns(2, |columns| {
-                                modified |= columns[0]
+                            if item.parameter_type.is_none() {
+                                modified |= ui
                                     .add(luminol_components::Field::new(
                                         "Parameter",
                                         luminol_components::EnumComboBox::new(
@@ -236,18 +236,27 @@ impl luminol_core::Window for Window {
                                         ),
                                     ))
                                     .changed();
+                            } else {
+                                ui.columns(2, |columns| {
+                                    modified |= columns[0]
+                                        .add(luminol_components::Field::new(
+                                            "Parameter",
+                                            luminol_components::EnumComboBox::new(
+                                                "parameter_type",
+                                                &mut item.parameter_type,
+                                            ),
+                                        ))
+                                        .changed();
 
-                                modified |= columns[1]
-                                    .add_enabled(
-                                        !item.parameter_type.is_none(),
-                                        luminol_components::Field::new(
+                                    modified |= columns[1]
+                                        .add(luminol_components::Field::new(
                                             "Parameter Increment",
                                             egui::DragValue::new(&mut item.parameter_points)
                                                 .clamp_range(0..=i32::MAX),
-                                        ),
-                                    )
-                                    .changed();
-                            });
+                                        ))
+                                        .changed();
+                                });
+                            }
                         });
 
                         ui.with_padded_stripe(false, |ui| {

--- a/src/app/top_bar.rs
+++ b/src/app/top_bar.rs
@@ -337,15 +337,19 @@ impl TopBar {
                     .add_window(luminol_ui::windows::misc::FilesystemDebug::default());
             }
 
-            #[cfg(not(target_arch = "wasm32"))]
-            if ui.button("Log").clicked() {
-                self.show_log = true;
-            }
-
             if ui.button("WGPU Debug Info").clicked() {
                 update_state
                     .edit_windows
                     .add_window(luminol_ui::windows::misc::WgpuDebugInfo::new(update_state));
+            }
+
+            #[cfg(not(target_arch = "wasm32"))]
+            {
+                ui.separator();
+
+                if ui.button("Log").clicked() {
+                    self.show_log = true;
+                }
             }
         });
 

--- a/src/app/top_bar.rs
+++ b/src/app/top_bar.rs
@@ -413,7 +413,12 @@ impl TopBar {
 
         ui.separator();
 
-        ui.label("Brush:");
+        ui.vertical(|ui| {
+            ui.add_space(ui.spacing().button_padding.y.max(
+                (ui.spacing().interact_size.y - ui.text_style_height(&egui::TextStyle::Body)) / 2.,
+            ));
+            ui.label("Brush:");
+        });
 
         for brush in luminol_core::Pencil::iter() {
             ui.selectable_value(&mut update_state.toolbar.pencil, brush, brush.to_string());


### PR DESCRIPTION
**Description**
This pull request fixes a bug where the archive manager creates a version 2 archive instead of a version 1 archive when "VX" is selected as the version. Also, the pull request template has been changed to show the correct method of running clippy with `--target wasm32-unknown-unknown`

There are also some minor visual fixes:

- The wgpu debug window and the log window have been swapped in the debug menu so that the wgpu debug window is next to the filesystem debug window.
- The filesystem debug window now has an adjustable width rather than having the same width as the text.
- The filesystem debug window now correctly shows cached paths that differ only by file extension or letter casing. Before, when there were two files in the same folder whose names differ only by file extension or letter casing, only one of them would be shown in the window, and consequently there would be blank lines at the bottom of the filesystem debug window since the number of the lines in the scroll area was set to the total number of cached paths.
- The word "Brush" in the top bar is now properly aligned with the rest of the text.
- Fixed a bug in the item editor where using the tab key on the keyboard to focus widgets cannot cycle past the "Parameter Increment" when the "Parameter" is set to "None".
- Fixed a bug in the enemy editor where using the tab key on the keyboard to focus widgets cannot cycle past the "Treasure" when the "Treasure Type" is set to "None".
- The "Treasure Probability" in the enemy editor now has a percentage sign.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown -Z build-std=std,panic_abort`
- [x] Run `cargo build --release`
- [x] If applicable, run `trunk build --release`