### PR TITLE
Update egui to 0.27.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6369,9 +6369,9 @@ checksum = "0770833d60a970638e989b3fa9fd2bb1aaadcf88963d1659fd7d9990196ed2d6"
 
 [[package]]
 name = "winit"
-version = "0.29.11"
+version = "0.29.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "272be407f804517512fdf408f0fe6c067bf24659a913c61af97af176bfd5aa92"
+checksum = "0d59ad965a635657faf09c8f062badd885748428933dad8e8bdd64064d92e5ca"
 dependencies = [
  "ahash",
  "android-activity",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1415,9 +1415,9 @@ dependencies = [
 
 [[package]]
 name = "ecolor"
-version = "0.26.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03cfe80b1890e1a8cdbffc6044d6872e814aaf6011835a2a5e2db0e5c5c4ef4e"
+checksum = "20930a432bbd57a6d55e07976089708d4893f3d556cf42a0d79e9e321fa73b10"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1425,9 +1425,9 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.26.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180f595432a5b615fc6b74afef3955249b86cfea72607b40740a4cd60d5297d0"
+checksum = "584c5d1bf9a67b25778a3323af222dbe1a1feb532190e103901187f92c7fe29a"
 dependencies = [
  "accesskit",
  "ahash",
@@ -1441,27 +1441,27 @@ dependencies = [
 
 [[package]]
 name = "egui-modal"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da17dbe55bb1b04fd8b4624ab1b68f6ec245f44aedc90893463f8dbc70f28231"
+checksum = "738cdffefd15dbb6a5fff75d118eee82a9e894bbfa45e41c24d7de42519fa673"
 dependencies = [
  "egui",
 ]
 
 [[package]]
 name = "egui-notify"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4abbfff21281b41451a347f2c0938ce278fab65ee450eb7a495efffa0bc3bb95"
+checksum = "319327faee7bb116bcdbe43af1b8cbea06dc5d9ddbb23d35e012949afbd76cde"
 dependencies = [
  "egui",
 ]
 
 [[package]]
 name = "egui-winit"
-version = "0.26.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4d44f8d89f70d4480545eb2346b76ea88c3022e9f4706cebc799dbe8b004a2"
+checksum = "2e3da0cbe020f341450c599b35b92de4af7b00abde85624fd16f09c885573609"
 dependencies = [
  "accesskit_winit",
  "arboard",
@@ -1478,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "egui_dock"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d14beb118bc4d114bb875f14d1d437736be7010939cedf60c9ee002d7d02d09f"
+checksum = "c3b8d9a54c0ed60f2670ad387c269663b4771431f090fa586906cf5f0bc586f4"
 dependencies = [
  "duplicate",
  "egui",
@@ -1489,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.26.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f4a6962241a76da5be5e64e41b851ee1c95fda11f76635522a3c82b119b5475"
+checksum = "1b78779f35ded1a853786c9ce0b43fe1053e10a21ea3b23ebea411805ce41593"
 dependencies = [
  "egui",
  "enum-map",
@@ -1510,9 +1510,9 @@ checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "emath"
-version = "0.26.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6916301ecf80448f786cdf3eb51d9dbdd831538732229d49119e2d4312eaaf09"
+checksum = "e4c3a552cfca14630702449d35f41c84a0d15963273771c6059175a803620f3f"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1594,9 +1594,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.26.2"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b9fdf617dd7f58b0c8e6e9e4a1281f730cde0831d40547da446b2bb76a47af"
+checksum = "b381f8b149657a4acf837095351839f32cd5c4aec1817fc4df84e18d76334176"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -2461,7 +2461,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "socket2 0.5.6",
  "tokio",
  "tower-service",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,9 +60,9 @@ categories = ["games"]
 
 # Shared dependencies
 [workspace.dependencies]
-egui = "0.26.2"
-egui_extras = { version = "0.26.2", features = ["svg", "image"] }
-epaint = "0.26.2"
+egui = "0.27.2"
+egui_extras = { version = "0.27.2", features = ["svg", "image"] }
+epaint = "0.27.2"
 
 luminol-eframe = { version = "0.4.0", path = "crates/eframe/", features = [
     "wgpu",
@@ -73,7 +73,7 @@ luminol-eframe = { version = "0.4.0", path = "crates/eframe/", features = [
     "wayland",
 ], default-features = false }
 luminol-egui-wgpu = { version = "0.4.0", path = "crates/egui-wgpu/" }
-egui-winit = "0.26.2"
+egui-winit = "0.27.2"
 
 wgpu = { version = "0.19.1", features = ["naga-ir"] }
 glam = { version = "0.24.2", features = ["bytemuck"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,9 +19,9 @@ workspace = true
 [dependencies]
 egui.workspace = true
 
-egui_dock = "0.11.2"
-egui-notify = "0.13.0"
-egui-modal = "0.3.4"
+egui_dock = "0.12.0"
+egui-notify = "0.14.0"
+egui-modal = "0.3.6"
 
 poll-promise.workspace = true
 once_cell.workspace = true

--- a/crates/core/src/tab.rs
+++ b/crates/core/src/tab.rs
@@ -94,7 +94,7 @@ impl Tabs {
                 style.overlay.surface_fade_opacity = 1.;
 
                 let focused_id = ui
-                    .memory(|m| m.focus().is_none())
+                    .memory(|m| m.focused().is_none())
                     .then_some(self.dock_state.find_active_focused().map(|(_, t)| t.id()))
                     .flatten();
                 egui_dock::DockArea::new(&mut self.dock_state)

--- a/crates/core/src/tab.rs
+++ b/crates/core/src/tab.rs
@@ -84,31 +84,24 @@ impl Tabs {
         ui: &mut egui::Ui,
         update_state: &mut crate::UpdateState<'_>,
     ) {
-        // This scroll area with hidden scrollbars is a hacky workaround for
-        // https://github.com/Adanos020/egui_dock/issues/90
-        // which, for us, seems to manifest when the user moves tabs around
-        egui::ScrollArea::vertical()
-            .scroll_bar_visibility(egui::scroll_area::ScrollBarVisibility::AlwaysHidden)
-            .show(ui, |ui| {
-                let mut style = egui_dock::Style::from_egui(ui.style());
-                style.overlay.surface_fade_opacity = 1.;
+        let mut style = egui_dock::Style::from_egui(ui.style());
+        style.overlay.surface_fade_opacity = 1.;
 
-                let focused_id = ui
-                    .memory(|m| m.focused().is_none())
-                    .then_some(self.dock_state.find_active_focused().map(|(_, t)| t.id()))
-                    .flatten();
-                egui_dock::DockArea::new(&mut self.dock_state)
-                    .id(self.id)
-                    .style(style)
-                    .show_inside(
-                        ui,
-                        &mut TabViewer {
-                            update_state,
-                            focused_id,
-                            allowed_in_windows: self.allowed_in_windows,
-                        },
-                    );
-            });
+        let focused_id = ui
+            .memory(|m| m.focused().is_none())
+            .then_some(self.dock_state.find_active_focused().map(|(_, t)| t.id()))
+            .flatten();
+        egui_dock::DockArea::new(&mut self.dock_state)
+            .id(self.id)
+            .style(style)
+            .show_inside(
+                ui,
+                &mut TabViewer {
+                    update_state,
+                    focused_id,
+                    allowed_in_windows: self.allowed_in_windows,
+                },
+            );
     }
 
     /// Display all tabs.

--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -7,6 +7,40 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.2 - 2024-04-02
+#### Desktop/Native
+* Fix continuous repaint on Wayland when TextEdit is focused or IME output is set [#4269](https://github.com/emilk/egui/pull/4269) (thanks [@white-axe](https://github.com/white-axe)!)
+* Remove a bunch of `unwrap()` [#4285](https://github.com/emilk/egui/pull/4285)
+
+#### Web
+* Fix blurry rendering in some browsers [#4299](https://github.com/emilk/egui/pull/4299)
+* Correctly identify if the browser tab has focus [#4280](https://github.com/emilk/egui/pull/4280)
+
+
+## 0.27.1 - 2024-03-29
+* Web: repaint if the `#hash` in the URL changes [#4261](https://github.com/emilk/egui/pull/4261)
+* Add web support for `zoom_factor` [#4260](https://github.com/emilk/egui/pull/4260) (thanks [@justusdieckmann](https://github.com/justusdieckmann)!)
+
+
+## 0.27.0 - 2024-03-26
+* Update to document-features 0.2.8 [#4003](https://github.com/emilk/egui/pull/4003)
+* Added `App::raw_input_hook` allows for the manipulation or filtering of raw input events [#4008](https://github.com/emilk/egui/pull/4008) (thanks [@varphone](https://github.com/varphone)!)
+
+#### Desktop/Native
+* Add with_taskbar to viewport builder [#3958](https://github.com/emilk/egui/pull/3958) (thanks [@AnotherNathan](https://github.com/AnotherNathan)!)
+* Add `winuser` feature to `winapi` to fix unresolved import [#4037](https://github.com/emilk/egui/pull/4037) (thanks [@varphone](https://github.com/varphone)!)
+* Add `get_proc_address` in CreationContext [#4145](https://github.com/emilk/egui/pull/4145) (thanks [@Chaojimengnan](https://github.com/Chaojimengnan)!)
+* Don't clear modifier state on focus change [#4157](https://github.com/emilk/egui/pull/4157) (thanks [@ming08108](https://github.com/ming08108)!)
+* Add x11 window type settings to viewport builder [#4175](https://github.com/emilk/egui/pull/4175) (thanks [@psethwick](https://github.com/psethwick)!)
+
+#### Web
+* Add `webgpu` feature by default to wgpu [#4124](https://github.com/emilk/egui/pull/4124) (thanks [@ctaggart](https://github.com/ctaggart)!)
+* Update kb modifiers from web mouse events [#4156](https://github.com/emilk/egui/pull/4156) (thanks [@ming08108](https://github.com/ming08108)!)
+* Fix crash on `request_animation_frame` when destroying web runner [#4169](https://github.com/emilk/egui/pull/4169) (thanks [@jprochazk](https://github.com/jprochazk)!)
+* Fix bug parsing url query with escaped & or = [#4172](https://github.com/emilk/egui/pull/4172)
+* `Location::query_map`: support repeated key [#4183](https://github.com/emilk/egui/pull/4183)
+
+
 ## 0.26.2 - 2024-02-14
 * Add `winuser` feature to `winapi` to fix unresolved import [#4037](https://github.com/emilk/egui/pull/4037) (thanks [@varphone](https://github.com/varphone)!)
 
@@ -22,38 +56,38 @@ Changes since the last release can be found at <https://github.com/emilk/egui/co
 * Much more accurate `cpu_usage` timing [#3913](https://github.com/emilk/egui/pull/3913)
 * Update to puffin 0.19 [#3940](https://github.com/emilk/egui/pull/3940)
 
-#### Desktop/Native:
+#### Desktop/Native
 * Keep `ViewportInfo::maximized` and `minimized` up-to-date on Windows [#3831](https://github.com/emilk/egui/pull/3831) (thanks [@rustbasic](https://github.com/rustbasic)!)
 * Handle `IconData::default()` without crashing [#3842](https://github.com/emilk/egui/pull/3842)
 * Fix Android crash on resume [#3847](https://github.com/emilk/egui/pull/3847) [#3867](https://github.com/emilk/egui/pull/3867) (thanks [@Garoven](https://github.com/Garoven)!)
 * Add `WgpuConfiguration::desired_maximum_frame_latency` [#3874](https://github.com/emilk/egui/pull/3874)
 * Don't call `App::update` on minimized windows [#3877](https://github.com/emilk/egui/pull/3877) (thanks [@rustbasic](https://github.com/rustbasic)!)
 
-#### Web:
+#### Web
 * When using `wgpu` on web, `eframe` will try to use WebGPU if available, then fall back to WebGL [#3824](https://github.com/emilk/egui/pull/3824) [#3895](https://github.com/emilk/egui/pull/3895) (thanks [@Wumpf](https://github.com/Wumpf)!)
 
 
 ## 0.25.0 - 2024-01-08
 * If both `glow` and `wgpu` features are enabled, default to `wgpu` [#3717](https://github.com/emilk/egui/pull/3717)
 
-#### Desktop/Native:
+#### Desktop/Native
 * Update to winit 0.29 [#3649](https://github.com/emilk/egui/pull/3649) (thanks [@fornwall](https://github.com/fornwall)!)
 * Make glow `Send + Sync` again [#3646](https://github.com/emilk/egui/pull/3646) (thanks [@surban](https://github.com/surban)!)
 * Bug fix: framebuffer clear when using glow with multi-viewports [#3713](https://github.com/emilk/egui/pull/3713)
 * Fix: Let `accesskit` process window events [#3733](https://github.com/emilk/egui/pull/3733) (thanks [@DataTriny](https://github.com/DataTriny)!)
 
-#### Web:
+#### Web
 * Fix building the `wasm32` docs for `docs.rs` [#3757](https://github.com/emilk/egui/pull/3757)
 
 
 ## 0.24.1 - 2023-11-30
-#### Desktop/Native:
+#### Desktop/Native
 * Fix window flashing white on launch [#3631](https://github.com/emilk/egui/pull/3631) (thanks [@zeozeozeo](https://github.com/zeozeozeo)!)
 * Fix windowing problems when using the `x11` feature on Linux [#3643](https://github.com/emilk/egui/pull/3643)
 * Fix bugs when there are multiple monitors with different scales [#3663](https://github.com/emilk/egui/pull/3663)
 * `glow` backend: clear framebuffer color before calling `App::update` [#3665](https://github.com/emilk/egui/pull/3665)
 
-#### Web:
+#### Web
 * Fix click-to-copy on Safari [#3621](https://github.com/emilk/egui/pull/3621)
 * Don't throw away frames on click/copy/cut [#3623](https://github.com/emilk/egui/pull/3623)
 * Remove dependency on `tts` [#3651](https://github.com/emilk/egui/pull/3651)
@@ -117,7 +151,7 @@ ui.input(|i| {
 * `eframe::Frame::info` returns a reference [#3301](https://github.com/emilk/egui/pull/3301) (thanks [@Barugon](https://github.com/Barugon)!)
 * Move `App::persist_window` to `NativeOptions` and `App::max_size_points` to `WebOptions` [#3397](https://github.com/emilk/egui/pull/3397)
 
-#### Desktop/Native:
+#### Desktop/Native
 * Only show on-screen-keyboard and IME when editing text [#3362](https://github.com/emilk/egui/pull/3362) (thanks [@Barugon](https://github.com/Barugon)!)
 * Add `eframe::storage_dir` [#3286](https://github.com/emilk/egui/pull/3286)
 * Add `NativeOptions::window_builder` for more customization [#3390](https://github.com/emilk/egui/pull/3390) (thanks [@twop](https://github.com/twop)!)
@@ -136,7 +170,7 @@ ui.input(|i| {
 * Recognize numpad enter/plus/minus [#3285](https://github.com/emilk/egui/pull/3285)
 * Add more puffin profile scopes to `eframe` [#3330](https://github.com/emilk/egui/pull/3330) [#3332](https://github.com/emilk/egui/pull/3332)
 
-#### Web:
+#### Web
 * Update to wasm-bindgen 0.2.87 [#3237](https://github.com/emilk/egui/pull/3237)
 * Remove `Function()` invocation from eframe text_agent to bypass "unsafe-eval" restrictions in Chrome browser extensions. [#3349](https://github.com/emilk/egui/pull/3349) (thanks [@aspect](https://github.com/aspect)!)
 * Fix docs about web [#3026](https://github.com/emilk/egui/pull/3026) (thanks [@kerryeon](https://github.com/kerryeon)!)
@@ -149,7 +183,7 @@ ui.input(|i| {
 * Replace `tracing` with `log` [#2928](https://github.com/emilk/egui/pull/2928)
 * Update accesskit to 0.11 [#3012](https://github.com/emilk/egui/pull/3012)
 
-#### Desktop/Native:
+#### Desktop/Native
 * Automatically change theme when system dark/light mode changes [#2750](https://github.com/emilk/egui/pull/2750) (thanks [@bash](https://github.com/bash)!)
 * Enabled wayland feature for winit when running native [#2751](https://github.com/emilk/egui/pull/2751) (thanks [@ItsEthra](https://github.com/ItsEthra)!)
 * Fix eframe window position bug (pixels vs points) [#2763](https://github.com/emilk/egui/pull/2763) (thanks [@get200](https://github.com/get200)!)
@@ -168,7 +202,7 @@ ui.input(|i| {
 * capture a screenshot using `Frame::request_screenshot` [870264b](https://github.com/emilk/egui/commit/870264b00577a95d3fd9bdf36efaf87fd351de62)
 
 
-#### Web:
+#### Web
 * ⚠️ BREAKING: `eframe::start_web` has been replaced with `eframe::WebRunner`, which also installs a nice panic hook (no need for `console_error_panic_hook`).
 * ⚠️ BREAKING: WebGPU is now the default web renderer when using the `wgpu` feature of `eframe`. To use WebGL with `wgpu`, you need to add `wgpu = { version = "0.16.0", features = ["webgl"] }` to your own `Cargo.toml`. ([#2945](https://github.com/emilk/egui/pull/2945))
 * Add `eframe::WebLogger` for redirecting `log` calls to the web console (`console.log`).
@@ -195,7 +229,7 @@ ui.input(|i| {
 * ⚠️ BREAKING: `App::clear_color` now expects you to return a raw float array ([#2666](https://github.com/emilk/egui/pull/2666)).
 * The `screen_reader` feature has now been renamed `web_screen_reader` and only work on web. On other platforms, use the `accesskit` feature flag instead ([#2669](https://github.com/emilk/egui/pull/2669)).
 
-#### Desktop/Native:
+#### Desktop/Native
 * `eframe::run_native` now returns a `Result` ([#2433](https://github.com/emilk/egui/pull/2433)).
 * Update to `winit` 0.28, adding support for mac trackpad zoom ([#2654](https://github.com/emilk/egui/pull/2654)).
 * Fix bug where the cursor could get stuck using the wrong icon.
@@ -203,7 +237,7 @@ ui.input(|i| {
 * Add `Frame::set_minimized` and `set_maximized` ([#2292](https://github.com/emilk/egui/pull/2292), [#2672](https://github.com/emilk/egui/pull/2672)).
 * Fixed persistence of native window position on Windows OS ([#2583](https://github.com/emilk/egui/issues/2583)).
 
-#### Web:
+#### Web
 * Prevent ctrl-P/cmd-P from opening the print dialog ([#2598](https://github.com/emilk/egui/pull/2598)).
 
 
@@ -215,7 +249,7 @@ ui.input(|i| {
 * MSRV (Minimum Supported Rust Version) is now `1.65.0` ([#2314](https://github.com/emilk/egui/pull/2314)).
 * Allow empty textures with the glow renderer.
 
-#### Desktop/Native:
+#### Desktop/Native
 * Don't repaint when just moving window ([#1980](https://github.com/emilk/egui/pull/1980)).
 * Added `NativeOptions::event_loop_builder` hook for apps to change platform specific event loop options ([#1952](https://github.com/emilk/egui/pull/1952)).
 * Enabled deferred render state initialization to support Android ([#1952](https://github.com/emilk/egui/pull/1952)).
@@ -230,7 +264,7 @@ ui.input(|i| {
 * Added optional, but enabled by default, integration with [AccessKit](https://accesskit.dev/) for implementing platform accessibility APIs ([#2294](https://github.com/emilk/egui/pull/2294)).
 * Fix: Less flickering on resize on Windows ([#2280](https://github.com/emilk/egui/pull/2280)).
 
-#### Web:
+#### Web
 * ⚠️ BREAKING: `start_web` is a now `async` ([#2107](https://github.com/emilk/egui/pull/2107)).
 * Web: You can now use WebGL on top of `wgpu` by enabling the `wgpu` feature (and disabling `glow` via disabling default features) ([#2107](https://github.com/emilk/egui/pull/2107)).
 * Web: Add `WebInfo::user_agent` ([#2202](https://github.com/emilk/egui/pull/2202)).
@@ -249,7 +283,7 @@ ui.input(|i| {
 * Added `NativeOptions::follow_system_theme` and `NativeOptions::default_theme` ([#1726](https://github.com/emilk/egui/pull/1726)).
 * Selectively expose parts of the API based on target arch (`wasm32` or not) ([#1867](https://github.com/emilk/egui/pull/1867)).
 
-#### Desktop/Native:
+#### Desktop/Native
 * Fixed clipboard on Wayland ([#1613](https://github.com/emilk/egui/pull/1613)).
 * Added ability to read window position and size with `frame.info().window_info` ([#1617](https://github.com/emilk/egui/pull/1617)).
 * Allow running on native without hardware accelerated rendering. Change with `NativeOptions::hardware_acceleration` ([#1681](https://github.com/emilk/egui/pull/1681), [#1693](https://github.com/emilk/egui/pull/1693)).
@@ -260,7 +294,7 @@ ui.input(|i| {
 * You can now continue execution after closing the native desktop window ([#1889](https://github.com/emilk/egui/pull/1889)).
 * `Frame::quit` has been renamed to `Frame::close` and `App::on_exit_event` is now `App::on_close_event` ([#1943](https://github.com/emilk/egui/pull/1943)).
 
-#### Web:
+#### Web
 * Added ability to stop/re-run web app from JavaScript. ⚠️ You need to update your CSS with `html, body: { height: 100%; width: 100%; }` ([#1803](https://github.com/emilk/egui/pull/1650)).
 * Added `WebOptions::follow_system_theme` and `WebOptions::default_theme` ([#1726](https://github.com/emilk/egui/pull/1726)).
 * Added option to select WebGL version ([#1803](https://github.com/emilk/egui/pull/1803)).
@@ -280,7 +314,7 @@ ui.input(|i| {
   * `Frame` is no longer `Clone` or `Sync`.
 * Added `glow` (OpenGL) context to `Frame` ([#1425](https://github.com/emilk/egui/pull/1425)).
 
-#### Desktop/Native:
+#### Desktop/Native
 * Remove the `egui_glium` feature. `eframe` will now always use `egui_glow` as the native backend ([#1357](https://github.com/emilk/egui/pull/1357)).
 * Change default for `NativeOptions::drag_and_drop_support` to `true` ([#1329](https://github.com/emilk/egui/pull/1329)).
 * Added new `NativeOptions`: `vsync`, `multisampling`, `depth_buffer`, `stencil_buffer`.
@@ -290,7 +324,7 @@ ui.input(|i| {
 * Moved app persistence to a background thread, allowing for smoother frame rates (on native).
 * Added `Frame::set_window_pos` ([#1505](https://github.com/emilk/egui/pull/1505)).
 
-#### Web:
+#### Web
 * Use full browser width by default ([#1378](https://github.com/emilk/egui/pull/1378)).
 * egui code will no longer be called after panic ([#1306](https://github.com/emilk/egui/pull/1306)).
 
@@ -300,7 +334,7 @@ ui.input(|i| {
 * Shift-scroll will now result in horizontal scrolling on all platforms ([#1136](https://github.com/emilk/egui/pull/1136)).
 * Log using the `tracing` crate. Log to stdout by adding `tracing_subscriber::fmt::init();` to your `main` ([#1192](https://github.com/emilk/egui/pull/1192)).
 
-#### Desktop/Native:
+#### Desktop/Native
 * The default native backend is now `egui_glow` (instead of `egui_glium`) ([#1020](https://github.com/emilk/egui/pull/1020)).
 * Automatically detect and apply dark or light mode from system ([#1045](https://github.com/emilk/egui/pull/1045)).
 * Fixed horizontal scrolling direction on Linux.
@@ -308,7 +342,7 @@ ui.input(|i| {
 * Added `NativeOptions::initial_window_pos`.
 * Fixed `enable_drag` for Windows OS ([#1108](https://github.com/emilk/egui/pull/1108)).
 
-#### Web:
+#### Web
 * The default web painter is now `egui_glow` (instead of WebGL) ([#1020](https://github.com/emilk/egui/pull/1020)).
 * Fixed glow failure on Chromium ([#1092](https://github.com/emilk/egui/pull/1092)).
 * Updated `eframe::IntegrationInfo::web_location_hash` on `hashchange` event ([#1140](https://github.com/emilk/egui/pull/1140)).
@@ -320,7 +354,7 @@ ui.input(|i| {
 * Added `Frame::request_repaint` to replace `repaint_signal` ([#999](https://github.com/emilk/egui/pull/999)).
 * Added `Frame::alloc_texture/free_texture` to replace `tex_allocator` ([#999](https://github.com/emilk/egui/pull/999)).
 
-#### Web:
+#### Web
 * Fixed [dark rendering in WebKitGTK](https://github.com/emilk/egui/issues/794) ([#888](https://github.com/emilk/egui/pull/888/)).
 * Added feature `glow` to switch to a [`glow`](https://github.com/grovesNL/glow) based painter ([#868](https://github.com/emilk/egui/pull/868)).
 
@@ -331,11 +365,11 @@ ui.input(|i| {
 * Remove "http" feature (use https://github.com/emilk/ehttp instead!).
 * Added `App::persist_native_window` and `App::persist_egui_memory` to control what gets persisted.
 
-#### Desktop/Native:
+#### Desktop/Native
 * Increase native scroll speed.
 * Added new backend `egui_glow` as an alternative to `egui_glium`. Enable with `default-features = false, features = ["default_fonts", "egui_glow"]`.
 
-#### Web:
+#### Web
 * Implement `eframe::NativeTexture` trait for the WebGL painter.
 * Deprecate `Painter::register_webgl_texture.
 * Fixed multiline paste.

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -263,4 +263,8 @@ luminol-web = { version = "0.4.0", path = "../web/" }
 
 # optional web:
 luminol-egui-wgpu = { workspace = true, optional = true } # if wgpu is used, use it without (!) winit
-wgpu = { workspace = true, optional = true }
+wgpu = { workspace = true, optional = true, features = [
+  # Let's enable some backends so that users can use `eframe` out-of-the-box
+  # without having to explicitly opt-in to backends
+  "webgpu",
+] }

--- a/crates/eframe/README.md
+++ b/crates/eframe/README.md
@@ -1,5 +1,5 @@
 > [!IMPORTANT]
-> luminol-eframe is currently based on emilk/egui@0.26.2
+> luminol-eframe is currently based on emilk/egui@0.27.2
 
 > [!NOTE]
 > This is Luminol's modified version of eframe. The original version is dual-licensed under MIT and Apache 2.0.

--- a/crates/eframe/src/epi.rs
+++ b/crates/eframe/src/epi.rs
@@ -67,6 +67,10 @@ pub struct CreationContext<'s> {
     #[cfg(feature = "glow")]
     pub gl: Option<std::sync::Arc<glow::Context>>,
 
+    /// The `get_proc_address` wrapper of underlying GL context
+    #[cfg(feature = "glow")]
+    pub get_proc_address: Option<&'s dyn Fn(&std::ffi::CStr) -> *const std::ffi::c_void>,
+
     /// The underlying WGPU render state.
     ///
     /// Only available when compiling with the `wgpu` feature and using [`Renderer::Wgpu`].
@@ -196,6 +200,24 @@ pub trait App {
     fn persist_egui_memory(&self) -> bool {
         true
     }
+
+    /// A hook for manipulating or filtering raw input before it is processed by [`Self::update`].
+    ///
+    /// This function provides a way to modify or filter input events before they are processed by egui.
+    ///
+    /// It can be used to prevent specific keyboard shortcuts or mouse events from being processed by egui.
+    ///
+    /// Additionally, it can be used to inject custom keyboard or mouse events into the input stream, which can be useful for implementing features like a virtual keyboard.
+    ///
+    /// # Arguments
+    ///
+    /// * `_ctx` - The context of the egui, which provides access to the current state of the egui.
+    /// * `_raw_input` - The raw input events that are about to be processed. This can be modified to change the input that egui processes.
+    ///
+    /// # Note
+    ///
+    /// This function does not return a value. Any changes to the input should be made directly to `_raw_input`.
+    fn raw_input_hook(&mut self, _ctx: &egui::Context, _raw_input: &mut egui::RawInput) {}
 }
 
 /// Selects the level of hardware graphics acceleration.
@@ -696,7 +718,7 @@ pub struct WebInfo {
 #[cfg(target_arch = "wasm32")]
 #[derive(Clone, Debug)]
 pub struct Location {
-    /// The full URL (`location.href`) without the hash.
+    /// The full URL (`location.href`) without the hash, percent-decoded.
     ///
     /// Example: `"http://www.example.com:80/index.html?foo=bar"`.
     pub url: String,
@@ -736,8 +758,8 @@ pub struct Location {
 
     /// The parsed "query" part of "www.example.com/index.html?query#fragment".
     ///
-    /// "foo=42&bar%20" is parsed as `{"foo": "42",  "bar ": ""}`
-    pub query_map: std::collections::BTreeMap<String, String>,
+    /// "foo=hello&bar%20&foo=world" is parsed as `{"bar ": [""], "foo": ["hello", "world"]}`
+    pub query_map: std::collections::BTreeMap<String, Vec<String>>,
 
     /// `location.origin`
     ///

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -274,6 +274,8 @@ impl EpiIntegration {
 
         let close_requested = raw_input.viewport().close_requested();
 
+        app.raw_input_hook(&self.egui_ctx, &mut raw_input);
+
         let full_output = self.egui_ctx.run(raw_input, |egui_ctx| {
             if let Some(viewport_ui_cb) = viewport_ui_cb {
                 // Child viewport

--- a/crates/eframe/src/native/file_storage.rs
+++ b/crates/eframe/src/native/file_storage.rs
@@ -104,7 +104,6 @@ impl crate::Storage for FileStorage {
                 .spawn(move || {
                     save_to_disk(&file_path, &kv);
                 });
-
             match result {
                 Ok(join_handle) => {
                     self.last_save_join_handle = Some(join_handle);

--- a/crates/eframe/src/native/glow_integration.rs
+++ b/crates/eframe/src/native/glow_integration.rs
@@ -7,7 +7,7 @@
 
 #![allow(clippy::arc_with_non_send_sync)] // glow::Context was accidentally non-Sync in glow 0.13, but that will be fixed in future releases of glow: https://github.com/grovesNL/glow/commit/c4a5f7151b9b4bbb380faa06ec27415235d1bf7e
 
-use std::{cell::RefCell, rc::Rc, sync::Arc, time::Instant};
+use std::{cell::RefCell, num::NonZeroU32, rc::Rc, sync::Arc, time::Instant};
 
 use glutin::{
     config::GlConfig,
@@ -22,9 +22,9 @@ use winit::{
 };
 
 use egui::{
-    epaint::ahash::HashMap, DeferredViewportUiCallback, ImmediateViewport, NumExt as _,
-    ViewportBuilder, ViewportClass, ViewportId, ViewportIdMap, ViewportIdPair, ViewportIdSet,
-    ViewportInfo, ViewportOutput,
+    epaint::ahash::HashMap, DeferredViewportUiCallback, ImmediateViewport, ViewportBuilder,
+    ViewportClass, ViewportId, ViewportIdMap, ViewportIdPair, ViewportIdSet, ViewportInfo,
+    ViewportOutput,
 };
 #[cfg(feature = "accesskit")]
 use egui_winit::accesskit_winit;
@@ -252,7 +252,7 @@ impl GlowWinitApp {
         #[cfg(feature = "accesskit")]
         {
             let event_loop_proxy = self.repaint_proxy.lock().clone();
-            let viewport = glutin.viewports.get_mut(&ViewportId::ROOT).unwrap();
+            let viewport = glutin.viewports.get_mut(&ViewportId::ROOT).unwrap(); // we always have a root
             if let Viewport {
                 window: Some(window),
                 egui_winit: Some(egui_winit),
@@ -284,12 +284,14 @@ impl GlowWinitApp {
             // Use latest raw_window_handle for eframe compatibility
             use raw_window_handle::{HasDisplayHandle as _, HasWindowHandle as _};
 
+            let get_proc_address = |addr: &_| glutin.get_proc_address(addr);
             let window = glutin.window(ViewportId::ROOT);
             let cc = CreationContext {
                 egui_ctx: integration.egui_ctx.clone(),
                 integration_info: integration.frame.info().clone(),
                 storage: integration.frame.storage(),
                 gl: Some(gl),
+                get_proc_address: Some(&get_proc_address),
                 #[cfg(feature = "wgpu")]
                 wgpu_render_state: None,
                 raw_display_handle: window.display_handle().map(|h| h.as_raw()),
@@ -446,6 +448,33 @@ impl WinitApp for GlowWinitApp {
                 }
             }
 
+            winit::event::Event::DeviceEvent {
+                device_id: _,
+                event: winit::event::DeviceEvent::MouseMotion { delta },
+            } => {
+                if let Some(running) = &mut self.running {
+                    let mut glutin = running.glutin.borrow_mut();
+                    if let Some(viewport) = glutin
+                        .focused_viewport
+                        .and_then(|viewport| glutin.viewports.get_mut(&viewport))
+                    {
+                        if let Some(egui_winit) = viewport.egui_winit.as_mut() {
+                            egui_winit.on_mouse_motion(*delta);
+                        }
+
+                        if let Some(window) = viewport.window.as_ref() {
+                            EventResult::RepaintNext(window.id())
+                        } else {
+                            EventResult::Wait
+                        }
+                    } else {
+                        EventResult::Wait
+                    }
+                } else {
+                    EventResult::Wait
+                }
+            }
+
             #[cfg(feature = "accesskit")]
             winit::event::Event::UserEvent(UserEvent::AccessKitActionRequest(
                 accesskit_winit::ActionRequestEvent { request, window_id },
@@ -515,13 +544,17 @@ impl GlowWinitRunning {
         let (raw_input, viewport_ui_cb) = {
             let mut glutin = self.glutin.borrow_mut();
             let egui_ctx = glutin.egui_ctx.clone();
-            let viewport = glutin.viewports.get_mut(&viewport_id).unwrap();
+            let Some(viewport) = glutin.viewports.get_mut(&viewport_id) else {
+                return EventResult::Wait;
+            };
             let Some(window) = viewport.window.as_ref() else {
                 return EventResult::Wait;
             };
             egui_winit::update_viewport_info(&mut viewport.info, &egui_ctx, window);
 
-            let egui_winit = viewport.egui_winit.as_mut().unwrap();
+            let Some(egui_winit) = viewport.egui_winit.as_mut() else {
+                return EventResult::Wait;
+            };
             let mut raw_input = egui_winit.take_egui_input(window);
             let viewport_ui_cb = viewport.viewport_ui_cb.clone();
 
@@ -554,8 +587,12 @@ impl GlowWinitRunning {
                 ..
             } = &mut *glutin;
             let viewport = &viewports[&viewport_id];
-            let window = viewport.window.as_ref().unwrap();
-            let gl_surface = viewport.gl_surface.as_ref().unwrap();
+            let Some(window) = viewport.window.as_ref() else {
+                return EventResult::Wait;
+            };
+            let Some(gl_surface) = viewport.gl_surface.as_ref() else {
+                return EventResult::Wait;
+            };
 
             let screen_size_in_pixels: [u32; 2] = window.inner_size().into();
 
@@ -605,7 +642,9 @@ impl GlowWinitRunning {
             ..
         } = &mut *glutin;
 
-        let viewport = viewports.get_mut(&viewport_id).unwrap();
+        let Some(viewport) = viewports.get_mut(&viewport_id) else {
+            return EventResult::Wait;
+        };
         viewport.info.events.clear(); // they should have been processed
         let window = viewport.window.clone().unwrap();
         let gl_surface = viewport.gl_surface.as_ref().unwrap();
@@ -668,7 +707,7 @@ impl GlowWinitRunning {
         #[cfg(feature = "__screenshot")]
         if integration.egui_ctx.frame_nr() == 2 {
             if let Ok(path) = std::env::var("EFRAME_SCREENSHOT_TO") {
-                save_screeshot_and_exit(&path, &painter, screen_size_in_pixels);
+                save_screenshot_and_exit(&path, &painter, screen_size_in_pixels);
             }
         }
 
@@ -836,7 +875,7 @@ impl GlutinWindowContext {
             crate::HardwareAcceleration::Off => Some(false),
         };
         let swap_interval = if native_options.vsync {
-            glutin::surface::SwapInterval::Wait(std::num::NonZeroU32::new(1).unwrap())
+            glutin::surface::SwapInterval::Wait(NonZeroU32::MIN)
         } else {
             glutin::surface::SwapInterval::DontWait
         };
@@ -1060,8 +1099,8 @@ impl GlutinWindowContext {
 
             // surface attributes
             let (width_px, height_px): (u32, u32) = window.inner_size().into();
-            let width_px = std::num::NonZeroU32::new(width_px.at_least(1)).unwrap();
-            let height_px = std::num::NonZeroU32::new(height_px.at_least(1)).unwrap();
+            let width_px = NonZeroU32::new(width_px).unwrap_or(NonZeroU32::MIN);
+            let height_px = NonZeroU32::new(height_px).unwrap_or(NonZeroU32::MIN);
             let surface_attributes = {
                 use rwh_05::HasRawWindowHandle as _; // glutin stuck on old version of raw-window-handle
                 glutin::surface::SurfaceAttributesBuilder::<glutin::surface::WindowSurface>::new()
@@ -1140,8 +1179,8 @@ impl GlutinWindowContext {
     }
 
     fn resize(&mut self, viewport_id: ViewportId, physical_size: winit::dpi::PhysicalSize<u32>) {
-        let width_px = std::num::NonZeroU32::new(physical_size.width.at_least(1)).unwrap();
-        let height_px = std::num::NonZeroU32::new(physical_size.height.at_least(1)).unwrap();
+        let width_px = NonZeroU32::new(physical_size.width).unwrap_or(NonZeroU32::MIN);
+        let height_px = NonZeroU32::new(physical_size.height).unwrap_or(NonZeroU32::MIN);
 
         if let Some(viewport) = self.viewports.get(&viewport_id) {
             if let Some(gl_surface) = &viewport.gl_surface {
@@ -1452,7 +1491,7 @@ fn render_immediate_viewport(
 }
 
 #[cfg(feature = "__screenshot")]
-fn save_screeshot_and_exit(
+fn save_screenshot_and_exit(
     path: &str,
     painter: &egui_glow::Painter,
     screen_size_in_pixels: [u32; 2],

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -43,7 +43,7 @@ fn with_event_loop<R>(
     mut native_options: epi::NativeOptions,
     f: impl FnOnce(&mut EventLoop<UserEvent>, epi::NativeOptions) -> R,
 ) -> Result<R> {
-    thread_local!(static EVENT_LOOP: RefCell<Option<EventLoop<UserEvent>>> = RefCell::new(None));
+    thread_local!(static EVENT_LOOP: RefCell<Option<EventLoop<UserEvent>>> = const { RefCell::new(None) });
 
     EVENT_LOOP.with(|event_loop| {
         // Since we want to reference NativeOptions when creating the EventLoop we can't

--- a/crates/eframe/src/web/backend.rs
+++ b/crates/eframe/src/web/backend.rs
@@ -35,15 +35,19 @@ impl WebInput {
             .native_pixels_per_point = Some(pixels_per_point);
         raw_input
     }
+
+    /// On alt-tab and similar.
+    pub fn on_web_page_focus_change(&mut self, focused: bool) {
+        // log::debug!("on_web_page_focus_change: {focused}");
+        self.raw.modifiers = egui::Modifiers::default(); // Avoid sticky modifier keys on alt-tab:
+        self.raw.focused = focused;
+        self.raw.events.push(egui::Event::WindowFocused(focused));
+        self.latest_touch_pos = None;
+        self.latest_touch_pos_id = None;
+    }
 }
 
 // ----------------------------------------------------------------------------
-
-// ensure that AtomicF64 is using atomic ops (otherwise it would use global locks, and that would be bad)
-const _: [(); 0 - !{
-    const ASSERT: bool = portable_atomic::AtomicF64::is_always_lock_free();
-    ASSERT
-} as usize] = [];
 
 /// Stores when to do the next repaint.
 pub(crate) struct NeedRepaint(portable_atomic::AtomicF64);
@@ -101,44 +105,45 @@ pub fn web_location() -> epi::Location {
         .search()
         .unwrap_or_default()
         .strip_prefix('?')
-        .map(percent_decode)
-        .unwrap_or_default();
-
-    let query_map = parse_query_map(&query)
-        .iter()
-        .map(|(k, v)| ((*k).to_owned(), (*v).to_owned()))
-        .collect();
+        .unwrap_or_default()
+        .to_owned();
 
     epi::Location {
+        // TODO(emilk): should we really percent-decode the url? 🤷‍♂️
         url: percent_decode(&location.href().unwrap_or_default()),
         protocol: percent_decode(&location.protocol().unwrap_or_default()),
         host: percent_decode(&location.host().unwrap_or_default()),
         hostname: percent_decode(&location.hostname().unwrap_or_default()),
         port: percent_decode(&location.port().unwrap_or_default()),
         hash,
+        query_map: parse_query_map(&query),
         query,
-        query_map,
         origin: percent_decode(&location.origin().unwrap_or_default()),
     }
 }
 
-fn parse_query_map(query: &str) -> BTreeMap<&str, &str> {
-    query
-        .split('&')
-        .filter_map(|pair| {
-            if pair.is_empty() {
-                None
+/// query is percent-encoded
+fn parse_query_map(query: &str) -> BTreeMap<String, Vec<String>> {
+    let mut map: BTreeMap<String, Vec<String>> = Default::default();
+
+    for pair in query.split('&') {
+        if !pair.is_empty() {
+            if let Some((key, value)) = pair.split_once('=') {
+                map.entry(percent_decode(key))
+                    .or_default()
+                    .push(percent_decode(value));
             } else {
-                Some(if let Some((key, value)) = pair.split_once('=') {
-                    (key, value)
-                } else {
-                    (pair, "")
-                })
+                map.entry(percent_decode(pair))
+                    .or_default()
+                    .push(String::new());
             }
-        })
-        .collect()
+        }
+    }
+
+    map
 }
 
+// TODO(emilk): this test is never acgtually run, because this whole module is wasm32 only 🤦‍♂️
 #[test]
 fn test_parse_query() {
     assert_eq!(parse_query_map(""), BTreeMap::default());
@@ -158,5 +163,12 @@ fn test_parse_query() {
     assert_eq!(
         parse_query_map("foo&baz&&"),
         BTreeMap::from_iter([("foo", ""), ("baz", "")])
+    );
+    assert_eq!(
+        parse_query_map("badger=data.rrd%3Fparam1%3Dfoo%26param2%3Dbar&mushroom=snake"),
+        BTreeMap::from_iter([
+            ("badger", "data.rrd?param1=foo&param2=bar"),
+            ("mushroom", "snake")
+        ])
     );
 }

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -128,14 +128,6 @@ fn paint_if_needed(runner: &mut AppRunner) {
     runner.auto_save_if_needed();
 }
 
-pub(crate) fn request_animation_frame(runner_ref: WebRunner) -> Result<(), JsValue> {
-    let worker = luminol_web::bindings::worker().unwrap();
-    let closure = Closure::once(move || paint_and_schedule(&runner_ref));
-    worker.request_animation_frame(closure.as_ref().unchecked_ref())?;
-    closure.forget(); // We must forget it, or else the callback is canceled on drop
-    Ok(())
-}
-
 // ------------------------------------------------------------------------
 
 pub(crate) fn install_document_events(state: &MainState) -> Result<(), JsValue> {

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -5,7 +5,7 @@ use super::*;
 /// Calls `request_animation_frame` to schedule repaint.
 ///
 /// It will only paint if needed, but will always call `request_animation_frame` immediately.
-fn paint_and_schedule(runner_ref: &WebRunner) -> Result<(), JsValue> {
+pub(crate) fn paint_and_schedule(runner_ref: &WebRunner) -> Result<(), JsValue> {
     // Only paint and schedule if there has been no panic
     if let Some(mut runner_lock) = runner_ref.try_lock() {
         let mut width = runner_lock.painter.width;
@@ -14,29 +14,30 @@ fn paint_and_schedule(runner_ref: &WebRunner) -> Result<(), JsValue> {
         let mut modifiers = runner_lock.input.raw.modifiers;
         let mut should_save = false;
         let mut touch = None;
+        runner_lock.input.raw.events = Vec::new();
+        let mut events = Vec::new();
 
-        for event in runner_lock
-            .worker_options
-            .channels
-            .custom_event_rx
-            .try_iter()
-        {
+        for event in runner_lock.worker_options.channels.event_rx.try_iter() {
             match event {
-                WebRunnerCustomEvent::ScreenResize(new_width, new_height, new_pixel_ratio) => {
+                WebRunnerEvent::EguiEvent(event) => {
+                    events.push(event);
+                }
+
+                WebRunnerEvent::ScreenResize(new_width, new_height, new_pixel_ratio) => {
                     width = new_width;
                     height = new_height;
                     pixel_ratio = new_pixel_ratio;
                 }
 
-                WebRunnerCustomEvent::Modifiers(new_modifiers) => {
+                WebRunnerEvent::Modifiers(new_modifiers) => {
                     modifiers = new_modifiers;
                 }
 
-                WebRunnerCustomEvent::Save => {
+                WebRunnerEvent::Save => {
                     should_save = true;
                 }
 
-                WebRunnerCustomEvent::Touch(touch_id, touch_pos) => {
+                WebRunnerEvent::Touch(touch_id, touch_pos) => {
                     touch = Some((touch_id, touch_pos));
                 }
             }
@@ -55,12 +56,7 @@ fn paint_and_schedule(runner_ref: &WebRunner) -> Result<(), JsValue> {
             runner_lock.needs_repaint.repaint_asap();
         }
 
-        runner_lock.input.raw.events = runner_lock
-            .worker_options
-            .channels
-            .event_rx
-            .try_iter()
-            .collect();
+        runner_lock.input.raw.events = events;
         if !runner_lock.input.raw.events.is_empty() {
             // Render immediately if there are any pending events
             runner_lock.needs_repaint.repaint_asap();
@@ -97,7 +93,7 @@ fn paint_and_schedule(runner_ref: &WebRunner) -> Result<(), JsValue> {
 
         paint_if_needed(&mut runner_lock);
         drop(runner_lock);
-        request_animation_frame(runner_ref.clone())?;
+        runner_ref.request_animation_frame()?;
     }
     Ok(())
 }
@@ -145,28 +141,21 @@ pub(crate) fn request_animation_frame(runner_ref: WebRunner) -> Result<(), JsVal
 pub(crate) fn install_document_events(state: &MainState) -> Result<(), JsValue> {
     let document = web_sys::window().unwrap().document().unwrap();
 
-    {
-        // Avoid sticky modifier keys on alt-tab:
-        for event_name in ["blur", "focus"] {
-            let closure = move |event: web_sys::MouseEvent, state: &MainState| {
-                let has_focus = event_name == "focus";
+    for event_name in ["blur", "focus"] {
+        let closure = move |_event: web_sys::MouseEvent, state: &MainState| {
+            // log::debug!("{event_name:?}");
+            let has_focus = event_name == "focus";
 
-                if !has_focus {
-                    // We lost focus - good idea to save
-                    state.channels.send_custom(WebRunnerCustomEvent::Save);
-                }
+            if !has_focus {
+                // We lost focus - good idea to save
+                state.channels.send_custom(WebRunnerEvent::Save);
+            }
 
-                //runner.input.on_web_page_focus_change(has_focus);
-                //runner.egui_ctx().request_repaint();
-                // log::debug!("{event_name:?}");
+            //runner.input.on_web_page_focus_change(has_focus);
+            //runner.egui_ctx().request_repaint();
+        };
 
-                state.channels.send_custom(WebRunnerCustomEvent::Modifiers(
-                    modifiers_from_mouse_event(&event),
-                ));
-            };
-
-            state.add_event_listener(&document, event_name, closure)?;
-        }
+        state.add_event_listener(&document, event_name, closure)?;
     }
 
     state.add_event_listener(
@@ -178,10 +167,10 @@ pub(crate) fn install_document_events(state: &MainState) -> Result<(), JsValue> 
                 return;
             }
 
-            let modifiers = modifiers_from_event(&event);
+            let modifiers = modifiers_from_kb_event(&event);
             state
                 .channels
-                .send_custom(WebRunnerCustomEvent::Modifiers(modifiers));
+                .send_custom(WebRunnerEvent::Modifiers(modifiers));
 
             let key = event.key();
             let egui_key = translate_key(&key);
@@ -189,7 +178,7 @@ pub(crate) fn install_document_events(state: &MainState) -> Result<(), JsValue> 
             if let Some(key) = egui_key {
                 state.channels.send(egui::Event::Key {
                     key,
-                    physical_key: None, // TODO
+                    physical_key: None, // TODO(fornwall)
                     pressed: true,
                     repeat: false, // egui will fill this in for us!
                     modifiers,
@@ -254,14 +243,14 @@ pub(crate) fn install_document_events(state: &MainState) -> Result<(), JsValue> 
         &document,
         "keyup",
         |event: web_sys::KeyboardEvent, state| {
-            let modifiers = modifiers_from_event(&event);
+            let modifiers = modifiers_from_kb_event(&event);
             state
                 .channels
-                .send_custom(WebRunnerCustomEvent::Modifiers(modifiers));
+                .send_custom(WebRunnerEvent::Modifiers(modifiers));
             if let Some(key) = translate_key(&event.key()) {
                 state.channels.send(egui::Event::Key {
                     key,
-                    physical_key: None, // TODO
+                    physical_key: None, // TODO(fornwall)
                     pressed: false,
                     repeat: false,
                     modifiers,
@@ -330,6 +319,23 @@ pub(crate) fn install_document_events(state: &MainState) -> Result<(), JsValue> 
 pub(crate) fn install_window_events(state: &MainState) -> Result<(), JsValue> {
     let window = web_sys::window().unwrap();
 
+    for event_name in ["blur", "focus"] {
+        let closure = move |_event: web_sys::MouseEvent, state: &MainState| {
+            // log::debug!("{event_name:?}");
+            let has_focus = event_name == "focus";
+
+            if !has_focus {
+                // We lost focus - good idea to save
+                state.channels.send_custom(WebRunnerEvent::Save);
+            }
+
+            //runner.input.on_web_page_focus_change(has_focus);
+            //runner.egui_ctx().request_repaint();
+        };
+
+        state.add_event_listener(&window, event_name, closure)?;
+    }
+
     /*
 
     // Save-on-close
@@ -338,7 +344,8 @@ pub(crate) fn install_window_events(state: &MainState) -> Result<(), JsValue> {
     })?;
 
     for event_name in &["load", "pagehide", "pageshow", "resize"] {
-        runner_ref.add_event_listener(&window, event_name, |_: web_sys::Event, runner| {
+        runner_ref.add_event_listener(&window, event_name, move |_: web_sys::Event, runner| {
+            // log::debug!("{event_name:?}");
             runner.needs_repaint.repaint_asap();
         })?;
     }
@@ -346,6 +353,7 @@ pub(crate) fn install_window_events(state: &MainState) -> Result<(), JsValue> {
     runner_ref.add_event_listener(&window, "hashchange", |_: web_sys::Event, runner| {
         // `epi::Frame::info(&self)` clones `epi::IntegrationInfo`, but we need to modify the original here
         runner.frame.info.web_info.location.hash = location_hash();
+        runner.needs_repaint.repaint_asap(); // tell the user about the new hash
     })?;
 
     */
@@ -369,11 +377,7 @@ pub(crate) fn install_window_events(state: &MainState) -> Result<(), JsValue> {
                 .set_attribute("height", height.to_string().as_str());
             state
                 .channels
-                .send_custom(WebRunnerCustomEvent::ScreenResize(
-                    width,
-                    height,
-                    pixel_ratio,
-                ));
+                .send_custom(WebRunnerEvent::ScreenResize(width, height, pixel_ratio));
         }
     };
     closure(web_sys::Event::new("")?, state);
@@ -428,8 +432,12 @@ pub(crate) fn install_canvas_events(state: &MainState) -> Result<(), JsValue> {
         &state.canvas,
         "mousedown",
         |event: web_sys::MouseEvent, state| {
+            let modifiers = modifiers_from_mouse_event(&event);
+            state
+                .channels
+                .send_custom(WebRunnerEvent::Modifiers(modifiers));
             if let Some(button) = button_from_mouse_event(&event) {
-                let pos = pos_from_mouse_event(&state.canvas, &event);
+                let pos = pos_from_mouse_event(&state.canvas, &event, state.channels.zoom_factor());
                 let modifiers = modifiers_from_mouse_event(&event);
                 state.channels.send(egui::Event::PointerButton {
                     pos,
@@ -454,7 +462,11 @@ pub(crate) fn install_canvas_events(state: &MainState) -> Result<(), JsValue> {
         &state.canvas,
         "mousemove",
         |event: web_sys::MouseEvent, state| {
-            let pos = pos_from_mouse_event(&state.canvas, &event);
+            let modifiers = modifiers_from_mouse_event(&event);
+            state
+                .channels
+                .send_custom(WebRunnerEvent::Modifiers(modifiers));
+            let pos = pos_from_mouse_event(&state.canvas, &event, state.channels.zoom_factor());
             state.channels.send(egui::Event::PointerMoved(pos));
             //runner.needs_repaint.repaint_asap();
             event.stop_propagation();
@@ -466,9 +478,12 @@ pub(crate) fn install_canvas_events(state: &MainState) -> Result<(), JsValue> {
         &state.canvas,
         "mouseup",
         |event: web_sys::MouseEvent, state| {
+            let modifiers = modifiers_from_mouse_event(&event);
+            state
+                .channels
+                .send_custom(WebRunnerEvent::Modifiers(modifiers));
             if let Some(button) = button_from_mouse_event(&event) {
-                let pos = pos_from_mouse_event(&state.canvas, &event);
-                let modifiers = modifiers_from_mouse_event(&event);
+                let pos = pos_from_mouse_event(&state.canvas, &event, state.channels.zoom_factor());
                 state.channels.send(egui::Event::PointerButton {
                     pos,
                     button,
@@ -494,7 +509,7 @@ pub(crate) fn install_canvas_events(state: &MainState) -> Result<(), JsValue> {
         &state.canvas,
         "mouseleave",
         |event: web_sys::MouseEvent, state| {
-            state.channels.send_custom(WebRunnerCustomEvent::Save);
+            state.channels.send_custom(WebRunnerEvent::Save);
 
             state.channels.send(egui::Event::PointerGone);
             //runner.needs_repaint.repaint_asap();
@@ -509,10 +524,15 @@ pub(crate) fn install_canvas_events(state: &MainState) -> Result<(), JsValue> {
         |event: web_sys::TouchEvent, state| {
             let mut inner = state.inner.borrow_mut();
 
-            inner.touch_pos = pos_from_touch_event(&state.canvas, &event, &mut inner.touch_id);
+            inner.touch_pos = pos_from_touch_event(
+                &state.canvas,
+                &event,
+                &mut inner.touch_id,
+                state.channels.zoom_factor(),
+            );
             state
                 .channels
-                .send_custom(WebRunnerCustomEvent::Touch(inner.touch_id, inner.touch_pos));
+                .send_custom(WebRunnerEvent::Touch(inner.touch_id, inner.touch_pos));
             let modifiers = modifiers_from_touch_event(&event);
             state.channels.send(egui::Event::PointerButton {
                 pos: inner.touch_pos,
@@ -534,10 +554,15 @@ pub(crate) fn install_canvas_events(state: &MainState) -> Result<(), JsValue> {
         |event: web_sys::TouchEvent, state| {
             let mut inner = state.inner.borrow_mut();
 
-            inner.touch_pos = pos_from_touch_event(&state.canvas, &event, &mut inner.touch_id);
+            inner.touch_pos = pos_from_touch_event(
+                &state.canvas,
+                &event,
+                &mut inner.touch_id,
+                state.channels.zoom_factor(),
+            );
             state
                 .channels
-                .send_custom(WebRunnerCustomEvent::Touch(inner.touch_id, inner.touch_pos));
+                .send_custom(WebRunnerEvent::Touch(inner.touch_id, inner.touch_pos));
             state
                 .channels
                 .send(egui::Event::PointerMoved(inner.touch_pos));
@@ -609,7 +634,9 @@ pub(crate) fn install_canvas_events(state: &MainState) -> Result<(), JsValue> {
             });
 
             let scroll_multiplier = match unit {
-                egui::MouseWheelUnit::Page => canvas_size_in_points(&state.canvas).y,
+                egui::MouseWheelUnit::Page => {
+                    canvas_size_in_points(&state.canvas, state.channels.zoom_factor()).y
+                }
                 egui::MouseWheelUnit::Line => {
                     #[allow(clippy::let_and_return)]
                     let points_per_scroll_line = 8.0; // Note that this is intentionally different from what we use in winit.

--- a/crates/eframe/src/web/input.rs
+++ b/crates/eframe/src/web/input.rs
@@ -1,13 +1,14 @@
-use super::{canvas_element, canvas_origin, AppRunner};
+use super::{canvas_origin, AppRunner};
 
 pub fn pos_from_mouse_event(
     canvas: &web_sys::HtmlCanvasElement,
     event: &web_sys::MouseEvent,
+    zoom_factor: f32,
 ) -> egui::Pos2 {
     let rect = canvas.get_bounding_client_rect();
     egui::Pos2 {
-        x: event.client_x() as f32 - rect.left() as f32,
-        y: event.client_y() as f32 - rect.top() as f32,
+        x: (event.client_x() as f32 - rect.left() as f32) / zoom_factor,
+        y: (event.client_y() as f32 - rect.top() as f32) / zoom_factor,
     }
 }
 
@@ -32,6 +33,7 @@ pub fn pos_from_touch_event(
     canvas: &web_sys::HtmlCanvasElement,
     event: &web_sys::TouchEvent,
     touch_id_for_pos: &mut Option<egui::TouchId>,
+    zoom_factor: f32,
 ) -> egui::Pos2 {
     let touch_for_pos = if let Some(touch_id_for_pos) = touch_id_for_pos {
         // search for the touch we previously used for the position
@@ -49,14 +51,18 @@ pub fn pos_from_touch_event(
         .or_else(|| event.touches().get(0))
         .map_or(Default::default(), |touch| {
             *touch_id_for_pos = Some(egui::TouchId::from(touch.identifier()));
-            pos_from_touch(canvas_origin(canvas), &touch)
+            pos_from_touch(canvas_origin(canvas), &touch, zoom_factor)
         })
 }
 
-fn pos_from_touch(canvas_origin: egui::Pos2, touch: &web_sys::Touch) -> egui::Pos2 {
+fn pos_from_touch(
+    canvas_origin: egui::Pos2,
+    touch: &web_sys::Touch,
+    zoom_factor: f32,
+) -> egui::Pos2 {
     egui::Pos2 {
-        x: touch.page_x() as f32 - canvas_origin.x,
-        y: touch.page_y() as f32 - canvas_origin.y,
+        x: (touch.page_x() as f32 - canvas_origin.x) / zoom_factor,
+        y: (touch.page_y() as f32 - canvas_origin.y) / zoom_factor,
     }
 }
 
@@ -72,7 +78,7 @@ pub fn push_touches(
                 device_id: egui::TouchDeviceId(0),
                 id: egui::TouchId::from(touch.identifier()),
                 phase,
-                pos: pos_from_touch(canvas_origin, &touch),
+                pos: pos_from_touch(canvas_origin, &touch, state.channels.zoom_factor()),
                 force: Some(touch.force()),
             });
         }
@@ -139,11 +145,11 @@ macro_rules! modifiers {
     };
 }
 
-pub fn modifiers_from_event(event: &web_sys::KeyboardEvent) -> egui::Modifiers {
+pub fn modifiers_from_kb_event(event: &web_sys::KeyboardEvent) -> egui::Modifiers {
     modifiers!(event)
 }
 
-pub(super) fn modifiers_from_mouse_event(event: &web_sys::MouseEvent) -> egui::Modifiers {
+pub fn modifiers_from_mouse_event(event: &web_sys::MouseEvent) -> egui::Modifiers {
     modifiers!(event)
 }
 

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -455,5 +455,5 @@ enum WebRunnerOutput {
 static PANIC_LOCK: once_cell::sync::OnceCell<()> = once_cell::sync::OnceCell::new();
 
 thread_local! {
-    static EVENTS_TO_UNSUBSCRIBE: std::cell::RefCell<Vec<web_runner::EventToUnsubscribe>> = std::cell::RefCell::new(Vec::new());
+    static EVENTS_TO_UNSUBSCRIBE: std::cell::RefCell<Vec<web_runner::EventToUnsubscribe>> = const { std::cell::RefCell::new(Vec::new()) };
 }

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -440,6 +440,9 @@ enum WebRunnerEvent {
     Save,
     /// The browser detected a touchstart or touchmove event with this ID and position in canvas coordinates
     Touch(Option<egui::TouchId>, egui::Pos2),
+    /// This should be sent whenever the web page gains or loses focus (true when focus is gained,
+    /// false when focus is lost)
+    Focus(bool),
 }
 
 /// A custom output that can be sent from the worker thread to the main thread.

--- a/crates/eframe/src/web/text_agent.rs
+++ b/crates/eframe/src/web/text_agent.rs
@@ -5,7 +5,7 @@ use std::{cell::Cell, rc::Rc};
 
 use wasm_bindgen::prelude::*;
 
-use super::{canvas_element, AppRunner, WebRunner};
+use super::{AppRunner, WebRunner};
 
 static AGENT_ID: &str = "egui_text_agent";
 
@@ -229,8 +229,7 @@ pub fn move_text_cursor(
     ime: Option<egui::output::IMEOutput>,
     canvas: &web_sys::HtmlCanvasElement,
 ) -> Option<()> {
-    let input = text_agent();
-    let style = input.style();
+    let style = text_agent().style();
     // Note: moving agent on mobile devices will lead to unpredictable scroll.
     if is_mobile() == Some(false) {
         ime.as_ref().and_then(|ime| {

--- a/crates/eframe/src/web/web_painter.rs
+++ b/crates/eframe/src/web/web_painter.rs
@@ -9,6 +9,9 @@ pub(crate) trait WebPainter {
     // where
     //     Self: Sized;
 
+    /// Reference to the canvas in use.
+    fn canvas(&self) -> &web_sys::OffscreenCanvas;
+
     /// Maximum size of a texture in one direction.
     fn max_texture_side(&self) -> usize;
 

--- a/crates/eframe/src/web/web_painter_glow.rs
+++ b/crates/eframe/src/web/web_painter_glow.rs
@@ -10,7 +10,6 @@ use super::web_painter::WebPainter;
 
 pub(crate) struct WebPainterGlow {
     canvas: HtmlCanvasElement,
-    canvas_id: String,
     painter: egui_glow::Painter,
 }
 
@@ -20,7 +19,7 @@ impl WebPainterGlow {
     }
 
     pub async fn new(canvas_id: &str, options: &WebOptions) -> Result<Self, String> {
-        let canvas = super::canvas_element_or_die(canvas_id);
+        let canvas = super::get_canvas_element_by_id_or_die(canvas_id);
 
         let (gl, shader_prefix) =
             init_glow_context_from_canvas(&canvas, options.webgl_context_option)?;
@@ -30,11 +29,7 @@ impl WebPainterGlow {
         let painter = egui_glow::Painter::new(gl, shader_prefix, None)
             .map_err(|err| format!("Error starting glow painter: {err}"))?;
 
-        Ok(Self {
-            canvas,
-            canvas_id: canvas_id.to_owned(),
-            painter,
-        })
+        Ok(Self { canvas, painter })
     }
 }
 
@@ -43,8 +38,8 @@ impl WebPainter for WebPainterGlow {
         self.painter.max_texture_side()
     }
 
-    fn canvas_id(&self) -> &str {
-        &self.canvas_id
+    fn canvas(&self) -> &HtmlCanvasElement {
+        &self.canvas
     }
 
     fn paint_and_update_textures(

--- a/crates/eframe/src/web/web_painter_wgpu.rs
+++ b/crates/eframe/src/web/web_painter_wgpu.rs
@@ -216,6 +216,10 @@ impl WebPainterWgpu {
 }
 
 impl WebPainter for WebPainterWgpu {
+    fn canvas(&self) -> &web_sys::OffscreenCanvas {
+        &self.canvas
+    }
+
     fn max_texture_side(&self) -> usize {
         self.render_state.as_ref().map_or(0, |state| {
             state.device.limits().max_texture_dimension_2d as _

--- a/crates/eframe/src/web/web_runner.rs
+++ b/crates/eframe/src/web/web_runner.rs
@@ -1,4 +1,7 @@
-use std::{cell::RefCell, rc::Rc};
+use std::{
+    cell::{Cell, RefCell},
+    rc::Rc,
+};
 
 use wasm_bindgen::prelude::*;
 
@@ -24,6 +27,9 @@ pub struct WebRunner {
     /// They have to be in a separate `Rc` so that we don't need to pass them to
     /// the panic handler, since they aren't `Send`.
     events_to_unsubscribe: Rc<RefCell<Vec<EventToUnsubscribe>>>,
+
+    /// Used in `destroy` to cancel a pending frame.
+    request_animation_frame_id: Cell<Option<i32>>,
 }
 
 impl WebRunner {
@@ -41,6 +47,7 @@ impl WebRunner {
             panic_handler,
             runner: Rc::new(RefCell::new(None)),
             events_to_unsubscribe: Rc::new(RefCell::new(Default::default())),
+            request_animation_frame_id: Cell::new(None),
         }
     }
 
@@ -164,6 +171,11 @@ impl WebRunner {
     pub fn destroy(&self) {
         self.unsubscribe_from_all_events();
 
+        if let Some(id) = self.request_animation_frame_id.get() {
+            let window = web_sys::window().unwrap();
+            window.cancel_animation_frame(id).ok();
+        }
+
         if let Some(runner) = self.runner.replace(None) {
             runner.destroy();
         }
@@ -233,6 +245,18 @@ impl WebRunner {
             .borrow_mut()
             .push(EventToUnsubscribe::TargetEvent(handle));
 
+        Ok(())
+    }
+
+    pub(crate) fn request_animation_frame(&self) -> Result<(), wasm_bindgen::JsValue> {
+        let window = web_sys::window().unwrap();
+        let closure = Closure::once({
+            let runner_ref = self.clone();
+            move || events::paint_and_schedule(&runner_ref)
+        });
+        let id = window.request_animation_frame(closure.as_ref().unchecked_ref())?;
+        self.request_animation_frame_id.set(Some(id));
+        closure.forget(); // We must forget it, or else the callback is canceled on drop
         Ok(())
     }
 }

--- a/crates/eframe/src/web/web_runner.rs
+++ b/crates/eframe/src/web/web_runner.rs
@@ -134,7 +134,7 @@ impl WebRunner {
         self.runner.replace(Some(runner));
 
         {
-            events::request_animation_frame(self.clone())?;
+            self.request_animation_frame()?;
         }
 
         Ok(())
@@ -249,12 +249,12 @@ impl WebRunner {
     }
 
     pub(crate) fn request_animation_frame(&self) -> Result<(), wasm_bindgen::JsValue> {
-        let window = web_sys::window().unwrap();
+        let worker = luminol_web::bindings::worker().unwrap();
         let closure = Closure::once({
             let runner_ref = self.clone();
             move || events::paint_and_schedule(&runner_ref)
         });
-        let id = window.request_animation_frame(closure.as_ref().unchecked_ref())?;
+        let id = worker.request_animation_frame(closure.as_ref().unchecked_ref())?;
         self.request_animation_frame_id.set(Some(id));
         closure.forget(); // We must forget it, or else the callback is canceled on drop
         Ok(())

--- a/crates/egui-wgpu/CHANGELOG.md
+++ b/crates/egui-wgpu/CHANGELOG.md
@@ -6,6 +6,18 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.27.2 - 2024-04-02
+* Nothing new
+
+
+## 0.27.1 - 2024-03-29
+* Nothing new
+
+
+## 0.27.0 - 2024-03-26
+* Improve panic message in egui-wgpu when failing to create buffers [#3986](https://github.com/emilk/egui/pull/3986)
+
+
 ## 0.26.2 - 2024-02-14
 * Nothing new
 

--- a/crates/egui-wgpu/README.md
+++ b/crates/egui-wgpu/README.md
@@ -1,5 +1,5 @@
 > [!IMPORTANT]
-> luminol-egui-wgpu is currently based on emilk/egui@0.26.2
+> luminol-egui-wgpu is currently based on emilk/egui@0.27.2
 
 > [!NOTE]
 > This is Luminol's modified version of egui-wgpu. The original version is dual-licensed under MIT and Apache 2.0.

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -334,7 +334,7 @@ impl luminol_eframe::App for App {
         // If a file/folder picker is open, prevent the user from interacting with the application
         // with the mouse.
         if update_state.project_manager.is_picker_open() {
-            egui::Area::new("luminol_picker_overlay").show(ctx, |ui| {
+            egui::Area::new("luminol_picker_overlay".into()).show(ctx, |ui| {
                 ui.allocate_response(
                     ui.ctx().input(|i| i.screen_rect.size()),
                     egui::Sense::click_and_drag(),


### PR DESCRIPTION
**Description**
This pull request updates egui to 0.27.2. Also updates winit from 0.29.11 to 0.29.15 because winit 0.29.11 has been yanked, and also removes a workaround for an egui_dock bug that has been fixed in egui_dock 0.12.0.

**Testing**
The changes in this release mostly affect the web version of eframe, so I've tested that the map editor and item editors still work properly in web builds.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown -Z build-std=std,panic_abort`
- [x] Run `cargo build --release`
- [x] If applicable, run `trunk build --release`
