### PR TITLE
Brush randomization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3174,6 +3174,7 @@ dependencies = [
  "luminol-macros",
  "luminol-modals",
  "luminol-term",
+ "murmur3",
  "once_cell",
  "poll-promise",
  "qp-trie",
@@ -3393,6 +3394,12 @@ checksum = "359f76430b20a79f9e20e115b3428614e654f04fab314482fc0fda0ebd3c6044"
 dependencies = [
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "murmur3"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "naga"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2933,6 +2933,7 @@ dependencies = [
  "luminol-egui-wgpu",
  "luminol-filesystem",
  "luminol-graphics",
+ "murmur3",
  "parking_lot",
  "qp-trie",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -132,6 +132,7 @@ rfd = "0.12.0"
 tempfile = "3.8.1"
 
 rand = "0.8.5"
+murmur3 = "0.5.2"
 
 alacritty_terminal = "0.22.0"
 

--- a/crates/components/Cargo.toml
+++ b/crates/components/Cargo.toml
@@ -48,3 +48,4 @@ fragile.workspace = true
 parking_lot.workspace = true
 
 fuzzy-matcher = "0.3.7"
+murmur3.workspace = true

--- a/crates/components/src/map_view.rs
+++ b/crates/components/src/map_view.rs
@@ -352,7 +352,8 @@ impl MapView {
         );
         let pattern_rect = egui::Rect::from_min_size(
             map_rect.min + (self.cursor_pos.to_vec2() * tile_size),
-            if !force_show_pattern_rect && drawing_shape_pos.is_some() {
+            if tilepicker.brush_random || (!force_show_pattern_rect && drawing_shape_pos.is_some())
+            {
                 egui::Vec2::splat(tile_size)
             } else {
                 egui::vec2(

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -147,13 +147,14 @@ impl ModifiedState {
 }
 
 #[allow(missing_docs)]
-#[derive(Default)]
 pub struct ToolbarState {
     /// The currently selected pencil.
     pub pencil: Pencil,
     /// Brush density between 0 and 1 inclusive; determines the proportion of randomly chosen tiles
     /// the brush draws on if less than 1
     pub brush_density: f32,
+    /// Whether or not brush tile ID randomization is active.
+    pub brush_random: bool,
 }
 
 #[derive(Default, strum::EnumIter, strum::Display, PartialEq, Eq, Clone, Copy)]
@@ -164,6 +165,16 @@ pub enum Pencil {
     Circle,
     Rectangle,
     Fill,
+}
+
+impl Default for ToolbarState {
+    fn default() -> Self {
+        Self {
+            pencil: Default::default(),
+            brush_density: 1.,
+            brush_random: false,
+        }
+    }
 }
 
 impl<'res> UpdateState<'res> {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -151,6 +151,9 @@ impl ModifiedState {
 pub struct ToolbarState {
     /// The currently selected pencil.
     pub pencil: Pencil,
+    /// Brush density between 0 and 1 inclusive; determines the proportion of randomly chosen tiles
+    /// the brush draws on if less than 1
+    pub brush_density: f32,
 }
 
 #[derive(Default, strum::EnumIter, strum::Display, PartialEq, Eq, Clone, Copy)]

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -55,5 +55,7 @@ color-eyre.workspace = true
 
 wgpu.workspace = true
 
+murmur3 = "0.5.2"
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 luminol-term = { version = "0.4.0", path = "../term/" }

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -55,7 +55,7 @@ color-eyre.workspace = true
 
 wgpu.workspace = true
 
-murmur3 = "0.5.2"
+murmur3.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 luminol-term = { version = "0.4.0", path = "../term/" }

--- a/crates/ui/src/tabs/map/brush.rs
+++ b/crates/ui/src/tabs/map/brush.rs
@@ -46,13 +46,19 @@ impl super::Tab {
 
         match pencil {
             luminol_core::Pencil::Pen => {
+                let (rect_width, rect_height) = if self.tilepicker.brush_random {
+                    (1, 1)
+                } else {
+                    (width, height)
+                };
+
                 let drawing_shape_pos = if let Some(drawing_shape_pos) = self.drawing_shape_pos {
                     drawing_shape_pos
                 } else {
                     self.drawing_shape_pos = Some(map_pos);
                     map_pos
                 };
-                for (y, x) in (0..height).cartesian_product(0..width) {
+                for (y, x) in (0..rect_height).cartesian_product(0..rect_width) {
                     let absolute_x = map_x + x as usize;
                     let absolute_y = map_y + y as usize;
 
@@ -64,6 +70,9 @@ impl super::Tab {
                     self.set_tile(
                         map,
                         self.tilepicker.get_tile_from_offset(
+                            absolute_x as i16,
+                            absolute_y as i16,
+                            tile_layer as i16,
                             x + (map_x as f32 - drawing_shape_pos.x) as i16,
                             y + (map_y as f32 - drawing_shape_pos.y) as i16,
                         ),
@@ -87,6 +96,9 @@ impl super::Tab {
                     self.set_tile(
                         map,
                         self.tilepicker.get_tile_from_offset(
+                            position.0 as i16,
+                            position.1 as i16,
+                            tile_layer as i16,
                             position.0 as i16 - drawing_shape_pos.x as i16,
                             position.1 as i16 - drawing_shape_pos.y as i16,
                         ),
@@ -159,6 +171,9 @@ impl super::Tab {
                             self.set_tile(
                                 map,
                                 self.tilepicker.get_tile_from_offset(
+                                    x as i16,
+                                    y as i16,
+                                    tile_layer as i16,
                                     x as i16 - drawing_shape_pos.x as i16,
                                     y as i16 - drawing_shape_pos.y as i16,
                                 ),
@@ -202,6 +217,9 @@ impl super::Tab {
                         self.set_tile(
                             map,
                             self.tilepicker.get_tile_from_offset(
+                                map_x as i16,
+                                map_y as i16,
+                                tile_layer as i16,
                                 map_x as i16 - drawing_shape_pos.x as i16,
                                 map_y as i16 - drawing_shape_pos.y as i16,
                             ),
@@ -250,6 +268,9 @@ impl super::Tab {
                                     self.set_tile(
                                         map,
                                         self.tilepicker.get_tile_from_offset(
+                                            x as i16,
+                                            y as i16,
+                                            tile_layer as i16,
                                             x as i16 - drawing_shape_pos.x as i16,
                                             y as i16 - drawing_shape_pos.y as i16,
                                         ),
@@ -292,6 +313,9 @@ impl super::Tab {
                                     self.set_tile(
                                         map,
                                         self.tilepicker.get_tile_from_offset(
+                                            x as i16,
+                                            y as i16,
+                                            tile_layer as i16,
                                             x as i16 - drawing_shape_pos.x as i16,
                                             y as i16 - drawing_shape_pos.y as i16,
                                         ),

--- a/crates/ui/src/tabs/map/mod.rs
+++ b/crates/ui/src/tabs/map/mod.rs
@@ -90,7 +90,7 @@ pub struct Tab {
     /// the brush draws on if less than 1
     brush_density: f32,
     /// Seed for the PRNG used for the brush when brush density is less than 1
-    brush_seed: [u8; 8],
+    brush_seed: [u8; 16],
 }
 
 // TODO: If we add support for changing event IDs, these need to be added as history entries
@@ -139,6 +139,18 @@ impl Tab {
             |x, y, passage| passages[(x, y)] = passage,
         );
 
+        let mut brush_seed = [0u8; 16];
+        brush_seed[0..8].copy_from_slice(
+            &update_state
+                .project_config
+                .as_ref()
+                .expect("project not loaded")
+                .project
+                .persistence_id
+                .to_le_bytes(),
+        );
+        brush_seed[8..16].copy_from_slice(&(id as u64).to_le_bytes());
+
         Ok(Self {
             id,
 
@@ -165,13 +177,7 @@ impl Tab {
             passages,
 
             brush_density: 1.,
-            brush_seed: update_state
-                .project_config
-                .as_ref()
-                .expect("project not loaded")
-                .project
-                .persistence_id
-                .to_le_bytes(),
+            brush_seed,
         })
     }
 }

--- a/crates/ui/src/tabs/map/util.rs
+++ b/crates/ui/src/tabs/map/util.rs
@@ -148,6 +148,27 @@ impl super::Tab {
         tile: luminol_components::SelectedTile,
         position: (usize, usize, usize),
     ) {
+        if self.brush_density != 1. {
+            if self.brush_density == 0. {
+                return;
+            }
+
+            // Pick a pseudorandom normal f32 uniformly in the interval [0, 1)
+            let mut image = [0u8; 40];
+            image[0..8].copy_from_slice(&self.brush_seed);
+            image[8..16].copy_from_slice(&(position.0 as u64).to_le_bytes());
+            image[16..24].copy_from_slice(&(position.1 as u64).to_le_bytes());
+            image[24..32].copy_from_slice(&(position.2 as u64).to_le_bytes());
+            let f = (murmur3::murmur3_32(&mut std::io::Cursor::new(image), self.id as u32).unwrap()
+                & 16777215) as f32
+                / 16777216f32;
+
+            // Set the tile only if that's less than the brush density
+            if f >= self.brush_density {
+                return;
+            }
+        }
+
         map.data[position] = tile.to_id();
 
         for y in -1i8..=1i8 {

--- a/crates/ui/src/tabs/map/util.rs
+++ b/crates/ui/src/tabs/map/util.rs
@@ -154,17 +154,17 @@ impl super::Tab {
             }
 
             // Pick a pseudorandom normal f32 uniformly in the interval [0, 1)
-            let mut image = [0u8; 40];
-            image[0..8].copy_from_slice(&self.brush_seed);
-            image[8..16].copy_from_slice(&(position.0 as u64).to_le_bytes());
-            image[16..24].copy_from_slice(&(position.1 as u64).to_le_bytes());
-            image[24..32].copy_from_slice(&(position.2 as u64).to_le_bytes());
-            let f = (murmur3::murmur3_32(&mut std::io::Cursor::new(image), self.id as u32).unwrap()
+            let mut preimage = [0u8; 40];
+            preimage[0..16].copy_from_slice(&self.brush_seed);
+            preimage[16..24].copy_from_slice(&(position.0 as u64).to_le_bytes());
+            preimage[24..32].copy_from_slice(&(position.1 as u64).to_le_bytes());
+            preimage[32..40].copy_from_slice(&(position.2 as u64).to_le_bytes());
+            let image = (murmur3::murmur3_32(&mut std::io::Cursor::new(preimage), 1729).unwrap()
                 & 16777215) as f32
                 / 16777216f32;
 
             // Set the tile only if that's less than the brush density
-            if f >= self.brush_density {
+            if image >= self.brush_density {
                 return;
             }
         }

--- a/src/app/top_bar.rs
+++ b/src/app/top_bar.rs
@@ -424,19 +424,19 @@ impl TopBar {
             ui.selectable_value(&mut update_state.toolbar.pencil, brush, brush.to_string());
         }
 
-        ui.separator();
-
-        ui.vertical(|ui| {
-            ui.add_space(ui.spacing().button_padding.y.max(
-                (ui.spacing().interact_size.y - ui.text_style_height(&egui::TextStyle::Body)) / 2.,
-            ));
-            ui.label("Brush Density:");
-        });
-
         ui.add(egui::Slider::new(
             &mut update_state.toolbar.brush_density,
             0.0..=1.0,
-        ));
+        ))
+        .on_hover_text("The proportion of tiles the brush is able to draw on");
+
+        let alt_down = ui.input(|i| i.modifiers.alt);
+        let mut brush_random = update_state.toolbar.brush_random != alt_down;
+        ui.add(egui::Checkbox::new(
+            &mut brush_random, "Randomize ID",
+        ))
+        .on_hover_text("If enabled, the brush will randomly place tiles out of the selected tiles in the tilepicker instead of placing them in a pattern");
+        update_state.toolbar.brush_random = brush_random != alt_down;
 
         if open_project {
             update_state.project_manager.open_project_picker();

--- a/src/app/top_bar.rs
+++ b/src/app/top_bar.rs
@@ -424,6 +424,20 @@ impl TopBar {
             ui.selectable_value(&mut update_state.toolbar.pencil, brush, brush.to_string());
         }
 
+        ui.separator();
+
+        ui.vertical(|ui| {
+            ui.add_space(ui.spacing().button_padding.y.max(
+                (ui.spacing().interact_size.y - ui.text_style_height(&egui::TextStyle::Body)) / 2.,
+            ));
+            ui.label("Brush Density:");
+        });
+
+        ui.add(egui::Slider::new(
+            &mut update_state.toolbar.brush_density,
+            0.0..=1.0,
+        ));
+
         if open_project {
             update_state.project_manager.open_project_picker();
         }


### PR DESCRIPTION
**Connections**
* Closes #122

**Description**
This adds a checkbox to the top bar to make the brushes use random tiles from the rectangle of selected tiles in the tilepicker, which makes it easier to create randomly distributed tiles. Holding down the Alt key on the keyboard inverts the setting.

There's also a density setting in the top bar that allows making the brush only draw on a percentage of randomly chosen tiles on the map instead of every tile. This is intended to make it easier to create heterogeneous sets of random tiles, like if someone wants to create a map consisting mostly of one set of random tiles but with a small number of a different set of random tiles here and there.

**Testing**
Needs to be verified that the random patterns created by the Randomize ID setting and the density setting in the top bar are deterministic when drawing over the same region of a map multiple times, including with different brushes. This is important because otherwise the random tiles may not be uniformly distributed when the density setting is less than 1. Other than that, I highly doubt anything else needs to be tested.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown -Z build-std=std,panic_abort`
- [x] Run `cargo build --release`
- [ ] If applicable, run `trunk build --release`
