### PR TITLE
Tile ID display

### DIFF
--- a/crates/components/src/map_view.rs
+++ b/crates/components/src/map_view.rs
@@ -47,6 +47,9 @@ pub struct MapView {
 
     pub darken_unselected_layers: bool,
 
+    /// Whether to display the tile IDs on the map
+    pub display_tile_ids: bool,
+
     pub scale: f32,
     pub previous_scale: f32,
 
@@ -160,6 +163,8 @@ impl MapView {
             hover_tile: None,
 
             selected_event_is_hovered: false,
+
+            display_tile_ids: false,
 
             scale,
             previous_scale: scale,
@@ -609,6 +614,29 @@ impl MapView {
                 grid_inner_thickness,
                 canvas_rect,
             );
+        }
+
+        // FIXME: If we want to be fast, we should be rendering all the tile ids to a texture once and then just rendering that texture here
+        if self.display_tile_ids {
+            if let SelectedLayer::Tiles(layer) = self.selected_layer {
+                for (i, id) in map.data.layer_as_slice(layer).iter().copied().enumerate() {
+                    let x = i % map.data.xsize();
+                    let y = i / map.data.xsize();
+
+                    let tile_x = x as f32 * tile_size;
+                    let tile_y = y as f32 * tile_size;
+                    let tile_pos = egui::Pos2::new(tile_x, tile_y)
+                        + egui::Vec2::splat(tile_size / 2.0)
+                        + map_rect.min.to_vec2();
+                    ui.painter().text(
+                        tile_pos,
+                        egui::Align2::CENTER_CENTER,
+                        id.to_string(),
+                        egui::FontId::monospace(12. * scale),
+                        egui::Color32::WHITE,
+                    );
+                }
+            }
         }
 
         // Do we display the visible region?

--- a/crates/ui/src/tabs/map/mod.rs
+++ b/crates/ui/src/tabs/map/mod.rs
@@ -214,6 +214,7 @@ impl luminol_core::Tab for Tab {
         self.brush_density = update_state.toolbar.brush_density;
 
         // Display the toolbar.
+        // FIXME: find a proper place for this toolbar! it looks very out of place right now.
         egui::TopBottomPanel::top(format!("map_{}_toolbar", self.id)).show_inside(ui, |ui| {
             ui.horizontal_wrapped(|ui| {
                 ui.add(
@@ -285,17 +286,23 @@ impl luminol_core::Tab for Tab {
 
                 ui.separator();
 
-                ui.checkbox(&mut self.view.visible_display, "Display visible area")
-                    .on_hover_text("Display the visible area in-game (640x480)");
-                ui.checkbox(&mut self.view.move_preview, "Preview event move routes")
-                    .on_hover_text("Preview event page move routes");
-                ui.checkbox(&mut self.view.snap_to_grid, "Snap to grid")
-                    .on_hover_text("Snaps the viewport to the tile grid");
-                ui.checkbox(
-                    &mut self.view.darken_unselected_layers,
-                    "Darken unselected layers",
-                )
-                .on_hover_text("Toggles darkening unselected layers");
+                ui.menu_button("Display options ⏷", |ui| {
+                    ui.checkbox(&mut self.view.visible_display, "Display visible area")
+                        .on_hover_text("Display the visible area in-game (640x480)");
+                    ui.checkbox(&mut self.view.move_preview, "Preview event move routes")
+                        .on_hover_text("Preview event page move routes");
+                    ui.checkbox(&mut self.view.snap_to_grid, "Snap to grid")
+                        .on_hover_text("Snaps the viewport to the tile grid");
+                    ui.checkbox(
+                        &mut self.view.darken_unselected_layers,
+                        "Darken unselected layers",
+                    )
+                    .on_hover_text("Toggles darkening unselected layers");
+                    ui.checkbox(&mut self.view.display_tile_ids, "Display tile IDs")
+                        .on_disabled_hover_text(
+                            "Display the tile IDs of the currently selected layer",
+                        );
+                });
 
                 /*
                 if ui.button("Save map preview").clicked() {


### PR DESCRIPTION
**Connections**
N/A

**Description**
This PR adds a toggle to display the tile IDs of the currently selected layer. It's more of a low-level thing, useful to people working on Luminol or RGSS implementations (i.e. me)

**Testing**
Open a map, press `Display options ⏷` then check `Display tile IDs`. Then select a layer.
You should see something like this:
![image](https://github.com/Astrabit-ST/Luminol/assets/54482069/f46d04c7-49c9-4806-a8b4-76486d29fe1d)

<!-- 
Thanks for filing a pull request! The codeowners file will automatically request reviews.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown -Z build-std=std,panic_abort`
- [x] Run `cargo build --release`
- [ ] If applicable, run `trunk build --release`
