### PR TITLE
Script manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3240,6 +3240,7 @@ dependencies = [
  "luminol-term",
  "murmur3",
  "once_cell",
+ "parking_lot",
  "poll-promise",
  "qp-trie",
  "reqwest",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3239,6 +3239,7 @@ dependencies = [
  "camino",
  "color-eyre",
  "egui",
+ "futures-lite 2.2.0",
  "futures-util",
  "itertools 0.11.0",
  "luminol-audio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,7 +149,7 @@ version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc7ceabf6fc76511f616ca216b51398a2511f19ba9f71bcbd977999edff1b0d1"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bitflags 2.4.2",
  "home",
  "libc",
@@ -656,6 +656,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,9 +829,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cairo-sys-rs"
@@ -2605,9 +2611,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.3"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "233cf39063f058ea2caae4091bf4a3ef70a653afbc026f5c4a4135d114e3c177"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -2681,9 +2687,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jni"
@@ -2847,6 +2853,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libyml"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e281a65eeba3d4503a2839252f86374528f9ceafe6fed97c1d3b52e1fb625c1"
+
+[[package]]
 name = "line-wrap"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2891,9 +2903,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
 dependencies = [
  "value-bag",
 ]
@@ -3048,6 +3060,7 @@ name = "luminol-data"
 version = "0.4.0"
 dependencies = [
  "alox-48",
+ "base64 0.22.1",
  "bytemuck",
  "camino",
  "flate2",
@@ -3244,7 +3257,10 @@ dependencies = [
  "poll-promise",
  "qp-trie",
  "reqwest",
+ "ron",
  "serde",
+ "serde_json",
+ "serde_yml",
  "strip-ansi-escapes",
  "strum",
  "target-triple",
@@ -3339,9 +3355,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
+checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
 
 [[package]]
 name = "memmap2"
@@ -4007,7 +4023,7 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5699cc8a63d1aa2b1ee8e12b9ad70ac790d65788cd36101fa37f87ea46c4cef"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "indexmap",
  "line-wrap",
  "quick-xml",
@@ -4377,7 +4393,7 @@ version = "0.11.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -4476,7 +4492,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "bitflags 2.4.2",
  "serde",
  "serde_derive",
@@ -4564,7 +4580,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
- "base64",
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -4581,9 +4597,9 @@ checksum = "a2316fb90175e4f747331f29c9275aaddf2868b355472e94a3b82ad235a719b5"
 
 [[package]]
 name = "ryu"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e86697c916019a8588c99b5fac3cead74ec0b4b819707a682fd4d23fa0ce1ba1"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "safemem"
@@ -4665,18 +4681,18 @@ checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.203"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4685,9 +4701,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "455182ea6142b14f93f4bc5320a2b31c1f266b66a4a5c858b013302a5d8cbfc3"
 dependencies = [
  "itoa",
  "ryu",
@@ -4724,6 +4740,23 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yml"
+version = "0.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ce6afeda22f0b55dde2c34897bce76a629587348480384231205c14b59a01f"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "libyml",
+ "log",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -5607,7 +5640,7 @@ version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b0a51b72ab80ca511d126b77feeeb4fb1e972764653e61feac30adc161a756"
 dependencies = [
- "base64",
+ "base64 0.21.7",
  "log",
  "pico-args",
  "usvg-parser",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,8 @@ glam = { version = "0.24.2", features = ["bytemuck"] }
 image = "0.24.7"
 
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_yml = "0.0.10"
 alox-48 = { version = "0.5.0" }
 ron = "0.8.1"
 rust-ini = "0.20.0"

--- a/crates/components/src/filesystem_view.rs
+++ b/crates/components/src/filesystem_view.rs
@@ -86,7 +86,7 @@ impl Entry {
 
 impl<T> FileSystemView<T>
 where
-    T: luminol_filesystem::FileSystem,
+    T: luminol_filesystem::ReadDir,
 {
     pub fn new(id: egui::Id, filesystem: T, root_name: String) -> Self {
         let mut arena = indextree::Arena::new();
@@ -641,17 +641,17 @@ pub struct Metadata {
 /// none of its contents.
 pub struct SelectedIter<'a, T>
 where
-    T: luminol_filesystem::FileSystem,
+    T: luminol_filesystem::ReadDir,
 {
     view: &'a FileSystemView<T>,
     edge: Option<indextree::NodeEdge>,
 }
 
-impl<'a, T> std::iter::FusedIterator for SelectedIter<'a, T> where T: luminol_filesystem::FileSystem {}
+impl<'a, T> std::iter::FusedIterator for SelectedIter<'a, T> where T: luminol_filesystem::ReadDir {}
 
 impl<'a, T> Iterator for SelectedIter<'a, T>
 where
-    T: luminol_filesystem::FileSystem,
+    T: luminol_filesystem::ReadDir,
 {
     type Item = Metadata;
     fn next(&mut self) -> Option<Self::Item> {
@@ -724,7 +724,7 @@ where
 
 impl<'a, T> IntoIterator for &'a FileSystemView<T>
 where
-    T: luminol_filesystem::FileSystem,
+    T: luminol_filesystem::ReadDir,
 {
     type Item = Metadata;
     type IntoIter = SelectedIter<'a, T>;

--- a/crates/core/src/data_cache.rs
+++ b/crates/core/src/data_cache.rs
@@ -124,7 +124,7 @@ fn write_nil_padded(
         .map_err(color_eyre::Report::from)
 }
 
-fn format_traced_error(
+pub fn format_traced_error(
     error: impl Into<color_eyre::Report>,
     trace: alox_48::path_to_error::Trace,
 ) -> color_eyre::Report {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -45,6 +45,9 @@ pub mod project_manager;
 pub use project_manager::spawn_future;
 pub use project_manager::ProjectManager;
 
+pub use alox_48;
+pub use data_cache::format_traced_error;
+
 static GIT_REVISION: once_cell::sync::OnceCell<&'static str> = once_cell::sync::OnceCell::new();
 
 pub fn set_git_revision(revision: &'static str) {

--- a/crates/data/Cargo.toml
+++ b/crates/data/Cargo.toml
@@ -22,6 +22,7 @@ num_enum = "0.7.0"
 rand.workspace = true
 
 flate2 = "1.0"
+base64 = "0.22.1"
 
 serde.workspace = true
 alox-48.workspace = true

--- a/crates/data/src/shared/script.rs
+++ b/crates/data/src/shared/script.rs
@@ -146,11 +146,11 @@ impl<'de> serde::Deserialize<'de> for Script {
                 }
 
                 let Some(name) = name else {
-                    return Err(A::Error::missing_field("name".into()));
+                    return Err(A::Error::missing_field("name"));
                 };
 
                 let Some(data) = data else {
-                    return Err(A::Error::missing_field("data".into()));
+                    return Err(A::Error::missing_field("data"));
                 };
 
                 let mut decoder = flate2::bufread::ZlibDecoder::new(std::io::Cursor::new(

--- a/crates/data/src/shared/script.rs
+++ b/crates/data/src/shared/script.rs
@@ -15,12 +15,26 @@
 // You should have received a copy of the GNU General Public License
 // along with Luminol.  If not, see <http://www.gnu.org/licenses/>.
 
+use base64::Engine;
+use rand::Rng;
+
 #[allow(missing_docs)]
-#[derive(serde::Deserialize, serde::Serialize)]
 #[derive(Debug, Clone)]
 pub struct Script {
+    pub id: u32,
     pub name: String,
     pub script_text: String,
+}
+
+impl Script {
+    /// Creates a new `Script` with a random ID.
+    pub fn new(name: impl Into<String>, script_text: impl Into<String>) -> Self {
+        Self {
+            id: rand::thread_rng().gen_range(0..=99999999),
+            name: name.into(),
+            script_text: script_text.into(),
+        }
+    }
 }
 
 impl<'de> alox_48::Deserialize<'de> for Script {
@@ -43,7 +57,7 @@ impl<'de> alox_48::Deserialize<'de> for Script {
             {
                 use std::io::Read;
 
-                let Some(_) = array.next_element::<alox_48::de::Ignored>()? else {
+                let Some(id) = array.next_element()? else {
                     return Err(alox_48::DeError::missing_field("id".into()));
                 };
 
@@ -62,6 +76,7 @@ impl<'de> alox_48::Deserialize<'de> for Script {
                     .map_err(alox_48::DeError::custom)?;
 
                 Ok(Script {
+                    id,
                     name,
                     script_text: script,
                 })
@@ -88,10 +103,106 @@ impl alox_48::Serialize for Script {
             .and_then(|_| encoder.finish())
             .map_err(alox_48::SerError::custom)?;
 
-        array.serialize_element(&0usize)?;
+        array.serialize_element(&self.id)?;
         array.serialize_element(&self.name)?;
         array.serialize_element(&alox_48::RbString { data })?;
 
         array.end()
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Script {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct Visitor;
+
+        impl<'de> serde::de::Visitor<'de> for Visitor {
+            type Value = Script;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("a key-value mapping")
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: serde::de::MapAccess<'de>,
+            {
+                use serde::de::Error;
+                use std::io::Read;
+
+                let mut id = None;
+                let mut name = None;
+                let mut data = None;
+
+                while let Some(key) = map.next_key::<String>()? {
+                    match key.as_str() {
+                        "id" => id = Some(map.next_value()?),
+                        "name" => name = Some(map.next_value()?),
+                        "data" => data = Some(map.next_value::<String>()?),
+                        _ => {}
+                    }
+                }
+
+                let Some(name) = name else {
+                    return Err(A::Error::missing_field("name".into()));
+                };
+
+                let Some(data) = data else {
+                    return Err(A::Error::missing_field("data".into()));
+                };
+
+                let mut decoder = flate2::bufread::ZlibDecoder::new(std::io::Cursor::new(
+                    base64::engine::general_purpose::STANDARD
+                        .decode(data)
+                        .map_err(A::Error::custom)?,
+                ));
+                let mut script = String::new();
+                decoder
+                    .read_to_string(&mut script)
+                    .map_err(A::Error::custom)?;
+
+                Ok(if let Some(id) = id {
+                    Script {
+                        id,
+                        name,
+                        script_text: script,
+                    }
+                } else {
+                    Script::new(name, script)
+                })
+            }
+        }
+
+        deserializer.deserialize_any(Visitor)
+    }
+}
+
+impl serde::Serialize for Script {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        use serde::ser::Error;
+        use serde::ser::SerializeMap;
+        use std::io::Write;
+
+        let mut map = serializer.serialize_map(Some(3))?;
+
+        let mut encoder = flate2::write::ZlibEncoder::new(Vec::new(), Default::default());
+        let data = encoder
+            .write_all(self.script_text.as_bytes())
+            .and_then(|_| encoder.finish())
+            .map_err(S::Error::custom)?;
+
+        map.serialize_entry("id", &self.id)?;
+        map.serialize_entry("name", &self.name)?;
+        map.serialize_entry(
+            "data",
+            &base64::engine::general_purpose::STANDARD.encode(data),
+        )?;
+
+        map.end()
     }
 }

--- a/crates/filesystem/src/lib.rs
+++ b/crates/filesystem/src/lib.rs
@@ -261,3 +261,16 @@ pub trait FileSystem: Send + Sync {
         Ok(())
     }
 }
+
+pub trait ReadDir {
+    fn read_dir(&self, path: impl AsRef<camino::Utf8Path>) -> Result<Vec<DirEntry>>;
+}
+
+impl<T> ReadDir for T
+where
+    T: FileSystem,
+{
+    fn read_dir(&self, path: impl AsRef<camino::Utf8Path>) -> Result<Vec<DirEntry>> {
+        self.read_dir(path)
+    }
+}

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -44,6 +44,7 @@ strip-ansi-escapes = "0.2.0"
 
 poll-promise.workspace = true
 async-std.workspace = true
+futures-lite.workspace = true
 futures-util = "0.3.30"
 reqwest = { version = "0.11.23", features = ["json"] }
 

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -34,6 +34,9 @@ camino.workspace = true
 strum.workspace = true
 
 serde.workspace = true
+serde_json.workspace = true
+serde_yml.workspace = true
+ron.workspace = true
 
 target-triple = "0.1.2"
 

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -46,6 +46,7 @@ reqwest = { version = "0.11.23", features = ["json"] }
 
 zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
 
+parking_lot.workspace = true
 once_cell.workspace = true
 qp-trie.workspace = true
 

--- a/crates/ui/src/windows/archive_manager.rs
+++ b/crates/ui/src/windows/archive_manager.rs
@@ -206,16 +206,14 @@ impl luminol_core::Window for Window {
                                     if let Some(v) = view {
                                         v.ui(ui, update_state, None);
                                     } else {
-                                        ui.add(egui::Label::new("No archive chosen").wrap(false));
+                                        ui.add(egui::Label::new("No archive chosen"));
                                     }
                                 }
                                 Mode::Create { view, .. } => {
                                     if let Some(v) = view {
                                         v.ui(ui, update_state, Some(&CREATE_DEFAULT_SELECTED_DIRS));
                                     } else {
-                                        ui.add(
-                                            egui::Label::new("No source folder chosen").wrap(false),
-                                        );
+                                        ui.add(egui::Label::new("No source folder chosen"));
                                     }
                                 }
                             });

--- a/crates/ui/src/windows/mod.rs
+++ b/crates/ui/src/windows/mod.rs
@@ -57,6 +57,8 @@ pub mod new_project;
 pub mod reporter;
 /// The script editor
 pub mod script_edit;
+/// The script manager for creating and extracting Scripts.rxdata.
+pub mod script_manager;
 /// The skill editor.
 pub mod skills;
 /// The sound test.

--- a/crates/ui/src/windows/script_edit.rs
+++ b/crates/ui/src/windows/script_edit.rs
@@ -99,10 +99,7 @@ impl luminol_core::Window for Window {
                             if let Some(index) = insert_index {
                                 scripts.data.insert(
                                     index,
-                                    luminol_data::rpg::Script {
-                                        name: "New Script".to_string(),
-                                        script_text: String::new(),
-                                    },
+                                    luminol_data::rpg::Script::new("New Script", String::new()),
                                 );
                             }
 

--- a/crates/ui/src/windows/script_manager.rs
+++ b/crates/ui/src/windows/script_manager.rs
@@ -97,7 +97,11 @@ impl luminol_filesystem::ReadDir for ScriptsFileSystem {
             .iter_dir(path)
             .map_or_else(Default::default, |iter| {
                 iter.map(|(name, maybe_script)| luminol_filesystem::DirEntry {
-                    path: format!("{path}/{name}").into(),
+                    path: if path.as_str().is_empty() {
+                        name.into()
+                    } else {
+                        format!("{path}/{name}").into()
+                    },
                     metadata: if let Some(script) = maybe_script {
                         luminol_filesystem::Metadata {
                             is_file: true,

--- a/crates/ui/src/windows/script_manager.rs
+++ b/crates/ui/src/windows/script_manager.rs
@@ -33,6 +33,8 @@ pub struct Window {
     progress: std::sync::Arc<std::sync::atomic::AtomicUsize>,
 }
 
+type Scripts = Vec<luminol_data::rpg::Script>;
+
 enum Mode {
     Extract {
         view: Option<luminol_components::FileSystemView<ScriptsFileSystem>>,
@@ -51,15 +53,8 @@ enum Mode {
         progress_total: usize,
     },
     Convert {
-        scripts: Option<(
-            std::sync::Arc<parking_lot::Mutex<Vec<luminol_data::rpg::Script>>>,
-            String,
-        )>,
-        load_promise: Option<
-            poll_promise::Promise<
-                luminol_filesystem::Result<(Vec<luminol_data::rpg::Script>, String)>,
-            >,
-        >,
+        scripts: Option<(std::sync::Arc<parking_lot::Mutex<Scripts>>, String)>,
+        load_promise: Option<poll_promise::Promise<luminol_filesystem::Result<(Scripts, String)>>>,
         save_promise: Option<poll_promise::Promise<luminol_filesystem::Result<()>>>,
         format: ScriptsFormat,
     },

--- a/crates/ui/src/windows/script_manager.rs
+++ b/crates/ui/src/windows/script_manager.rs
@@ -180,33 +180,31 @@ where
     {
         let mut archive = None;
         let output = scripts_path
+            .map(|path| format!("Data/{path}"))
+            .as_deref()
             .into_iter()
             .chain([
-                "xScripts.rxdata",
-                "xScripts.rvdata",
-                "xScripts.rvdata2",
-                "xScripts.json",
-                "xScripts.yaml",
-                "xScripts.yml",
-                "xScripts.ron",
-                "Scripts.rxdata",
-                "Scripts.rvdata",
-                "Scripts.rvdata2",
-                "Scripts.json",
-                "Scripts.yaml",
-                "Scripts.yml",
-                "Scripts.ron",
+                "Data/xScripts.rxdata",
+                "Data/xScripts.rvdata",
+                "Data/xScripts.rvdata2",
+                "Data/xScripts.json",
+                "Data/xScripts.yaml",
+                "Data/xScripts.yml",
+                "Data/xScripts.ron",
+                "Data/Scripts.rxdata",
+                "Data/Scripts.rvdata",
+                "Data/Scripts.rvdata2",
+                "Data/Scripts.json",
+                "Data/Scripts.yaml",
+                "Data/Scripts.yml",
+                "Data/Scripts.ron",
                 "Game.rgssad",
                 "Game.rgss2a",
                 "Game.rgss3a",
             ])
-            .find_map(|filename| {
-                let path = if filename.starts_with("Game") {
-                    filename.into()
-                } else {
-                    camino::Utf8PathBuf::from("Data").join(filename)
-                };
-                let file = filesystem.open_file(&path, OpenFlags::Read).ok()?;
+            .find_map(|path| {
+                let path = camino::Utf8PathBuf::from(path);
+                let mut file = filesystem.open_file(&path, OpenFlags::Read).ok()?;
                 let vec: Vec<_> = match path.extension() {
                     Some("json") => serde_json::from_reader(std::io::BufReader::new(file)).ok()?,
 
@@ -225,7 +223,9 @@ where
                     }
 
                     _ => {
-                        let data = filesystem.read(&path).ok()?;
+                        use std::io::Read;
+                        let mut data = Vec::with_capacity(file.metadata().ok()?.size as usize);
+                        file.read_to_end(&mut data).ok()?;
                         let mut de = luminol_core::alox_48::Deserializer::new(&data).ok()?;
                         de.deserialize_value().ok()?
                     }

--- a/src/app/top_bar.rs
+++ b/src/app/top_bar.rs
@@ -281,6 +281,12 @@ impl TopBar {
                     .edit_windows
                     .add_window(luminol_ui::windows::archive_manager::Window::default());
             }
+
+            if ui.button("Script Manager").clicked() {
+                update_state
+                    .edit_windows
+                    .add_window(luminol_ui::windows::script_manager::Window::default());
+            }
         });
 
         ui.separator();


### PR DESCRIPTION
**Connections**
* Closes #28

**Description**
Adds a "Script Manager" under the Tools menu in the top bar that can be used to extract the scripts from Scripts.rxdata, create Scripts.rxdata from scripts or convert Scripts.rxdata to another format (JSON/YAML/RON).

**Testing**
I tested that it's capable of extracting the scripts from the following example games from https://www.rpgmakerweb.com/additional-downloads:
* KNight-Blade (RPG Maker XP)
* Legionwood (RPG Maker VX)
* Crysalis (RPG Maker VX Ace) 

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown -Z build-std=std,panic_abort`
- [x] Run `cargo build --release`
- [ ] If applicable, run `trunk build --release`