### PR TITLE
Fix a nasty alox-48 bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,9 +175,9 @@ checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
 
 [[package]]
 name = "alox-48"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b95702b328de6416c5504d9d7d74438362f06ec907579d3be0f28ee94084dc"
+checksum = "6934ee23d65ca3613e4656d66ab8b20082b52eafd7c84c3529c3719b820c16b8"
 dependencies = [
  "alox-48-derive",
  "enum-as-inner",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ image = "0.24.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yml = "0.0.10"
-alox-48 = { version = "0.5.0" }
+alox-48 = { version = "0.6.0" }
 ron = "0.8.1"
 rust-ini = "0.20.0"
 


### PR DESCRIPTION
**Connections**
[See this commit](https://github.com/Speak2Erase/alox-48/commit/2b77e019033b46d6a8fce9643aec7d9246d906e7)

**Description**
alox-48 had a really nasty bug caused by adding an `Instance`'s data to the table of previously deserialized objects. This meant that there were more objects being added to the table then there should've been, causing a desync which could lead to objectlinks linking to the wrong object.

I'm genuinely surprised was not caught earlier, but I stumbled upon this bug when alox-48 got stuck in a loop deserializing the same object and would blow the stack. There's now a check in alox-48 to prevent recursive object links (what was causing a stack overflow) as well so this shouldn't happen again.

**Testing**
I opened the map that caused me to find this bug and it no longer crashes.

<!-- 
Thanks for filing a pull request! The codeowners file will automatically request reviews.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown -Z build-std=std,panic_abort`
- [x] Run `cargo build --release`
- [ ] If applicable, run `trunk build --release`
