### PR TITLE
Initialize `Audio` lazily in web builds

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -397,7 +397,7 @@ pub fn luminol_main_start() {
 
     *WORKER_DATA.lock() = Some(WorkerData {
         report,
-        audio: luminol_audio::Audio::default().into(),
+        audio: luminol_audio::AudioWrapper::default(),
         modified: modified.clone(),
         prefers_color_scheme_dark,
         fs_worker_channels,


### PR DESCRIPTION
**Description**
We were having problems with the sound test in web builds since #114 where if the user doesn't click on the canvas or press a key while the canvas is focused between when the page started and finished loading, the sound test would not be able to play any sound because the Web Audio API requires an "[activation triggering input event](https://html.spec.whatwg.org/multipage/interaction.html#user-activation-processing-model)" to play audio in most browsers.

The fork of cpal we were using before #114 avoided this problem by repeatedly attempting to create an audio context until the user interacted with the application. After #114, cpal only tries once to create an audio context and just gives up if the first attempt was unsuccessful.

This pull request works around this problem by deferring the creation of an audio context in web builds until a sound is played for the first time.

**Testing**
The bug can be reproduced in web builds by reloading the page and then not interacting with the application for about 1 second after the interface starts rendering. Playing a sound in the sound test window would then not play any sound unless the changes from this pull request are used.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown -Z build-std=std,panic_abort`
- [x] Run `cargo build --release`
- [x] If applicable, run `trunk build --release`
