### PR TITLE
Path cache file creation bugfix

### DIFF
--- a/crates/filesystem/src/path_cache.rs
+++ b/crates/filesystem/src/path_cache.rs
@@ -478,6 +478,13 @@ where
                 }
             }
             cache.trie.remove_dir(&path);
+
+            let path = with_trie_suffix(&path);
+            let extension_trie = cache.trie.get_file(&path).unwrap();
+            for index in extension_trie.values().copied() {
+                cache.cactus.remove(index);
+            }
+            cache.trie.remove_file(&path);
         }
 
         Ok(())

--- a/crates/filesystem/src/path_cache.rs
+++ b/crates/filesystem/src/path_cache.rs
@@ -267,6 +267,22 @@ where
             },
         );
     }
+
+    /// Finds the correct letter casing and file extension for the given RPG Maker-style
+    /// case-insensitive path. Returns `Err(NotExist)` if no matching path is found.
+    ///
+    /// If the path you pass to this function has a file extension, this function will prioritize
+    /// files with that file extension (case-insensitive) and then fall back to ignoring the file
+    /// extension.
+    ///
+    /// If the path you pass to this function has no file extension, this function will prioritize
+    /// files with no file extension and then fall back to a wildcard file extension search.
+    pub fn desensitize(&self, path: impl AsRef<camino::Utf8Path>) -> Result<camino::Utf8PathBuf> {
+        let path = path.as_ref();
+        let mut cache = self.cache.write();
+        cache.regen(&self.fs, path)?;
+        cache.desensitize(path).ok_or(Error::NotExist.into())
+    }
 }
 
 pub fn to_lowercase(p: impl AsRef<camino::Utf8Path>) -> camino::Utf8PathBuf {


### PR DESCRIPTION
**Description**
Fixes the problem with the path cache described in #139. The problem was that the code the path cache uses to create new files when calling `.open_file` with `OpenFlags::Create` attempted to create the file at the wrong path.

I also added a new method, `.desensitize`, to the path cache that can be used to perform a case-insensitive search for a file with a specific file extension.

**Testing**
Setting the script path to a nonexistent file in the config window and then saving the project shouldn't trigger an error anymore.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown -Z build-std=std,panic_abort`
- [x] Run `cargo build --release`
- [ ] If applicable, run `trunk build --release`
