### PR TITLE
Update egui to 0.28.1

### DIFF
--- a/.github/workflows/build-steam.yml
+++ b/.github/workflows/build-steam.yml
@@ -23,7 +23,7 @@ jobs:
           sudo apt install libgtk-3-dev libatk1.0-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev libasound2-dev clang mold -y
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-02-01
+          toolchain: nightly-2024-05-19
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
       - name: Build luminol (Release)
@@ -48,7 +48,7 @@ jobs:
           submodules: true
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-02-01
+          toolchain: nightly-2024-05-19
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
       - name: Build luminol (Release)
@@ -73,7 +73,7 @@ jobs:
           submodules: true
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-02-01
+          toolchain: nightly-2024-05-19
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
       - name: Build luminol (Release)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
           sudo apt install libgtk-3-dev libatk1.0-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev libasound2-dev clang mold -y
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-02-01
+          toolchain: nightly-2024-05-19
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
       - name: Build luminol (Release)
@@ -46,7 +46,7 @@ jobs:
           submodules: true
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-02-01
+          toolchain: nightly-2024-05-19
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
       - name: Build luminol (Release)
@@ -70,7 +70,7 @@ jobs:
           submodules: true
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-02-01
+          toolchain: nightly-2024-05-19
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
       - name: Build luminol (Release)
@@ -98,7 +98,7 @@ jobs:
           sudo apt install libgtk-3-dev libatk1.0-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev libasound2-dev clang mold -y
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-02-01
+          toolchain: nightly-2024-05-19
           targets: wasm32-unknown-unknown
           components: rust-src
       - name: Download and install Trunk binary

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,7 +27,7 @@ jobs:
           sudo apt install libgtk-3-dev libatk1.0-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev libasound2-dev clang mold -y
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-02-01
+          toolchain: nightly-2024-05-19
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
       - run: cargo check --all-features 
@@ -45,7 +45,7 @@ jobs:
           sudo apt install libgtk-3-dev libatk1.0-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev libasound2-dev clang mold -y
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-02-01
+          toolchain: nightly-2024-05-19
           targets: wasm32-unknown-unknown
           components: rust-src
       - name: Rust Cache
@@ -65,7 +65,7 @@ jobs:
   #         sudo apt install libgtk-3-dev libatk1.0-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev libasound2-dev clang mold -y
   #     - uses: dtolnay/rust-toolchain@nightly
   #       with:
-  #         toolchain: nightly-2024-02-01
+  #         toolchain: nightly-2024-05-19
   #     - name: Rust Cache
   #       uses: Swatinem/rust-cache@v2
   #     - run: cargo test --workspace 
@@ -83,7 +83,7 @@ jobs:
           sudo apt install libgtk-3-dev libatk1.0-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev libasound2-dev clang mold -y
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-02-01
+          toolchain: nightly-2024-05-19
           components: rustfmt
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -102,7 +102,7 @@ jobs:
           sudo apt install libgtk-3-dev libatk1.0-dev libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libspeechd-dev libxkbcommon-dev libssl-dev libasound2-dev clang mold -y
       - uses: dtolnay/rust-toolchain@nightly
         with:
-          toolchain: nightly-2024-02-01
+          toolchain: nightly-2024-05-19
           components: clippy
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,9 +122,9 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ahash"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b79b82693f705137f8fb9b37871d99e4f9a7df12b917eed79c3d3954830a60b"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
@@ -150,7 +150,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc7ceabf6fc76511f616ca216b51398a2511f19ba9f71bcbd977999edff1b0d1"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "home",
  "libc",
  "log",
@@ -213,7 +213,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37fe60779335388a88c01ac6c3be40304d1e349de3ada3b15f7808bb90fa9dce"
 dependencies = [
  "alsa-sys",
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "libc",
 ]
 
@@ -234,7 +234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee91c0c2905bae44f84bfa4e044536541df26b7703fd0888deeb9060fcc44289"
 dependencies = [
  "android-properties",
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "cc",
  "cesu8",
  "jni",
@@ -682,7 +682,7 @@ version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
@@ -725,9 +725,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.4.2"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed570934406eb16438a4e976b1b4500774099c13b8cb96eec99f620f05090ddf"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 dependencies = [
  "serde",
 ]
@@ -762,7 +762,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae85a0696e7ea3b835a453750bf002770776609115e6d25c6d2ff28a8200f7e7"
 dependencies = [
- "objc-sys 0.3.2",
+ "objc-sys 0.3.5",
 ]
 
 [[package]]
@@ -783,6 +783,15 @@ checksum = "15b55663a85f33501257357e6421bb33e769d5c9ffb5ba0921c975a123e35e68"
 dependencies = [
  "block-sys 0.2.1",
  "objc2 0.4.1",
+]
+
+[[package]]
+name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2 0.5.2",
 ]
 
 [[package]]
@@ -834,6 +843,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
 name = "bytes"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -855,7 +870,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fba7adb4dd5aa98e5553510223000e7148f621165ec5f9acd7113f6ca4995298"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "log",
  "polling 3.5.0",
  "rustix 0.38.31",
@@ -960,36 +975,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f9a0700e0127ba15d1d52dd742097f821cd9c65939303a44d970465040a297"
 dependencies = [
  "error-code",
-]
-
-[[package]]
-name = "cocoa"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6140449f97a6e97f9511815c5632d84c8aacf8ac271ad77c559218161a1373c"
-dependencies = [
- "bitflags 1.3.2",
- "block",
- "cocoa-foundation",
- "core-foundation",
- "core-graphics",
- "foreign-types 0.5.0",
- "libc",
- "objc",
-]
-
-[[package]]
-name = "cocoa-foundation"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7"
-dependencies = [
- "bitflags 1.3.2",
- "block",
- "core-foundation",
- "core-graphics-types",
- "libc",
- "objc",
 ]
 
 [[package]]
@@ -1286,11 +1271,11 @@ checksum = "96a6ac251f4a2aca6b3f91340350eab87ae57c3f127ffeb585e92bd336717991"
 
 [[package]]
 name = "d3d12"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e3d747f100290a1ca24b752186f61f6637e1deffe3bf6320de6fcb29510a307"
+checksum = "b28bfe653d79bd16c77f659305b195b82bb5ce0c0eb2a4846b82ddbd77586813"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "libloading 0.8.1",
  "winapi",
 ]
@@ -1404,24 +1389,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "directories-next"
-version = "2.0.0"
+name = "directories"
+version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
 dependencies = [
- "cfg-if",
- "dirs-sys-next",
+ "dirs-sys",
 ]
 
 [[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
+name = "dirs-sys"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
 dependencies = [
  "libc",
+ "option-ext",
  "redox_users",
- "winapi",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1475,22 +1460,24 @@ dependencies = [
 
 [[package]]
 name = "ecolor"
-version = "0.27.2"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20930a432bbd57a6d55e07976089708d4893f3d556cf42a0d79e9e321fa73b10"
+checksum = "2e6b451ff1143f6de0f33fc7f1b68fecfd2c7de06e104de96c4514de3f5396f8"
 dependencies = [
  "bytemuck",
+ "emath",
  "serde",
 ]
 
 [[package]]
 name = "egui"
-version = "0.27.2"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "584c5d1bf9a67b25778a3323af222dbe1a1feb532190e103901187f92c7fe29a"
+checksum = "20c97e70a2768de630f161bb5392cbd3874fcf72868f14df0e002e82e06cb798"
 dependencies = [
  "accesskit",
  "ahash",
+ "emath",
  "epaint",
  "log",
  "nohash-hasher",
@@ -1501,29 +1488,30 @@ dependencies = [
 
 [[package]]
 name = "egui-modal"
-version = "0.3.6"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "738cdffefd15dbb6a5fff75d118eee82a9e894bbfa45e41c24d7de42519fa673"
+checksum = "4d3bc636d5ddc0c4a90d7a24c7d84db10fb2f789298e9c50cdddd28832e83f1e"
 dependencies = [
  "egui",
 ]
 
 [[package]]
 name = "egui-notify"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "319327faee7bb116bcdbe43af1b8cbea06dc5d9ddbb23d35e012949afbd76cde"
+checksum = "d0c6c49d9c02771e28f3b40289c16b4473308807b1ed09a878713d7f11e3dcad"
 dependencies = [
  "egui",
 ]
 
 [[package]]
 name = "egui-winit"
-version = "0.27.2"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e3da0cbe020f341450c599b35b92de4af7b00abde85624fd16f09c885573609"
+checksum = "fac4e066af341bf92559f60dbdf2020b2a03c963415349af5f3f8d79ff7a4926"
 dependencies = [
  "accesskit_winit",
+ "ahash",
  "arboard",
  "egui",
  "log",
@@ -1538,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "egui_dock"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3b8d9a54c0ed60f2670ad387c269663b4771431f090fa586906cf5f0bc586f4"
+checksum = "629a8b0e440d69996795669ceacc0dd839a997843489273600d31d16c9cb3500"
 dependencies = [
  "duplicate",
  "egui",
@@ -1549,13 +1537,14 @@ dependencies = [
 
 [[package]]
 name = "egui_extras"
-version = "0.27.2"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b78779f35ded1a853786c9ce0b43fe1053e10a21ea3b23ebea411805ce41593"
+checksum = "5bb783d9fa348f69ed5c340aa25af78b5472043090e8b809040e30960cc2a746"
 dependencies = [
+ "ahash",
  "egui",
  "enum-map",
- "image",
+ "image 0.25.2",
  "log",
  "mime_guess2",
  "resvg",
@@ -1570,9 +1559,9 @@ checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "emath"
-version = "0.27.2"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c3a552cfca14630702449d35f41c84a0d15963273771c6059175a803620f3f"
+checksum = "0a6a21708405ea88f63d8309650b4d77431f4bc28fb9d8e6f77d3963b51249e6"
 dependencies = [
  "bytemuck",
  "serde",
@@ -1654,9 +1643,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.27.2"
+version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b381f8b149657a4acf837095351839f32cd5c4aec1817fc4df84e18d76334176"
+checksum = "3f0dcc0a0771e7500e94cd1cb797bd13c9f23b9409bdc3c824e2cbc562b7fa01"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -2237,7 +2226,7 @@ version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18fcd4ae4e86d991ad1300b8f57166e5be0c95ef1f63f3f5b827f8a164548746"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "cfg_aliases",
  "cgl",
  "core-foundation",
@@ -2313,7 +2302,7 @@ version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbcd2dba93594b227a1f57ee09b8b9da8892c34d55aa332e034a228d0fe6a171"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "gpu-alloc-types",
 ]
 
@@ -2323,7 +2312,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98ff03b468aa837d70984d55f5d3f846f6ec31fe34bbb97c4f85219caeee1ca4"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -2341,22 +2330,22 @@ dependencies = [
 
 [[package]]
 name = "gpu-descriptor"
-version = "0.2.4"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc11df1ace8e7e564511f53af41f3e42ddc95b56fd07b3f4445d2a6048bc682c"
+checksum = "9c08c1f623a8d0b722b8b99f821eb0ba672a1618f0d3b16ddbee1cedd2dd8557"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "gpu-descriptor-types",
  "hashbrown",
 ]
 
 [[package]]
 name = "gpu-descriptor-types"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf0b36e6f090b7e1d8a4b49c0cb81c1f8376f72198c65dd3ad9ff3556b8b78c"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -2422,7 +2411,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af2a7e73e1f34c48da31fb668a907f250794837e08faa144fd24f0b8b741e890"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "com",
  "libc",
  "libloading 0.8.1",
@@ -2587,6 +2576,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99314c8a2152b8ddb211f924cdae532d8c5e4c8bb54728e12fff1b0cd5963a10"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "num-traits",
+]
+
+[[package]]
 name = "imagesize"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2730,9 +2730,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.68"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406cda4b368d531c842222cf9d2600a9a4acce8d29423695379c6868a143a9ee"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2842,7 +2842,7 @@ version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85c833ca1e66078851dba29046874e38f08b2c883700aa29a03ddd3b23814ee8"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "libc",
  "redox_syscall 0.4.1",
 ]
@@ -2853,7 +2853,7 @@ version = "0.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3af92c55d7d839293953fcd0fda5ecfe93297cfde6ffbdec13b41d99c0ba6607"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "libc",
  "redox_syscall 0.4.1",
 ]
@@ -2941,7 +2941,7 @@ dependencies = [
  "egui_extras",
  "futures-lite 2.2.0",
  "git-version",
- "image",
+ "image 0.24.9",
  "js-sys",
  "luminol-audio",
  "luminol-config",
@@ -3006,7 +3006,7 @@ dependencies = [
  "fragile",
  "fuzzy-matcher",
  "glam",
- "image",
+ "image 0.24.9",
  "indextree",
  "itertools 0.11.0",
  "lexical-sort",
@@ -3089,21 +3089,23 @@ dependencies = [
 name = "luminol-eframe"
 version = "0.4.0"
 dependencies = [
+ "ahash",
  "bytemuck",
- "cocoa",
- "directories-next",
+ "directories",
  "document-features",
  "egui",
  "egui-winit",
  "flume",
  "glutin",
  "glutin-winit",
- "image",
+ "image 0.24.9",
  "js-sys",
  "log",
  "luminol-egui-wgpu",
  "luminol-web",
- "objc",
+ "objc2 0.5.2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "once_cell",
  "oneshot",
  "parking_lot",
@@ -3116,7 +3118,6 @@ dependencies = [
  "ron",
  "serde",
  "static_assertions",
- "thiserror",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3130,6 +3131,7 @@ dependencies = [
 name = "luminol-egui-wgpu"
 version = "0.4.0"
 dependencies = [
+ "ahash",
  "bytemuck",
  "document-features",
  "egui",
@@ -3150,7 +3152,7 @@ dependencies = [
  "async-fs 2.1.1",
  "async-std",
  "async_io_stream",
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "camino",
  "color-eyre",
  "dashmap",
@@ -3193,7 +3195,7 @@ dependencies = [
  "egui",
  "fragile",
  "glam",
- "image",
+ "image 0.24.9",
  "itertools 0.11.0",
  "luminol-data",
  "luminol-egui-wgpu",
@@ -3413,11 +3415,11 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
+checksum = "5637e166ea14be6063a3f8ba5ccb9a4159df7d8f6d61c02fc3d480b1f90dcfcb"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "block",
  "core-graphics-types",
  "foreign-types 0.5.0",
@@ -3486,12 +3488,13 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "naga"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8878eb410fc90853da3908aebfe61d73d26d4437ef850b70050461f939509899"
+checksum = "e536ae46fcab0876853bd4a632ede5df4b1c2527a58f6c5a4150fe86be858231"
 dependencies = [
+ "arrayvec",
  "bit-set",
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "codespan-reporting",
  "hexf-parse",
  "indexmap",
@@ -3507,9 +3510,9 @@ dependencies = [
 
 [[package]]
 name = "naga_oil"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86343242cc8fe7c38de0324f0c13a789729f3d360d98de12c464a815ad52feda"
+checksum = "275d9720a7338eedac966141089232514c84d76a246a58ef501af88c5edf402f"
 dependencies = [
  "bit-set",
  "codespan-reporting",
@@ -3558,7 +3561,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -3691,7 +3694,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
- "objc_exception",
 ]
 
 [[package]]
@@ -3713,9 +3715,9 @@ checksum = "df3b9834c1e95694a05a828b59f55fa2afec6288359cda67146126b3f90a55d7"
 
 [[package]]
 name = "objc-sys"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c71324e4180d0899963fc83d9d241ac39e699609fc1025a850aadac8257459"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
 
 [[package]]
 name = "objc2"
@@ -3734,8 +3736,58 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "559c5a40fdd30eb5e344fbceacf7595a81e242529fb4e21cf5f43fb4f11ff98d"
 dependencies = [
- "objc-sys 0.3.2",
+ "objc-sys 0.3.5",
  "objc2-encode 3.0.0",
+]
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys 0.3.5",
+ "objc2-encode 4.0.3",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4e89ad9e3d7d297152b17d39ed92cd50ca8063a89a9fa569046d41568891eff"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+ "objc2-core-data",
+ "objc2-core-image",
+ "objc2-foundation",
+ "objc2-quartz-core",
+]
+
+[[package]]
+name = "objc2-core-data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "617fbf49e071c178c0b24c080767db52958f716d9eabdf0890523aeae54773ef"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-image"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55260963a527c99f1819c4f8e3b47fe04f9650694ef348ffd2227e8196d34c80"
+dependencies = [
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -3754,12 +3806,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d079845b37af429bfe5dfa76e6d087d788031045b25cfc6fd898486fd9847666"
 
 [[package]]
-name = "objc_exception"
-version = "0.1.2"
+name = "objc2-encode"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
+checksum = "7891e71393cd1f227313c9379a26a584ff3d7e6e7159e988851f0934c993f0f8"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "cc",
+ "bitflags 2.6.0",
+ "block2 0.5.1",
+ "libc",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-metal"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-quartz-core"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
+dependencies = [
+ "bitflags 2.6.0",
+ "block2 0.5.1",
+ "objc2 0.5.2",
+ "objc2-foundation",
+ "objc2-metal",
 ]
 
 [[package]]
@@ -3833,7 +3919,7 @@ version = "0.10.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "cfg-if",
  "foreign-types 0.3.2",
  "libc",
@@ -3870,6 +3956,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbclient"
@@ -3966,9 +4058,9 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.1"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -3976,18 +4068,18 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "backtrace",
  "cfg-if",
  "libc",
  "petgraph",
- "redox_syscall 0.4.1",
+ "redox_syscall 0.5.3",
  "smallvec",
  "thread-id",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.3",
 ]
 
 [[package]]
@@ -4390,6 +4482,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4446,9 +4547,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "renderdoc-sys"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "216080ab382b992234dda86873c18d4c48358f5cfcb70fd693d7f6f2131b628b"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "reqwest"
@@ -4557,7 +4658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "serde",
  "serde_derive",
 ]
@@ -4619,7 +4720,7 @@ version = "0.38.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "errno",
  "itoa",
  "libc",
@@ -4930,7 +5031,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "922fd3eeab3bd820d76537ce8f582b1cf951eceb5475c28500c7457d9d17f53a"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "calloop",
  "calloop-wayland-source",
  "cursor-icon",
@@ -5004,7 +5105,7 @@ version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -5255,18 +5356,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5820,7 +5921,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40eb22ae96f050e0c0d6f7ce43feeae26c348fc4dea56928ca81537cfaa6188b"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "cursor-icon",
  "log",
  "serde",
@@ -5871,9 +5972,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e124130aee3fb58c5bdd6b639a0509486b0338acaaae0c84a5124b0f588b7f"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -5881,9 +5982,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9e7e1900c352b609c8488ad12639a311045f40a35491fb69ba8c12f758af70b"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
@@ -5896,9 +5997,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.40"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bde2032aeb86bdfaecc8b261eef3cba735cc426c1f3a3416d1e0791be95fc461"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -5908,9 +6009,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b30af9e2d358182b5c7449424f017eba305ed32a7010509ede96cdc4696c46ed"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5918,9 +6019,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "642f325be6301eb8107a83d12a8ac6c1e1c54345a7ef1a9261962dfefda09e66"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5931,9 +6032,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.91"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f186bd2dcf04330886ce82d6f33dd75a7bfcf69ecf5763b89fcde53b6ac9838"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "wayland-backend"
@@ -5955,7 +6056,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82fb96ee935c2cea6668ccb470fb7771f6215d1691746c2d896b447a00ad3f1f"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "rustix 0.38.31",
  "wayland-backend",
  "wayland-scanner",
@@ -5967,7 +6068,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625c5029dbd43d25e6aa9615e88b829a5cad13b2819c4ae129fdbb7c31ab4c7e"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "cursor-icon",
  "wayland-backend",
 ]
@@ -5989,7 +6090,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f81f365b8b4a97f422ac0e8737c438024b5951734506b0e1d775c73030561f4"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -6001,7 +6102,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23803551115ff9ea9bce586860c5c5a971e360825a0309264102a9495a5ff479"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -6014,7 +6115,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad1f61b76b6c2d8742e10f9ba5c3737f6530b4c243132c2a2ccc8aa96fe25cd6"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -6046,9 +6147,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.67"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6066,17 +6167,18 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "0.8.12"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b2391658b02c27719fc5a0a73d6e696285138e8b12fba9d4baa70451023c71"
+checksum = "425ba64c1e13b1c6e8c5d2541c8fac10022ca584f33da781db01b5756aef1f4e"
 dependencies = [
+ "block2 0.5.1",
  "core-foundation",
  "home",
  "jni",
  "log",
  "ndk-context",
- "objc",
- "raw-window-handle 0.5.2",
+ "objc2 0.5.2",
+ "objc2-foundation",
  "url",
  "web-sys",
 ]
@@ -6089,13 +6191,14 @@ checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "wgpu"
-version = "0.19.1"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bfe9a310dcf2e6b85f00c46059aaeaf4184caa8e29a1ecd4b7a704c3482332d"
+checksum = "90e37c7b9921b75dfd26dd973fdcbce36f13dfa6e2dc82aece584e0ed48c355c"
 dependencies = [
  "arrayvec",
  "cfg-if",
  "cfg_aliases",
+ "document-features",
  "js-sys",
  "log",
  "naga",
@@ -6114,15 +6217,16 @@ dependencies = [
 
 [[package]]
 name = "wgpu-core"
-version = "0.19.0"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b15e451d4060ada0d99a64df44e4d590213496da7c4f245572d51071e8e30ed"
+checksum = "d50819ab545b867d8a454d1d756b90cd5f15da1f2943334ca314af10583c9d39"
 dependencies = [
  "arrayvec",
  "bit-vec",
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "cfg_aliases",
  "codespan-reporting",
+ "document-features",
  "indexmap",
  "log",
  "naga",
@@ -6140,15 +6244,15 @@ dependencies = [
 
 [[package]]
 name = "wgpu-hal"
-version = "0.19.1"
+version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bb47856236bfafc0bc591a925eb036ac19cd987624a447ff353e7a7e7e6f72"
+checksum = "172e490a87295564f3fcc0f165798d87386f6231b04d4548bca458cbbfd63222"
 dependencies = [
  "android_system_properties",
  "arrayvec",
  "ash",
  "bit-set",
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "block",
  "cfg_aliases",
  "core-graphics-types",
@@ -6166,6 +6270,7 @@ dependencies = [
  "log",
  "metal",
  "naga",
+ "ndk-sys",
  "objc",
  "once_cell",
  "parking_lot",
@@ -6184,11 +6289,11 @@ dependencies = [
 
 [[package]]
 name = "wgpu-types"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "895fcbeb772bfb049eb80b2d6e47f6c9af235284e9703c96fc0218a42ffd5af2"
+checksum = "1353d9a46bff7f955a680577f34c69122628cc2076e1d6f3a9be6ef00ae793ef"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "js-sys",
  "web-sys",
 ]
@@ -6538,7 +6643,7 @@ dependencies = [
  "ahash",
  "android-activity",
  "atomic-waker",
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "bytemuck",
  "calloop",
  "cfg_aliases",
@@ -6679,7 +6784,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039de8032a9a8856a6be89cea3e5d12fdd82306ab7c94d74e6deab2460651c5"
 dependencies = [
- "bitflags 2.4.2",
+ "bitflags 2.6.0",
  "dlib",
  "log",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "aligned-vec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,6 +282,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad32ce52e4161730f7098c077cd2ed6229b5804ccf99e5366be1ab72a98b4e1"
 
 [[package]]
+name = "arbitrary"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+
+[[package]]
 name = "arboard"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,6 +301,17 @@ dependencies = [
  "parking_lot",
  "thiserror",
  "x11rb",
+]
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -641,6 +664,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "av1-grain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6678909d8c5d46a42abcf571271e15fdbc0a225e3646cf23762cd415046c78bf"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "876c75a42f6364451a033496a14c44bffe41f5f4a8236f697391f11024e596d2"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,6 +779,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitstream-io"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3dcde5f311c85b8ca30c2e4198d4326bc342c76541590106f5fa4a50946ea499"
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,6 +861,12 @@ dependencies = [
  "piper",
  "tracing",
 ]
+
+[[package]]
+name = "built"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "236e6289eda5a812bc6b53c3b024039382a2895fbbeef2d748b2931546d392c4"
 
 [[package]]
 name = "bumpalo"
@@ -2583,7 +2641,29 @@ checksum = "99314c8a2152b8ddb211f924cdae532d8c5e4c8bb54728e12fff1b0cd5963a10"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
  "num-traits",
+ "png",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79afb8cbee2ef20f59ccd477a218c12a93943d075b492015ecb1bb81f8ee904"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
 ]
 
 [[package]]
@@ -2591,6 +2671,12 @@ name = "imagesize"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "029d73f573d8e8d63e6d5020011d3255b28c3ba85d6cf870a07184ed23de9284"
+
+[[package]]
+name = "imgref"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44feda355f4159a7c757171a77de25daf6411e217b4cabd03bd6650690468126"
 
 [[package]]
 name = "indenter"
@@ -2639,6 +2725,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.51",
 ]
 
 [[package]]
@@ -2817,6 +2914,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "libfuzzer-sys"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96cfd5557eb82f2b83fed4955246c988d331975a002961b07c81584d107e7f7"
+dependencies = [
+ "arbitrary",
+ "cc",
+ "once_cell",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2931,6 +3039,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
 name = "luminol"
 version = "0.4.0"
 dependencies = [
@@ -2941,7 +3058,7 @@ dependencies = [
  "egui_extras",
  "futures-lite 2.2.0",
  "git-version",
- "image 0.24.9",
+ "image 0.25.2",
  "js-sys",
  "luminol-audio",
  "luminol-config",
@@ -3006,7 +3123,7 @@ dependencies = [
  "fragile",
  "fuzzy-matcher",
  "glam",
- "image 0.24.9",
+ "image 0.25.2",
  "indextree",
  "itertools 0.11.0",
  "lexical-sort",
@@ -3098,7 +3215,7 @@ dependencies = [
  "flume",
  "glutin",
  "glutin-winit",
- "image 0.24.9",
+ "image 0.25.2",
  "js-sys",
  "log",
  "luminol-egui-wgpu",
@@ -3381,6 +3498,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3621,6 +3748,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3628,6 +3761,16 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -3645,6 +3788,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.51",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -4338,6 +4501,19 @@ name = "profiling"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43d84d1d7a6ac92673717f9f6d1518374ef257669c24ebc5ac25d5033828be58"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8021cf59c8ec9c432cfc2526ac6b8aa508ecaf29cd415f271b8406c1b851c3fd"
+dependencies = [
+ "quote",
+ "syn 2.0.51",
+]
 
 [[package]]
 name = "puffin"
@@ -4370,6 +4546,12 @@ dependencies = [
  "new_debug_unreachable",
  "unreachable",
 ]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
@@ -4424,6 +4606,56 @@ name = "range-alloc"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8a99fddc9f0ba0a85884b8d14e3592853e787d581ca1816c91349b10e4eeab"
+
+[[package]]
+name = "rav1e"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd87ce80a7665b1cce111f8a16c1f3929f6547ce91ade6addf4ec86a8dda5ce9"
+dependencies = [
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools 0.12.1",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "profiling",
+ "rand",
+ "rand_chacha",
+ "simd_helpers",
+ "system-deps",
+ "thiserror",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc13288f5ab39e6d7c9d501759712e6969fcc9734220846fc9ed26cae2cc4234"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
 
 [[package]]
 name = "raw-window-handle"
@@ -4984,6 +5216,15 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
 
 [[package]]
 name = "simplecss"
@@ -5866,6 +6107,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
 dependencies = [
  "getrandom",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "v_frame"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f32aaa24bacd11e488aa9ba66369c7cd514885742c9fe08cfe85884db3e92b"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
  "wasm-bindgen",
 ]
 
@@ -6951,12 +7203,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "zune-core"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
+
+[[package]]
 name = "zune-inflate"
 version = "0.2.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16099418600b4d8f028622f73ff6e3deaabdff330fb9a2a131dea781ee8b0768"
+dependencies = [
+ "zune-core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ authors = [
     "Egor Poleshko <somedevfox@gmail.com>",
 ]
 edition = "2021"
-rust-version = "1.74"
+rust-version = "1.78"
 license = "GPL-3.0"
 readme = "README.md"
 repository = "https://github.com/Speak2Erase/Luminol"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,9 +61,9 @@ categories = ["games"]
 
 # Shared dependencies
 [workspace.dependencies]
-egui = "0.27.2"
-egui_extras = { version = "0.27.2", features = ["svg", "image"] }
-epaint = "0.27.2"
+egui = "0.28.1"
+egui_extras = { version = "0.28.1", features = ["svg", "image"] }
+epaint = "0.28.1"
 
 luminol-eframe = { version = "0.4.0", path = "crates/eframe/", features = [
     "wgpu",
@@ -74,9 +74,15 @@ luminol-eframe = { version = "0.4.0", path = "crates/eframe/", features = [
     "wayland",
 ], default-features = false }
 luminol-egui-wgpu = { version = "0.4.0", path = "crates/egui-wgpu/" }
-egui-winit = "0.27.2"
+egui-winit = "0.28.1"
 
-wgpu = { version = "0.19.1", features = ["naga-ir"] }
+egui_dock = "0.13.0"
+egui-notify = "0.15.0"
+egui-modal = "0.4.0"
+
+wgpu = { version = "0.20.0", features = ["naga-ir"] }
+naga = "0.20.0"
+naga_oil = "0.14.0"
 glam = { version = "0.24.2", features = ["bytemuck"] }
 image = "0.24.7"
 
@@ -107,11 +113,15 @@ winit = { version = "0.29.4", default-features = false }
 log = { version = "0.4", features = ["std"] }
 document-features = "0.2.8"
 web-time = "0.2"
+ahash = "0.8.11"
+glutin = "0.31"
+glutin-winit = "0.4"
 
-parking_lot = { version = "0.12.1", features = [
+parking_lot = { version = "0.12.3", features = [
     "nightly",            # This is required for parking_lot to work properly in WebAssembly builds with atomics support
     "deadlock_detection",
 ] }
+parking_lot_core = "0.9.10"
 once_cell = "1.18.0"
 crossbeam = "0.8.2"
 dashmap = "5.5.3"
@@ -138,6 +148,11 @@ rand = "0.8.5"
 murmur3 = "0.5.2"
 
 alacritty_terminal = "0.22.0"
+
+wasm-bindgen = "0.2.91"
+wasm-bindgen-futures = "0.4.42"
+web-sys = "0.3.67"
+js-sys = "0.3"
 
 luminol-audio = { version = "0.4.0", path = "crates/audio/" }
 luminol-components = { version = "0.4.0", path = "crates/components/" }
@@ -221,9 +236,9 @@ features = ["web"]
 # Web
 # Look into somehow pinning these as workspace dependencies
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen = "0.2.87"
-wasm-bindgen-futures = "=0.4.40"
-js-sys = "0.3"
+wasm-bindgen.workspace = true
+wasm-bindgen-futures.workspace = true
+js-sys.workspace = true
 
 oneshot.workspace = true
 
@@ -233,7 +248,7 @@ tracing-wasm = "0.2"
 tracing-log = "0.1.3"
 tracing.workspace = true
 
-web-sys = { version = "=0.3.67", features = [
+web-sys = { workspace = true, features = [
     "BeforeUnloadEvent",
     "Window",
     "Worker",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ wgpu = { version = "0.20.0", features = ["naga-ir"] }
 naga = "0.20.0"
 naga_oil = "0.14.0"
 glam = { version = "0.24.2", features = ["bytemuck"] }
-image = "0.24.7"
+image = { version = "0.25.0", features = ["png"] }
 
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/components/src/database_view.rs
+++ b/crates/components/src/database_view.rs
@@ -81,7 +81,7 @@ impl DatabaseView {
                         egui::Layout::bottom_up(ui.layout().horizontal_align()),
                         |ui| {
                             ui.horizontal(|ui| {
-                                ui.style_mut().wrap = Some(true);
+                                ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Wrap);
 
                                 ui.add(egui::DragValue::new(self.maximum.as_mut().unwrap()));
 

--- a/crates/components/src/lib.rs
+++ b/crates/components/src/lib.rs
@@ -148,7 +148,7 @@ where
             .vertical(|ui| {
                 let spacing = ui.spacing().item_spacing.y;
                 ui.add_space(spacing);
-                ui.add(egui::Label::new(format!("{}:", self.name)).truncate(true));
+                ui.add(egui::Label::new(format!("{}:", self.name)).truncate());
                 if ui.add(self.widget).changed() {
                     changed = true;
                 };
@@ -198,11 +198,11 @@ where
         let available_width = ui.available_width() - ui.spacing().item_spacing.x;
         let width = self.max_width.min(available_width);
         let mut response = egui::ComboBox::from_id_source(&self.id_source)
-            .wrap(true)
+            .wrap()
             .width(width)
             .selected_text(self.reference.to_string())
             .show_ui(ui, |ui| {
-                ui.style_mut().wrap = Some(true);
+                ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Wrap);
 
                 for (i, variant) in T::iter().enumerate() {
                     ui.with_stripe(i % 2 != 0, |ui| {
@@ -275,7 +275,7 @@ where
 
         let mut changed = false;
         let inner_response = egui::ComboBox::from_id_source(&self.id_source)
-            .wrap(true)
+            .wrap()
             .width(ui.available_width() - ui.spacing().item_spacing.x)
             .selected_text(formatter(&self))
             .show_ui(ui, |ui| {
@@ -409,7 +409,7 @@ where
                 }
             },
             |this, ui, ids, first_row_is_faint, show_none| {
-                ui.style_mut().wrap = Some(true);
+                ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Wrap);
 
                 if show_none
                     && ui
@@ -465,7 +465,7 @@ where
             ui,
             |this| (this.formatter)(*this.reference),
             |this, ui, ids, first_row_is_faint, _| {
-                ui.style_mut().wrap = Some(true);
+                ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Wrap);
 
                 let mut is_faint = first_row_is_faint;
 

--- a/crates/components/src/map_view.rs
+++ b/crates/components/src/map_view.rs
@@ -204,7 +204,7 @@ impl MapView {
 
             // Apply scroll and cap max zoom to 15%
             self.scale *= (delta / 9.0f32.exp2()).exp2();
-            self.scale = self.scale.max(15.).min(300.);
+            self.scale = self.scale.clamp(15., 300.);
 
             // Get the normalized cursor position relative to pan
             let pos_norm = (pos - self.pan - canvas_center) / old_scale;

--- a/crates/components/src/map_view.rs
+++ b/crates/components/src/map_view.rs
@@ -901,7 +901,7 @@ impl MapView {
             screenshot
                 .write_to(
                     &mut std::io::BufWriter::new(&mut file),
-                    image::ImageOutputFormat::Png,
+                    image::ImageFormat::Png,
                 )
                 .wrap_err(c)?;
             file.flush().wrap_err(c)?;

--- a/crates/components/src/syntax_highlighting.rs
+++ b/crates/components/src/syntax_highlighting.rs
@@ -26,6 +26,17 @@
 
 use egui::text::LayoutJob;
 
+impl egui::util::cache::ComputerMut<(luminol_config::CodeTheme, &str, &str), LayoutJob>
+    for Highlighter
+{
+    fn compute(
+        &mut self,
+        (theme, code, lang): (luminol_config::CodeTheme, &str, &str),
+    ) -> LayoutJob {
+        self.highlight(theme, code, lang)
+    }
+}
+
 /// View some code with syntax highlighting and selection.
 pub fn code_view_ui(ui: &mut egui::Ui, mut code: &str, theme: luminol_config::CodeTheme) {
     let language = "rb";
@@ -54,17 +65,6 @@ pub fn highlight(
     code: &str,
     language: &str,
 ) -> LayoutJob {
-    impl egui::util::cache::ComputerMut<(luminol_config::CodeTheme, &str, &str), LayoutJob>
-        for Highlighter
-    {
-        fn compute(
-            &mut self,
-            (theme, code, lang): (luminol_config::CodeTheme, &str, &str),
-        ) -> LayoutJob {
-            self.highlight(theme, code, lang)
-        }
-    }
-
     type HighlightCache = egui::util::cache::FrameCache<LayoutJob, Highlighter>;
 
     ctx.memory_mut(|m| {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -18,10 +18,9 @@ workspace = true
 
 [dependencies]
 egui.workspace = true
-
-egui_dock = "0.12.0"
-egui-notify = "0.14.0"
-egui-modal = "0.3.6"
+egui_dock.workspace = true
+egui-notify.workspace = true
+egui-modal.workspace = true
 
 poll-promise.workspace = true
 once_cell.workspace = true

--- a/crates/eframe/CHANGELOG.md
+++ b/crates/eframe/CHANGELOG.md
@@ -7,6 +7,83 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.28.1 - 2024-07-05
+* Web: only capture clicks/touches when actually over canvas [#4775](https://github.com/emilk/egui/pull/4775) by [@lucasmerlin](https://github.com/lucasmerlin)
+
+
+## 0.28.0 - 2024-07-03 - Better integration of a eframe in a bigger website
+### ✨ Highlights
+The eframe web canvas now works properly when its a small part of a larger web page.
+Previously this caused a lot of weird bugs, such as the eframe canvas stealing focus, and resizing the canvas in annoying ways.
+Now it should all work seamlessly to have an eframe canvas as part of a web page, including having multiple different eframe apps next to each other.
+As part of that the eframe canvas can now be focused (or not), just like an `<input>` HTML element.
+
+We've also implemented a better method for sizing and positioning the canvas so that it yields pixel-perfect rendering on all known browsers except for Desktop Safari.
+What this means is that text is much less likely to be blurry on web for users ([#4536](https://github.com/emilk/egui/pull/4536) by [@jprochazk](https://github.com/jprochazk)).
+
+### ⭐ Added
+* Add `register_native_texture` in `eframe::Frame` [#4246](https://github.com/emilk/egui/pull/4246) by [@Chaojimengnan](https://github.com/Chaojimengnan)
+* Add `NativeOptions::persistence_path` [#4423](https://github.com/emilk/egui/pull/4423) by [@lucasmerlin](https://github.com/lucasmerlin)
+* Make sure to call `raw_input_hook` on web [#4646](https://github.com/emilk/egui/pull/4646) by [@owen-d](https://github.com/owen-d)
+
+### 🔧 Changed
+* Early-out from context switching the `glow` backend [#4284](https://github.com/emilk/egui/pull/4284), [#4296](https://github.com/emilk/egui/pull/4296) by [@emilk](https://github.com/emilk)
+* Allow users to create viewports larger than monitor on Windows & macOS [#4337](https://github.com/emilk/egui/pull/4337) by [@lopo12123](https://github.com/lopo12123)
+* Use `objc2` and its framework crates [#4395](https://github.com/emilk/egui/pull/4395) by [@madsmtm](https://github.com/madsmtm)
+* Emit physical key presses when a non-Latin layout is active [#4461](https://github.com/emilk/egui/pull/4461) by [@TicClick](https://github.com/TicClick)
+* Clamp window size to monitor size by default on all platforms [#4410](https://github.com/emilk/egui/pull/4410) by [@rustbasic](https://github.com/rustbasic)
+* Ignore synthetic key presses [#4514](https://github.com/emilk/egui/pull/4514) by [@hut](https://github.com/hut)
+* Use `ResizeObserver` instead of `resize` event [#4536](https://github.com/emilk/egui/pull/4536) by [@jprochazk](https://github.com/jprochazk)
+* Make pinch-to-zoom more responsive on web [#4621](https://github.com/emilk/egui/pull/4621) by [@emilk](https://github.com/emilk)
+* Move first `request_animation_frame` into resize observer [#4628](https://github.com/emilk/egui/pull/4628) by [@jprochazk](https://github.com/jprochazk)
+* Replace `directories-next` dependency with `directories` [#4661](https://github.com/emilk/egui/pull/4661) by [@crumblingstatue](https://github.com/crumblingstatue)
+* `eframe::Result` is now short for `eframe::Result<()>` [#4706](https://github.com/emilk/egui/pull/4706) by [@emilk](https://github.com/emilk)
+* Ignore keyboard events unless canvas has focus [#4718](https://github.com/emilk/egui/pull/4718) by [@emilk](https://github.com/emilk)
+
+### 🐛 Fixed
+* Fix `ViewportCommand::InnerSize` not resizing viewport on Wayland (#4211) [#4211](https://github.com/emilk/egui/pull/4211) by [@rustbasic](https://github.com/rustbasic)
+* Improve IME support with new `Event::Ime` [#4358](https://github.com/emilk/egui/pull/4358) by [@rustbasic](https://github.com/rustbasic)
+* IME for chinese [#4436](https://github.com/emilk/egui/pull/4436) by [@rustbasic](https://github.com/rustbasic)
+* Fix: Window position creeps between executions on scaled monitors [#4443](https://github.com/emilk/egui/pull/4443) by [@avery-radmacher](https://github.com/avery-radmacher)
+* Fix: still track mouse when dragging outside web canvas [#4522](https://github.com/emilk/egui/pull/4522) by [@emilk](https://github.com/emilk)
+* Fix: Don't `.forget()` RAF closure [#4551](https://github.com/emilk/egui/pull/4551) by [@jprochazk](https://github.com/jprochazk)
+* Improve web text agent [#4561](https://github.com/emilk/egui/pull/4561) by [@jprochazk](https://github.com/jprochazk)
+* Fix broken mouse coordinates when there's padding on the canvas element [#4729](https://github.com/emilk/egui/pull/4729) by [@emilk](https://github.com/emilk)
+* Only repaint on cursor movements of area, or if dragging outside [#4730](https://github.com/emilk/egui/pull/4730) by [@emilk](https://github.com/emilk)
+* Fix drag-and-drop file preview/hover [#4732](https://github.com/emilk/egui/pull/4732) by [@emilk](https://github.com/emilk)
+* Fix stuck keys after pressing ctrl+C, cmd+A, etc [#4731](https://github.com/emilk/egui/pull/4731) by [@emilk](https://github.com/emilk)
+
+### 🧳 Migration
+* Update MSRV to 1.76 [#4411](https://github.com/emilk/egui/pull/4411) by [@emilk](https://github.com/emilk)
+
+#### Wrap app creator in a `Result`
+Applications can now return an error during the app creation ([#4565](https://github.com/emilk/egui/pull/4565) by [@emilk](https://github.com/emilk)), so you now need to wrap your `Box<dyn App>` in a `Result` like so:
+
+
+``` diff
+- eframe::run_native("My App", options, Box::new(|cc| Box::new(MyApp::new(cc))));
++ eframe::run_native("My App", options, Box::new(|cc| Ok(Box::new(MyApp::new(cc)))));
+```
+
+#### Change web CSS
+To make the eframe canvas fill the entire web browser, set its CSS to:
+
+``` css
+top: 0;
+left: 0;
+width: 100%;
+height: 100%;
+```
+
+See [`index.html`](https://github.com/emilk/egui/blob/a489374ca63f0d1ae983bb21d8bb766b2d68737b/web_demo/index.html#L30-L50) and [#4536](https://github.com/emilk/egui/pull/4536) for details.
+
+#### Web canvas focus
+If you are using eframe for a fullscreen app, you should call `.focus()` on your canvas during startup:
+```js
+document.getElementById("the_canvas_id").focus();
+```
+
+
 ## 0.27.2 - 2024-04-02
 #### Desktop/Native
 * Fix continuous repaint on Wayland when TextEdit is focused or IME output is set [#4269](https://github.com/emilk/egui/pull/4269) (thanks [@white-axe](https://github.com/white-axe)!)

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -24,6 +24,9 @@ all-features = true
 rustc-args = ["--cfg=web_sys_unstable_apis"]
 targets = ["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"]
 
+[lints]
+workspace = true
+
 [lib]
 
 
@@ -67,7 +70,7 @@ default_fonts = ["egui/default_fonts"]
 
 ## Enable saving app state to disk.
 persistence = [
-  "directories-next",
+  "directories",
   "egui-winit/serde",
   "egui/persistence",
   "ron",
@@ -134,12 +137,12 @@ egui = { workspace = true, features = [
   "log",
 ] }
 
+ahash.workspace = true
 document-features.workspace = true
 log.workspace = true
 parking_lot.workspace = true
 raw-window-handle.workspace = true
 static_assertions = "1.1.0"
-thiserror.workspace = true
 web-time.workspace = true
 
 # Optional dependencies
@@ -151,7 +154,7 @@ rwh_05 = { package = "raw-window-handle", version = "0.5.2", optional = true, fe
   "std",
 ] }
 ron = { workspace = true, optional = true, features = ["integer128"] }
-serde = { version = "1", optional = true, features = ["derive"] }
+serde = { workspace = true, optional = true }
 
 # -------------------------------------------
 # native:
@@ -160,13 +163,11 @@ egui-winit = { workspace = true, features = [
   "clipboard",
   "links",
 ] }
-image = { version = "0.24", default-features = false, features = [
-  "png",
-] } # Needed for app icon
+image = { workspace = true, features = ["png"] } # Needed for app icon
 winit = { workspace = true, default-features = false, features = ["rwh_06"] }
 
 # optional native:
-directories-next = { version = "2", optional = true }
+directories = { version = "5", optional = true }
 luminol-egui-wgpu = { workspace = true, optional = true, features = [
   "winit",
 ] } # if wgpu is used, use it with winit
@@ -174,8 +175,8 @@ pollster = { version = "0.3", optional = true } # needed for wgpu
 
 # we can expose these to user so that they can select which backends they want to enable to avoid compiling useless deps.
 # this can be done at the same time we expose x11/wayland features of winit crate.
-glutin = { version = "0.31", optional = true }
-glutin-winit = { version = "0.4", optional = true }
+glutin = { workspace = true, optional = true }
+glutin-winit = { workspace = true, optional = true }
 puffin = { workspace = true, optional = true }
 wgpu = { workspace = true, optional = true, features = [
   # Let's enable some backends so that users can use `eframe` out-of-the-box
@@ -186,8 +187,19 @@ wgpu = { workspace = true, optional = true, features = [
 
 # mac:
 [target.'cfg(any(target_os = "macos"))'.dependencies]
-cocoa = "0.25.0"
-objc = "0.2.7"
+objc2 = "0.5.1"
+objc2-foundation = { version = "0.2.0", features = [
+  "block2",
+  "NSData",
+  "NSString",
+] }
+objc2-app-kit = { version = "0.2.0", features = [
+  "NSApplication",
+  "NSImage",
+  "NSMenu",
+  "NSMenuItem",
+  "NSResponder",
+] }
 
 # windows:
 [target.'cfg(any(target_os = "windows"))'.dependencies]
@@ -196,12 +208,12 @@ winapi = { version = "0.3.9", features = ["winuser"] }
 # -------------------------------------------
 # web:
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-bytemuck = "1.7"
+bytemuck.workspace = true
 js-sys = "0.3"
 percent-encoding = "2.1"
-wasm-bindgen = "0.2"
-wasm-bindgen-futures = "0.4"
-web-sys = { version = "0.3.65", features = [ # Needs to be at least 0.3.65 for Luminol to work because that's the first version with a `WorkerGlobalScope.performance` binding
+wasm-bindgen.workspace = true
+wasm-bindgen-futures.workspace = true
+web-sys = { workspace = true, features = [ # Needs to be at least 0.3.65 for Luminol to work because that's the first version with a `WorkerGlobalScope.performance` binding
   "BinaryType",
   "Blob",
   "Clipboard",
@@ -233,7 +245,14 @@ web-sys = { version = "0.3.65", features = [ # Needs to be at least 0.3.65 for L
   "MediaQueryListEvent",
   "MouseEvent",
   "Navigator",
+  "Node",
+  "NodeList",
   "Performance",
+  "ResizeObserver",
+  "ResizeObserverBoxOptions",
+  "ResizeObserverEntry",
+  "ResizeObserverOptions",
+  "ResizeObserverSize",
   "Storage",
   "Touch",
   "TouchEvent",

--- a/crates/eframe/Cargo.toml
+++ b/crates/eframe/Cargo.toml
@@ -41,6 +41,9 @@ default = [
   "x11",
 ]
 
+# Dummy features so we don't run into compiler warnings
+glow = []
+
 ## Enable platform accessibility API implementations through [AccessKit](https://accesskit.dev/).
 accesskit = ["egui/accesskit", "egui-winit/accesskit"]
 

--- a/crates/eframe/README.md
+++ b/crates/eframe/README.md
@@ -1,5 +1,5 @@
 > [!IMPORTANT]
-> luminol-eframe is currently based on emilk/egui@0.27.2
+> luminol-eframe is currently based on emilk/egui@0.28.1
 
 > [!NOTE]
 > This is Luminol's modified version of eframe. The original version is dual-licensed under MIT and Apache 2.0.

--- a/crates/eframe/build.rs
+++ b/crates/eframe/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(web_sys_unstable_apis)");
+}

--- a/crates/eframe/src/icon_data.rs
+++ b/crates/eframe/src/icon_data.rs
@@ -54,7 +54,7 @@ impl IconDataExt for IconData {
         image
             .write_to(
                 &mut std::io::Cursor::new(&mut png_bytes),
-                image::ImageOutputFormat::Png,
+                image::ImageFormat::Png,
             )
             .map_err(|err| err.to_string())?;
         Ok(png_bytes)

--- a/crates/eframe/src/lib.rs
+++ b/crates/eframe/src/lib.rs
@@ -200,7 +200,7 @@ pub mod icon_data;
 /// ``` no_run
 /// use luminol_eframe::egui;
 ///
-/// fn main() -> eframe::Result {
+/// fn main() -> luminol_eframe::Result {
 ///     let native_options = luminol_eframe::NativeOptions::default();
 ///     luminol_eframe::run_native("MyApp", native_options, Box::new(|cc| Ok(Box::new(MyEguiApp::new(cc)))))
 /// }

--- a/crates/eframe/src/lib.rs
+++ b/crates/eframe/src/lib.rs
@@ -30,7 +30,7 @@
 //!
 //! fn main() {
 //!     let native_options = luminol_eframe::NativeOptions::default();
-//!     luminol_eframe::run_native("My egui App", native_options, Box::new(|cc| Box::new(MyEguiApp::new(cc))));
+//!     luminol_eframe::run_native("My egui App", native_options, Box::new(|cc| Ok(Box::new(MyEguiApp::new(cc)))));
 //! }
 //!
 //! #[derive(Default)]
@@ -90,7 +90,7 @@
 //!             .start(
 //!                 canvas_id,
 //!                 luminol_eframe::WebOptions::default(),
-//!                 Box::new(|cc| Box::new(MyEguiApp::new(cc))),
+//!                 Box::new(|cc| Ok(Box::new(MyEguiApp::new(cc))),)
 //!             )
 //!             .await
 //!     }
@@ -199,9 +199,9 @@ pub mod icon_data;
 /// ``` no_run
 /// use luminol_eframe::egui;
 ///
-/// fn main() -> luminol_eframe::Result<()> {
+/// fn main() -> eframe::Result {
 ///     let native_options = luminol_eframe::NativeOptions::default();
-///     luminol_eframe::run_native("MyApp", native_options, Box::new(|cc| Box::new(MyEguiApp::new(cc))))
+///     luminol_eframe::run_native("MyApp", native_options, Box::new(|cc| Ok(Box::new(MyEguiApp::new(cc)))))
 /// }
 ///
 /// #[derive(Default)]
@@ -235,7 +235,7 @@ pub fn run_native(
     app_name: &str,
     mut native_options: NativeOptions,
     app_creator: AppCreator,
-) -> Result<()> {
+) -> Result {
     #[cfg(not(feature = "__screenshot"))]
     assert!(
         std::env::var("EFRAME_SCREENSHOT_TO").is_err(),
@@ -280,7 +280,7 @@ pub fn run_native(
 ///
 /// # Example
 /// ``` no_run
-/// fn main() -> luminol_eframe::Result<()> {
+/// fn main() -> luminol_eframe::Result {
 ///     // Our application state:
 ///     let mut name = "Arthur".to_owned();
 ///     let mut age = 42;
@@ -312,7 +312,7 @@ pub fn run_simple_native(
     app_name: &str,
     native_options: NativeOptions,
     update_fun: impl FnMut(&egui::Context, &mut Frame) + 'static,
-) -> Result<()> {
+) -> Result {
     struct SimpleApp<U> {
         update_fun: U,
     }
@@ -326,48 +326,128 @@ pub fn run_simple_native(
     run_native(
         app_name,
         native_options,
-        Box::new(|_cc| Box::new(SimpleApp { update_fun })),
+        Box::new(|_cc| Ok(Box::new(SimpleApp { update_fun }))),
     )
 }
 
 // ----------------------------------------------------------------------------
 
 /// The different problems that can occur when trying to run `eframe`.
-#[derive(thiserror::Error, Debug)]
+#[derive(Debug)]
 pub enum Error {
+    /// Something went wrong in user code when creating the app.
+    AppCreation(Box<dyn std::error::Error + Send + Sync>),
+
     /// An error from [`winit`].
     #[cfg(not(target_arch = "wasm32"))]
-    #[error("winit error: {0}")]
-    Winit(#[from] winit::error::OsError),
+    Winit(winit::error::OsError),
 
     /// An error from [`winit::event_loop::EventLoop`].
     #[cfg(not(target_arch = "wasm32"))]
-    #[error("winit EventLoopError: {0}")]
-    WinitEventLoop(#[from] winit::error::EventLoopError),
+    WinitEventLoop(winit::error::EventLoopError),
 
     /// An error from [`glutin`] when using [`glow`].
     #[cfg(all(feature = "glow", not(target_arch = "wasm32")))]
-    #[error("glutin error: {0}")]
-    Glutin(#[from] glutin::error::Error),
+    Glutin(glutin::error::Error),
 
     /// An error from [`glutin`] when using [`glow`].
     #[cfg(all(feature = "glow", not(target_arch = "wasm32")))]
-    #[error("Found no glutin configs matching the template: {0:?}. Error: {1:?}")]
     NoGlutinConfigs(glutin::config::ConfigTemplate, Box<dyn std::error::Error>),
 
     /// An error from [`glutin`] when using [`glow`].
     #[cfg(feature = "glow")]
-    #[error("egui_glow: {0}")]
-    OpenGL(#[from] egui_glow::PainterError),
+    OpenGL(egui_glow::PainterError),
 
     /// An error from [`wgpu`].
     #[cfg(feature = "wgpu")]
-    #[error("WGPU error: {0}")]
-    Wgpu(#[from] luminol_egui_wgpu::WgpuError),
+    Wgpu(luminol_egui_wgpu::WgpuError),
+}
+
+impl std::error::Error for Error {}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<winit::error::OsError> for Error {
+    #[inline]
+    fn from(err: winit::error::OsError) -> Self {
+        Self::Winit(err)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<winit::error::EventLoopError> for Error {
+    #[inline]
+    fn from(err: winit::error::EventLoopError) -> Self {
+        Self::WinitEventLoop(err)
+    }
+}
+
+#[cfg(all(feature = "glow", not(target_arch = "wasm32")))]
+impl From<glutin::error::Error> for Error {
+    #[inline]
+    fn from(err: glutin::error::Error) -> Self {
+        Self::Glutin(err)
+    }
+}
+
+#[cfg(feature = "glow")]
+impl From<egui_glow::PainterError> for Error {
+    #[inline]
+    fn from(err: egui_glow::PainterError) -> Self {
+        Self::OpenGL(err)
+    }
+}
+
+#[cfg(feature = "wgpu")]
+impl From<luminol_egui_wgpu::WgpuError> for Error {
+    #[inline]
+    fn from(err: luminol_egui_wgpu::WgpuError) -> Self {
+        Self::Wgpu(err)
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AppCreation(err) => write!(f, "app creation error: {err}"),
+
+            #[cfg(not(target_arch = "wasm32"))]
+            Self::Winit(err) => {
+                write!(f, "winit error: {err}")
+            }
+
+            #[cfg(not(target_arch = "wasm32"))]
+            Self::WinitEventLoop(err) => {
+                write!(f, "winit EventLoopError: {err}")
+            }
+
+            #[cfg(all(feature = "glow", not(target_arch = "wasm32")))]
+            Self::Glutin(err) => {
+                write!(f, "glutin error: {err}")
+            }
+
+            #[cfg(all(feature = "glow", not(target_arch = "wasm32")))]
+            Self::NoGlutinConfigs(template, err) => {
+                write!(
+                    f,
+                    "Found no glutin configs matching the template: {template:?}. Error: {err}"
+                )
+            }
+
+            #[cfg(feature = "glow")]
+            Self::OpenGL(err) => {
+                write!(f, "egui_glow: {err}")
+            }
+
+            #[cfg(feature = "wgpu")]
+            Self::Wgpu(err) => {
+                write!(f, "WGPU error: {err}")
+            }
+        }
+    }
 }
 
 /// Short for `Result<T, luminol_eframe::Error>`.
-pub type Result<T, E = Error> = std::result::Result<T, E>;
+pub type Result<T = (), E = Error> = std::result::Result<T, E>;
 
 // ---------------------------------------------------------------------------
 

--- a/crates/eframe/src/lib.rs
+++ b/crates/eframe/src/lib.rs
@@ -137,6 +137,7 @@
 #![allow(clippy::needless_doctest_main)]
 // Luminol doesn't need everything from eframe, but we're leaving everything here to reduce merge conflicts
 #![allow(dead_code, unused_imports)]
+#![allow(clippy::thread_local_initializer_can_be_made_const)]
 
 // Re-export all useful libraries:
 pub use {egui, egui::emath, egui::epaint};

--- a/crates/eframe/src/native/app_icon.rs
+++ b/crates/eframe/src/native/app_icon.rs
@@ -118,7 +118,7 @@ fn set_app_icon_windows(icon_data: &IconData) -> AppIconStatus {
         if image_scaled
             .write_to(
                 &mut std::io::Cursor::new(&mut image_scaled_bytes),
-                image::ImageOutputFormat::Png,
+                image::ImageFormat::Png,
             )
             .is_err()
         {
@@ -203,12 +203,9 @@ fn set_title_and_icon_mac(title: &str, icon_data: Option<&IconData>) -> AppIconS
     use crate::icon_data::IconDataExt as _;
     crate::profile_function!();
 
-    use cocoa::{
-        appkit::{NSApp, NSApplication, NSImage, NSMenu, NSWindow},
-        base::{id, nil},
-        foundation::{NSData, NSString},
-    };
-    use objc::{msg_send, sel, sel_impl};
+    use objc2::ClassType;
+    use objc2_app_kit::{NSApplication, NSImage};
+    use objc2_foundation::{NSData, NSString};
 
     let png_bytes = if let Some(icon_data) = icon_data {
         match icon_data.to_png_bytes() {
@@ -222,38 +219,35 @@ fn set_title_and_icon_mac(title: &str, icon_data: Option<&IconData>) -> AppIconS
         None
     };
 
-    // SAFETY: Accessing raw data from icon in a read-only manner. Icon data is static!
+    // TODO(madsmtm): Move this into `objc2-app-kit`
+    extern "C" {
+        static NSApp: Option<&'static NSApplication>;
+    }
+
+    // SAFETY: we don't do anything dangerous here
     unsafe {
-        let app = NSApp();
-        if app.is_null() {
+        let Some(app) = NSApp else {
             log::debug!("NSApp is null");
             return AppIconStatus::NotSetIgnored;
-        }
+        };
 
         if let Some(png_bytes) = png_bytes {
-            let data = NSData::dataWithBytes_length_(
-                nil,
-                png_bytes.as_ptr().cast::<std::ffi::c_void>(),
-                png_bytes.len() as u64,
-            );
+            let data = NSData::from_vec(png_bytes);
 
             log::trace!("NSImage::initWithData…");
-            let app_icon = NSImage::initWithData_(NSImage::alloc(nil), data);
+            let app_icon = NSImage::initWithData(NSImage::alloc(), &data);
 
             crate::profile_scope!("setApplicationIconImage_");
             log::trace!("setApplicationIconImage…");
-            app.setApplicationIconImage_(app_icon);
+            app.setApplicationIconImage(app_icon.as_deref());
         }
 
         // Change the title in the top bar - for python processes this would be again "python" otherwise.
-        let main_menu = app.mainMenu();
-        if !main_menu.is_null() {
-            let item = main_menu.itemAtIndex_(0);
-            if !item.is_null() {
-                let app_menu: id = msg_send![item, submenu];
-                if !app_menu.is_null() {
+        if let Some(main_menu) = app.mainMenu() {
+            if let Some(item) = main_menu.itemAtIndex(0) {
+                if let Some(app_menu) = item.submenu() {
                     crate::profile_scope!("setTitle_");
-                    app_menu.setTitle_(NSString::alloc(nil).init_str(title));
+                    app_menu.setTitle(&NSString::from_str(title));
                 }
             }
         }

--- a/crates/eframe/src/native/epi_integration.rs
+++ b/crates/eframe/src/native/epi_integration.rs
@@ -1,6 +1,8 @@
 //! Common tools used by [`super::glow_integration`] and [`super::wgpu_integration`].
 
 use web_time::Instant;
+
+use std::path::PathBuf;
 use winit::event_loop::EventLoopWindowTarget;
 
 use raw_window_handle::{HasDisplayHandle as _, HasWindowHandle as _};
@@ -20,27 +22,41 @@ pub fn viewport_builder<E>(
 
     let mut viewport_builder = native_options.viewport.clone();
 
+    // On some Linux systems, a window size larger than the monitor causes crashes,
+    // and on Windows the window does not appear at all.
+    let clamp_size_to_monitor_size = viewport_builder.clamp_size_to_monitor_size.unwrap_or(true);
+
     // Always use the default window size / position on iOS. Trying to restore the previous position
     // causes the window to be shown too small.
     #[cfg(not(target_os = "ios"))]
     let inner_size_points = if let Some(mut window_settings) = window_settings {
         // Restore pos/size from previous session
 
-        window_settings
-            .clamp_size_to_sane_values(largest_monitor_point_size(egui_zoom_factor, event_loop));
+        if clamp_size_to_monitor_size {
+            window_settings.clamp_size_to_sane_values(largest_monitor_point_size(
+                egui_zoom_factor,
+                event_loop,
+            ));
+        }
         window_settings.clamp_position_to_monitors(egui_zoom_factor, event_loop);
 
-        viewport_builder = window_settings.initialize_viewport_builder(viewport_builder);
+        viewport_builder = window_settings.initialize_viewport_builder(
+            egui_zoom_factor,
+            event_loop,
+            viewport_builder,
+        );
         window_settings.inner_size_points()
     } else {
         if let Some(pos) = viewport_builder.position {
             viewport_builder = viewport_builder.with_position(pos);
         }
 
-        if let Some(initial_window_size) = viewport_builder.inner_size {
-            let initial_window_size = initial_window_size
-                .at_most(largest_monitor_point_size(egui_zoom_factor, event_loop));
-            viewport_builder = viewport_builder.with_inner_size(initial_window_size);
+        if clamp_size_to_monitor_size {
+            if let Some(initial_window_size) = viewport_builder.inner_size {
+                let initial_window_size = initial_window_size
+                    .at_most(largest_monitor_point_size(egui_zoom_factor, event_loop));
+                viewport_builder = viewport_builder.with_inner_size(initial_window_size);
+            }
         }
 
         viewport_builder.inner_size
@@ -118,6 +134,16 @@ pub fn create_storage(_app_name: &str) -> Option<Box<dyn epi::Storage>> {
     None
 }
 
+#[allow(clippy::unnecessary_wraps)]
+pub fn create_storage_with_file(_file: impl Into<PathBuf>) -> Option<Box<dyn epi::Storage>> {
+    #[cfg(feature = "persistence")]
+    return Some(Box::new(
+        super::file_storage::FileStorage::from_ron_filepath(_file),
+    ));
+    #[cfg(not(feature = "persistence"))]
+    None
+}
+
 // ----------------------------------------------------------------------------
 
 /// Everything needed to make a winit-based integration for [`epi`].
@@ -152,6 +178,9 @@ impl EpiIntegration {
         native_options: &crate::NativeOptions,
         storage: Option<Box<dyn epi::Storage>>,
         #[cfg(feature = "glow")] gl: Option<std::sync::Arc<glow::Context>>,
+        #[cfg(feature = "glow")] glow_register_native_texture: Option<
+            Box<dyn FnMut(glow::Texture) -> egui::TextureId>,
+        >,
         #[cfg(feature = "wgpu")] wgpu_render_state: Option<luminol_egui_wgpu::RenderState>,
     ) -> Self {
         let frame = epi::Frame {
@@ -162,6 +191,8 @@ impl EpiIntegration {
             storage,
             #[cfg(feature = "glow")]
             gl,
+            #[cfg(feature = "glow")]
+            glow_register_native_texture,
             #[cfg(feature = "wgpu")]
             wgpu_render_state,
             raw_display_handle: window.display_handle().map(|h| h.as_raw()),

--- a/crates/eframe/src/native/file_storage.rs
+++ b/crates/eframe/src/native/file_storage.rs
@@ -10,12 +10,12 @@ use std::{
 /// [`egui::ViewportBuilder::app_id`] of [`crate::NativeOptions::viewport`]
 /// or the title argument to [`crate::run_native`].
 ///
-/// On native the path is picked using [`directories_next::ProjectDirs::data_dir`](https://docs.rs/directories-next/2.0.0/directories_next/struct.ProjectDirs.html#method.data_dir) which is:
+/// On native the path is picked using [`directories::ProjectDirs::data_dir`](https://docs.rs/directories/5.0.1/directories/struct.ProjectDirs.html#method.data_dir) which is:
 /// * Linux:   `/home/UserName/.local/share/APP_ID`
 /// * macOS:   `/Users/UserName/Library/Application Support/APP_ID`
 /// * Windows: `C:\Users\UserName\AppData\Roaming\APP_ID`
 pub fn storage_dir(app_id: &str) -> Option<PathBuf> {
-    directories_next::ProjectDirs::from("", "", app_id)
+    directories::ProjectDirs::from("", "", app_id)
         .map(|proj_dirs| proj_dirs.data_dir().to_path_buf())
 }
 
@@ -41,7 +41,7 @@ impl Drop for FileStorage {
 
 impl FileStorage {
     /// Store the state in this .ron file.
-    fn from_ron_filepath(ron_filepath: impl Into<PathBuf>) -> Self {
+    pub(crate) fn from_ron_filepath(ron_filepath: impl Into<PathBuf>) -> Self {
         crate::profile_function!();
         let ron_filepath: PathBuf = ron_filepath.into();
         log::debug!("Loading app state from {:?}…", ron_filepath);

--- a/crates/eframe/src/native/run.rs
+++ b/crates/eframe/src/native/run.rs
@@ -2,7 +2,7 @@ use std::{cell::RefCell, time::Instant};
 
 use winit::event_loop::{EventLoop, EventLoopBuilder};
 
-use egui::epaint::ahash::HashMap;
+use ahash::HashMap;
 
 use crate::{
     epi,
@@ -43,7 +43,7 @@ fn with_event_loop<R>(
     mut native_options: epi::NativeOptions,
     f: impl FnOnce(&mut EventLoop<UserEvent>, epi::NativeOptions) -> R,
 ) -> Result<R> {
-    thread_local!(static EVENT_LOOP: RefCell<Option<EventLoop<UserEvent>>> = const { RefCell::new(None) });
+    thread_local!(static EVENT_LOOP: RefCell<Option<EventLoop<UserEvent>>> = RefCell::new(None));
 
     EVENT_LOOP.with(|event_loop| {
         // Since we want to reference NativeOptions when creating the EventLoop we can't
@@ -60,10 +60,7 @@ fn with_event_loop<R>(
 }
 
 #[cfg(not(target_os = "ios"))]
-fn run_and_return(
-    event_loop: &mut EventLoop<UserEvent>,
-    mut winit_app: impl WinitApp,
-) -> Result<()> {
+fn run_and_return(event_loop: &mut EventLoop<UserEvent>, mut winit_app: impl WinitApp) -> Result {
     use winit::{event_loop::ControlFlow, platform::run_on_demand::EventLoopExtRunOnDemand};
 
     log::trace!("Entering the winit event loop (run_on_demand)…");
@@ -234,7 +231,7 @@ fn run_and_return(
 fn run_and_exit(
     event_loop: EventLoop<UserEvent>,
     mut winit_app: impl WinitApp + 'static,
-) -> Result<()> {
+) -> Result {
     use winit::event_loop::ControlFlow;
     log::trace!("Entering the winit event loop (run)…");
 
@@ -390,7 +387,9 @@ pub fn run_glow(
     app_name: &str,
     mut native_options: epi::NativeOptions,
     app_creator: epi::AppCreator,
-) -> Result<()> {
+) -> Result {
+    #![allow(clippy::needless_return_with_question_mark)] // False positive
+
     use super::glow_integration::GlowWinitApp;
 
     #[cfg(not(target_os = "ios"))]
@@ -414,7 +413,9 @@ pub fn run_wgpu(
     app_name: &str,
     mut native_options: epi::NativeOptions,
     app_creator: epi::AppCreator,
-) -> Result<()> {
+) -> Result {
+    #![allow(clippy::needless_return_with_question_mark)] // False positive
+
     use super::wgpu_integration::WgpuWinitApp;
 
     #[cfg(not(target_os = "ios"))]

--- a/crates/eframe/src/native/winit_integration.rs
+++ b/crates/eframe/src/native/winit_integration.rs
@@ -9,8 +9,6 @@ use egui::ViewportId;
 #[cfg(feature = "accesskit")]
 use egui_winit::accesskit_winit;
 
-use super::epi_integration::EpiIntegration;
-
 /// Create an egui context, restoring it from storage if possible.
 pub fn create_egui_context(storage: Option<&dyn crate::Storage>) -> egui::Context {
     crate::profile_function!();
@@ -63,10 +61,6 @@ impl From<accesskit_winit::ActionRequestEvent> for UserEvent {
 pub trait WinitApp {
     /// The current frame number, as reported by egui.
     fn frame_nr(&self, viewport_id: ViewportId) -> u64;
-
-    fn is_focused(&self, window_id: WindowId) -> bool;
-
-    fn integration(&self) -> Option<&EpiIntegration>;
 
     fn window(&self, window_id: WindowId) -> Option<Arc<Window>>;
 

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -334,11 +334,21 @@ impl AppRunner {
         inner.mutable_text_under_cursor = mutable_text_under_cursor;
         inner.wants_keyboard_input = wants_keyboard_input;
 
-        let text_agent = inner.text_agent.as_ref().unwrap();
+        let has_focus = inner.has_focus;
+        let is_ime_active = inner.ime.is_some();
 
-        if inner.has_focus {
+        // Can't have `inner` borrowed for the `text_agent` operations because apparently they
+        // yield to the asynchronous runtime
+        drop(inner);
+
+        let text_agent = state
+            .text_agent
+            .get()
+            .expect("text agent should be initialized at this point");
+
+        if has_focus {
             // The eframe app has focus.
-            if inner.ime.is_some() {
+            if is_ime_active {
                 // We are editing text: give the focus to the text agent.
                 text_agent.focus();
             } else {

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -263,7 +263,6 @@ impl AppRunner {
             .send(super::WebRunnerOutput::PlatformOutput(
                 platform_output,
                 self.egui_ctx.options(|o| o.screen_reader),
-                self.egui_ctx.wants_keyboard_input(),
             ));
         self.textures_delta.append(textures_delta);
         self.clipped_primitives = Some(self.egui_ctx.tessellate(shapes, pixels_per_point));
@@ -294,7 +293,6 @@ impl AppRunner {
         state: &super::MainState,
         platform_output: egui::PlatformOutput,
         screen_reader_enabled: bool,
-        wants_keyboard_input: bool,
     ) {
         // We sometimes miss blur/focus events due to the text agent, so let's just poll each frame:
         state.update_focus();
@@ -310,8 +308,8 @@ impl AppRunner {
             cursor_icon,
             open_url,
             copied_text,
-            events: _,                 // already handled
-            mutable_text_under_cursor, // TODO(#4569): https://github.com/emilk/egui/issues/4569
+            events: _,                    // already handled
+            mutable_text_under_cursor: _, // TODO(#4569): https://github.com/emilk/egui/issues/4569
             ime,
             #[cfg(feature = "accesskit")]
                 accesskit_update: _, // not currently implemented

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -330,16 +330,9 @@ impl AppRunner {
         #[cfg(not(web_sys_unstable_apis))]
         let _ = copied_text;
 
-        let mut inner = state.inner.borrow_mut();
-        inner.mutable_text_under_cursor = mutable_text_under_cursor;
-        inner.wants_keyboard_input = wants_keyboard_input;
-
-        let has_focus = inner.has_focus;
-        let is_ime_active = inner.ime.is_some();
-
         // Can't have `inner` borrowed for the `text_agent` operations because apparently they
         // yield to the asynchronous runtime
-        drop(inner);
+        let has_focus = state.inner.borrow().has_focus;
 
         let text_agent = state
             .text_agent
@@ -348,7 +341,7 @@ impl AppRunner {
 
         if has_focus {
             // The eframe app has focus.
-            if is_ime_active {
+            if ime.is_some() {
                 // We are editing text: give the focus to the text agent.
                 text_agent.focus();
             } else {

--- a/crates/eframe/src/web/app_runner.rs
+++ b/crates/eframe/src/web/app_runner.rs
@@ -2,9 +2,10 @@ use egui::TexturesDelta;
 
 use crate::{epi, App};
 
-use super::{now_sec, web_painter::WebPainter, NeedRepaint};
+use super::{now_sec, text_agent::TextAgent, web_painter::WebPainter, NeedRepaint};
 
 pub struct AppRunner {
+    #[allow(dead_code)]
     web_options: crate::WebOptions,
     pub(crate) frame: epi::Frame,
     egui_ctx: egui::Context,
@@ -13,8 +14,6 @@ pub struct AppRunner {
     app: Box<dyn epi::App>,
     pub(crate) needs_repaint: std::sync::Arc<NeedRepaint>,
     last_save_time: f64,
-    pub(crate) ime: Option<egui::output::IMEOutput>,
-    pub(crate) mutable_text_under_cursor: bool,
 
     // Output for the last run:
     textures_delta: TexturesDelta,
@@ -32,7 +31,7 @@ impl Drop for AppRunner {
 
 impl AppRunner {
     /// # Errors
-    /// Failure to initialize WebGL renderer.
+    /// Failure to initialize WebGL renderer, or failure to create app.
     pub async fn new(
         canvas: web_sys::OffscreenCanvas,
         web_options: crate::WebOptions,
@@ -100,7 +99,7 @@ impl AppRunner {
         let theme = system_theme.unwrap_or(web_options.default_theme);
         egui_ctx.set_visuals(theme.egui_visuals());
 
-        let app = app_creator(&epi::CreationContext {
+        let cc = epi::CreationContext {
             egui_ctx: egui_ctx.clone(),
             integration_info: info.clone(),
             storage: Some(&storage),
@@ -115,7 +114,8 @@ impl AppRunner {
             wgpu_render_state: painter.render_state(),
             #[cfg(all(feature = "wgpu", feature = "glow"))]
             wgpu_render_state: None,
-        });
+        };
+        let app = app_creator(&cc).map_err(|err| err.to_string())?;
 
         let frame = epi::Frame {
             info,
@@ -147,8 +147,6 @@ impl AppRunner {
             app,
             needs_repaint,
             last_save_time: now_sec(),
-            ime: None,
-            mutable_text_under_cursor: false,
             textures_delta: Default::default(),
             clipped_primitives: None,
 
@@ -206,14 +204,32 @@ impl AppRunner {
         self.clipped_primitives.is_some()
     }
 
+    /*
+    pub fn update_focus(&mut self) {
+        let has_focus = self.has_focus();
+        if self.input.raw.focused != has_focus {
+            log::trace!("{} Focus changed to {has_focus}", self.canvas().id());
+            self.input.set_focus(has_focus);
+
+            if !has_focus {
+                // We lost focus - good idea to save
+                self.save();
+            }
+            self.egui_ctx().request_repaint();
+        }
+    }
+    */
+
     /// Runs the logic, but doesn't paint the result.
     ///
     /// The result can be painted later with a call to [`Self::run_and_paint`] or [`Self::paint`].
     pub fn logic(&mut self) {
-        let raw_input = self.input.new_frame(
+        let mut raw_input = self.input.new_frame(
             egui::vec2(self.painter.width as f32, self.painter.height as f32),
             self.painter.pixel_ratio,
         );
+
+        self.app.raw_input_hook(&self.egui_ctx, &mut raw_input);
 
         let full_output = self.egui_ctx.run(raw_input, |egui_ctx| {
             self.app.update(egui_ctx, &mut self.frame);
@@ -238,7 +254,6 @@ impl AppRunner {
             }
         }
 
-        self.mutable_text_under_cursor = platform_output.mutable_text_under_cursor;
         self.worker_options.channels.zoom_tx.store(
             self.egui_ctx.zoom_factor(),
             portable_atomic::Ordering::Relaxed,
@@ -281,6 +296,9 @@ impl AppRunner {
         screen_reader_enabled: bool,
         wants_keyboard_input: bool,
     ) {
+        // We sometimes miss blur/focus events due to the text agent, so let's just poll each frame:
+        state.update_focus();
+
         #[cfg(feature = "web_screen_reader")]
         if screen_reader_enabled {
             super::screen_reader::speak(&platform_output.events_description());
@@ -292,8 +310,8 @@ impl AppRunner {
             cursor_icon,
             open_url,
             copied_text,
-            events: _, // already handled
-            mutable_text_under_cursor,
+            events: _,                 // already handled
+            mutable_text_under_cursor, // TODO(#4569): https://github.com/emilk/egui/issues/4569
             ime,
             #[cfg(feature = "accesskit")]
                 accesskit_update: _, // not currently implemented
@@ -312,15 +330,29 @@ impl AppRunner {
         #[cfg(not(web_sys_unstable_apis))]
         let _ = copied_text;
 
-        {
-            let mut inner = state.inner.borrow_mut();
-            inner.mutable_text_under_cursor = mutable_text_under_cursor;
-            inner.wants_keyboard_input = wants_keyboard_input;
+        let mut inner = state.inner.borrow_mut();
+        inner.mutable_text_under_cursor = mutable_text_under_cursor;
+        inner.wants_keyboard_input = wants_keyboard_input;
 
-            if inner.ime != ime {
-                super::text_agent::move_text_cursor(ime, &state.canvas);
-                inner.ime = ime;
+        let text_agent = inner.text_agent.as_ref().unwrap();
+
+        if inner.has_focus {
+            // The eframe app has focus.
+            if inner.ime.is_some() {
+                // We are editing text: give the focus to the text agent.
+                text_agent.focus();
+            } else {
+                // We are not editing text - give the focus to the canvas.
+                text_agent.blur();
+                state.canvas.focus().ok();
             }
+        }
+
+        if let Err(err) = text_agent.move_to(ime, &state.canvas) {
+            log::error!(
+                "failed to update text agent position: {}",
+                super::string_from_js_value(&err)
+            );
         }
     }
 }

--- a/crates/eframe/src/web/backend.rs
+++ b/crates/eframe/src/web/backend.rs
@@ -12,10 +12,7 @@ use super::percent_decode;
 #[derive(Default)]
 pub(crate) struct WebInput {
     /// Required because we don't get a position on touched
-    pub latest_touch_pos: Option<egui::Pos2>,
-
-    /// Required to maintain a stable touch position for multi-touch gestures.
-    pub latest_touch_pos_id: Option<egui::TouchId>,
+    pub primary_touch: Option<egui::TouchId>,
 
     /// The raw input to `egui`.
     pub raw: egui::RawInput,
@@ -36,14 +33,17 @@ impl WebInput {
         raw_input
     }
 
-    /// On alt-tab and similar.
-    pub fn on_web_page_focus_change(&mut self, focused: bool) {
+    /// On alt-tab, or user clicking another HTML element.
+    pub fn set_focus(&mut self, focused: bool) {
+        if self.raw.focused == focused {
+            return;
+        }
+
         // log::debug!("on_web_page_focus_change: {focused}");
         self.raw.modifiers = egui::Modifiers::default(); // Avoid sticky modifier keys on alt-tab:
         self.raw.focused = focused;
         self.raw.events.push(egui::Event::WindowFocused(focused));
-        self.latest_touch_pos = None;
-        self.latest_touch_pos_id = None;
+        self.primary_touch = None;
     }
 }
 
@@ -143,6 +143,7 @@ fn parse_query_map(query: &str) -> BTreeMap<String, Vec<String>> {
     map
 }
 
+/*
 // TODO(emilk): this test is never acgtually run, because this whole module is wasm32 only 🤦‍♂️
 #[test]
 fn test_parse_query() {
@@ -172,3 +173,4 @@ fn test_parse_query() {
         ])
     );
 }
+*/

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -541,7 +541,7 @@ fn install_window_events(state: &MainState, window: &web_sys::Window) -> Result<
         }
     };
     closure(web_sys::Event::new("")?, state);
-    state.add_event_listener(&window, "resize", closure)?;
+    state.add_event_listener(window, "resize", closure)?;
 
     {
         let window = window.clone();

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -292,9 +292,9 @@ fn install_keydown(state: &MainState, target: &EventTarget) -> Result<(), JsValu
 
         let modifiers = modifiers_from_kb_event(&event);
         if !modifiers.ctrl
-                && !modifiers.command
-                // When text agent is focused, it is responsible for handling input events
-                && !state.inner.borrow().text_agent.as_ref().unwrap().has_focus()
+            && !modifiers.command
+            // When text agent is focused, it is responsible for handling input events
+            && !state.text_agent.get().expect("text agent should be initialized at this point").has_focus()
         {
             if let Some(text) = text_from_keyboard_event(&event) {
                 state.channels.send(egui::Event::Text(text));
@@ -382,11 +382,9 @@ fn should_prevent_default_for_key(
 
     if egui_key == egui::Key::Space
         && !state
-            .inner
-            .borrow()
             .text_agent
-            .as_ref()
-            .unwrap()
+            .get()
+            .expect("text agent should be initialized at this point")
             .has_focus()
     {
         // Space scrolls the web page, but we don't want that while canvas has focus

--- a/crates/eframe/src/web/events.rs
+++ b/crates/eframe/src/web/events.rs
@@ -1,4 +1,8 @@
 use super::*;
+use web_sys::EventTarget;
+
+// TODO(emilk): there are more calls to `prevent_default` and `stop_propagaton`
+// than what is probably needed.
 
 // ------------------------------------------------------------------------
 
@@ -8,13 +12,17 @@ use super::*;
 pub(crate) fn paint_and_schedule(runner_ref: &WebRunner) -> Result<(), JsValue> {
     // Only paint and schedule if there has been no panic
     if let Some(mut runner_lock) = runner_ref.try_lock() {
+        let ctx = runner_lock.egui_ctx().clone();
         let mut width = runner_lock.painter.width;
         let mut height = runner_lock.painter.height;
         let mut pixel_ratio = runner_lock.painter.pixel_ratio;
         let mut modifiers = runner_lock.input.raw.modifiers;
         let mut should_save = false;
+        let mut should_repaint = false;
         let mut touch = None;
         let mut has_focus = None;
+        let mut hash = None;
+        let mut theme = None;
         runner_lock.input.raw.events = Vec::new();
         let mut events = Vec::new();
 
@@ -22,6 +30,10 @@ pub(crate) fn paint_and_schedule(runner_ref: &WebRunner) -> Result<(), JsValue> 
             match event {
                 WebRunnerEvent::EguiEvent(event) => {
                     events.push(event);
+                }
+
+                WebRunnerEvent::Repaint => {
+                    should_repaint = true;
                 }
 
                 WebRunnerEvent::ScreenResize(new_width, new_height, new_pixel_ratio) => {
@@ -38,14 +50,59 @@ pub(crate) fn paint_and_schedule(runner_ref: &WebRunner) -> Result<(), JsValue> 
                     should_save = true;
                 }
 
-                WebRunnerEvent::Touch(touch_id, touch_pos) => {
-                    touch = Some((touch_id, touch_pos));
+                WebRunnerEvent::Touch(touch_id) => {
+                    touch = Some(touch_id);
                 }
 
                 WebRunnerEvent::Focus(new_has_focus) => {
                     has_focus = Some(new_has_focus);
                     events.push(egui::Event::WindowFocused(new_has_focus));
                     touch = None;
+                }
+
+                WebRunnerEvent::Wheel(wheel_unit, wheel_delta, wheel_modifiers) => {
+                    if wheel_modifiers.ctrl && !modifiers.ctrl {
+                        // The browser is saying the ctrl key is down, but it isn't _really_.
+                        // This happens on pinch-to-zoom on a Mac trackpad.
+                        // egui will treat ctrl+scroll as zoom, so it all works.
+                        // However, we explicitly handle it here in order to better match the pinch-to-zoom
+                        // speed of a native app, without being sensitive to egui's `scroll_zoom_speed` setting.
+                        let pinch_to_zoom_sensitivity = 0.01; // Feels good on a Mac trackpad in 2024
+                        let zoom_factor = (pinch_to_zoom_sensitivity * wheel_delta.y).exp();
+                        events.push(egui::Event::Zoom(zoom_factor));
+                    } else {
+                        events.push(egui::Event::MouseWheel {
+                            unit: wheel_unit,
+                            delta: wheel_delta,
+                            modifiers: wheel_modifiers,
+                        });
+                    }
+                }
+
+                WebRunnerEvent::CommandKeyReleased => {
+                    // When pressing Cmd+A (select all) or Ctrl+C (copy),
+                    // chromium will not fire a `keyup` for the letter key.
+                    // This leads to stuck keys, unless we do this hack.
+                    // See https://github.com/emilk/egui/issues/4724
+
+                    let keys_down = ctx.input(|i| i.keys_down.clone());
+                    for key in keys_down {
+                        events.push(egui::Event::Key {
+                            key,
+                            physical_key: None,
+                            pressed: false,
+                            repeat: false,
+                            modifiers,
+                        });
+                    }
+                }
+
+                WebRunnerEvent::Hash(new_hash) => {
+                    hash = Some(new_hash);
+                }
+
+                WebRunnerEvent::Theme(new_theme) => {
+                    theme = Some(new_theme);
                 }
             }
         }
@@ -54,15 +111,26 @@ pub(crate) fn paint_and_schedule(runner_ref: &WebRunner) -> Result<(), JsValue> 
         // touch state and trigger a rerender
         if let Some(has_focus) = has_focus {
             runner_lock.input.raw.focused = has_focus;
-            runner_lock.input.latest_touch_pos_id = None;
-            runner_lock.input.latest_touch_pos = None;
+            runner_lock.input.primary_touch = None;
             runner_lock.needs_repaint.repaint_asap();
         }
 
         // If a touch event has been detected, put it into the input and trigger a rerender
-        if let Some((touch_id, touch_pos)) = touch {
-            runner_lock.input.latest_touch_pos_id = touch_id;
-            runner_lock.input.latest_touch_pos = Some(touch_pos);
+        if let Some(touch_id) = touch {
+            runner_lock.input.primary_touch = touch_id;
+            runner_lock.needs_repaint.repaint_asap();
+        }
+
+        // If the URL hash has changed, put it into the epi frame and trigger a rerender
+        if let Some(hash) = hash {
+            runner_lock.frame.info.web_info.location.hash = hash;
+            runner_lock.needs_repaint.repaint_asap();
+        }
+
+        // If the color scheme has changed, put it into the epi frame and trigger a rerender
+        if let Some(theme) = theme {
+            runner_lock.frame.info.system_theme = Some(theme);
+            runner_lock.egui_ctx().set_visuals(theme.egui_visuals());
             runner_lock.needs_repaint.repaint_asap();
         }
 
@@ -81,6 +149,11 @@ pub(crate) fn paint_and_schedule(runner_ref: &WebRunner) -> Result<(), JsValue> 
         // Save and rerender immediately if saving was requested
         if should_save {
             runner_lock.save();
+            runner_lock.needs_repaint.repaint_asap();
+        }
+
+        // Rerender immediately if a repaint event was received
+        if should_repaint {
             runner_lock.needs_repaint.repaint_asap();
         }
 
@@ -146,167 +219,268 @@ fn paint_if_needed(runner: &mut AppRunner) {
 
 // ------------------------------------------------------------------------
 
-pub(crate) fn install_document_events(state: &MainState) -> Result<(), JsValue> {
-    let document = web_sys::window().unwrap().document().unwrap();
+pub(crate) fn install_event_handlers(state: &MainState) -> Result<(), JsValue> {
+    let window = web_sys::window().unwrap();
+    let document = window.document().unwrap();
+    let canvas = state.canvas.clone();
 
+    install_blur_focus(state, &canvas)?;
+
+    prevent_default_and_stop_propagation(
+        state,
+        &canvas,
+        &[
+            // Allow users to use ctrl-p for e.g. a command palette:
+            "afterprint",
+            // By default, right-clicks open a browser context menu.
+            // We don't want to do that (right clicks are handled by egui):
+            "contextmenu",
+        ],
+    )?;
+
+    install_keydown(state, &canvas)?;
+    install_keyup(state, &canvas)?;
+
+    // It seems copy/cut/paste events only work on the document,
+    // so we check if we have focus inside of the handler.
+    install_copy_cut_paste(state, &document)?;
+
+    install_mousedown(state, &canvas)?;
+    // Use `document` here to notice if the user releases a drag outside of the canvas:
+    // See https://github.com/emilk/egui/issues/3157
+    install_mousemove(state, &document)?;
+    install_mouseup(state, &document)?;
+    install_mouseleave(state, &canvas)?;
+
+    install_touchstart(state, &canvas)?;
+    // Use `document` here to notice if the user drag outside of the canvas:
+    // See https://github.com/emilk/egui/issues/3157
+    install_touchmove(state, &document)?;
+    install_touchend(state, &document)?;
+    install_touchcancel(state, &canvas)?;
+
+    install_wheel(state, &canvas)?;
+    //install_drag_and_drop(runner_ref, &canvas)?;
+    install_window_events(state, &window)?;
+    Ok(())
+}
+
+fn install_blur_focus(state: &MainState, target: &EventTarget) -> Result<(), JsValue> {
+    // NOTE: because of the text agent we sometime miss 'blur' events,
+    // so we also poll the focus state each frame in `AppRunner::handle_platform_output`.
     for event_name in ["blur", "focus"] {
         let closure = move |_event: web_sys::MouseEvent, state: &MainState| {
-            // log::debug!("{event_name:?}");
-            let has_focus = event_name == "focus";
+            log::trace!("{} {event_name:?}", state.canvas.id());
+            state.update_focus();
 
-            if !has_focus {
-                // We lost focus - good idea to save
+            if event_name == "blur" {
+                // This might be a good time to save the state
                 state.channels.send_custom(WebRunnerEvent::Save);
             }
-
-            state.channels.send_custom(WebRunnerEvent::Focus(has_focus));
-            //runner.egui_ctx().request_repaint();
         };
 
-        state.add_event_listener(&document, event_name, closure)?;
+        state.add_event_listener(target, event_name, closure)?;
+    }
+    Ok(())
+}
+
+fn install_keydown(state: &MainState, target: &EventTarget) -> Result<(), JsValue> {
+    state.add_event_listener(target, "keydown", |event: web_sys::KeyboardEvent, state| {
+        if !state.inner.borrow().has_focus {
+            return;
+        }
+
+        let modifiers = modifiers_from_kb_event(&event);
+        if !modifiers.ctrl
+                && !modifiers.command
+                // When text agent is focused, it is responsible for handling input events
+                && !state.inner.borrow().text_agent.as_ref().unwrap().has_focus()
+        {
+            if let Some(text) = text_from_keyboard_event(&event) {
+                state.channels.send(egui::Event::Text(text));
+                //state.channels.send_custom(WebRunnerEvent::Repaint);
+
+                // If this is indeed text, then prevent any other action.
+                event.prevent_default();
+
+                // Assume egui uses all key events, and don't let them propagate to parent elements.
+                event.stop_propagation();
+            }
+        }
+
+        on_keydown(event, state);
+    })
+}
+
+#[allow(clippy::needless_pass_by_value)] // So that we can pass it directly to `add_event_listener`
+pub(crate) fn on_keydown(event: web_sys::KeyboardEvent, state: &MainState) {
+    let has_focus = state.inner.borrow().has_focus;
+    if !has_focus {
+        return;
     }
 
-    state.add_event_listener(
-        &document,
-        "keydown",
-        |event: web_sys::KeyboardEvent, state| {
-            if event.is_composing() || event.key_code() == 229 {
-                // https://web.archive.org/web/20200526195704/https://www.fxsitecompat.dev/en-CA/docs/2018/keydown-and-keyup-events-are-now-fired-during-ime-composition/
-                return;
-            }
+    if event.is_composing() || event.key_code() == 229 {
+        // https://web.archive.org/web/20200526195704/https://www.fxsitecompat.dev/en-CA/docs/2018/keydown-and-keyup-events-are-now-fired-during-ime-composition/
+        return;
+    }
 
-            let modifiers = modifiers_from_kb_event(&event);
-            state
-                .channels
-                .send_custom(WebRunnerEvent::Modifiers(modifiers));
+    let modifiers = modifiers_from_kb_event(&event);
+    state
+        .channels
+        .send_custom(WebRunnerEvent::Modifiers(modifiers));
 
-            let key = event.key();
-            let egui_key = translate_key(&key);
+    let key = event.key();
+    let egui_key = translate_key(&key);
 
-            if let Some(key) = egui_key {
-                state.channels.send(egui::Event::Key {
-                    key,
-                    physical_key: None, // TODO(fornwall)
-                    pressed: true,
-                    repeat: false, // egui will fill this in for us!
-                    modifiers,
-                });
-            }
-            if !modifiers.ctrl
-                && !modifiers.command
-                && !should_ignore_key(&key)
-                // When text agent is shown, it sends text event instead.
-                && text_agent::text_agent().hidden()
-            {
-                state.channels.send(egui::Event::Text(key));
-            }
-            //runner.needs_repaint.repaint_asap();
+    if let Some(egui_key) = egui_key {
+        state.channels.send(egui::Event::Key {
+            key: egui_key,
+            physical_key: None, // TODO(fornwall)
+            pressed: true,
+            repeat: false, // egui will fill this in for us!
+            modifiers,
+        });
+        //state.channels.send_custom(WebRunnerEvent::Repaint);
 
-            let egui_wants_keyboard = state.inner.borrow().wants_keyboard_input;
+        let prevent_default = should_prevent_default_for_key(state, &modifiers, egui_key);
 
-            #[allow(clippy::if_same_then_else)]
-            let prevent_default = if egui_key == Some(egui::Key::Tab) {
-                // Always prevent moving cursor to url bar.
-                // egui wants to use tab to move to the next text field.
-                true
-            } else if matches!(
-                egui_key,
-                Some(egui::Key::P | egui::Key::S | egui::Key::O | egui::Key::F)
-            ) {
-                #[allow(clippy::needless_bool)]
-                if modifiers.ctrl || modifiers.command || modifiers.mac_cmd {
-                    true // Prevent ctrl-P opening the print dialog. Users may want to use it for a command palette.
-                } else {
-                    false // let normal P:s through
+        // log::debug!(
+        //     "On keydown {:?} {egui_key:?}, has_focus: {has_focus}, egui_wants_keyboard: {}, prevent_default: {prevent_default}",
+        //     event.key().as_str(),
+        //     runner.egui_ctx().wants_keyboard_input()
+        // );
+
+        if prevent_default {
+            event.prevent_default();
+        }
+
+        // Assume egui uses all key events, and don't let them propagate to parent elements.
+        event.stop_propagation();
+    }
+}
+
+/// If the canvas (or text agent) has focus:
+/// should we prevent the default browser event action when the user presses this key?
+fn should_prevent_default_for_key(
+    state: &MainState,
+    modifiers: &egui::Modifiers,
+    egui_key: egui::Key,
+) -> bool {
+    // NOTE: We never want to prevent:
+    // * F5 / cmd-R (refresh)
+    // * cmd-shift-C (debug tools)
+    // * cmd/ctrl-c/v/x (lest we prevent copy/paste/cut events)
+
+    // Prevent ctrl-P from opening the print dialog. Users may want to use it for a command palette.
+    if matches!(
+        egui_key,
+        egui::Key::P | egui::Key::S | egui::Key::O | egui::Key::F,
+    ) && (modifiers.ctrl || modifiers.command || modifiers.mac_cmd)
+    {
+        return true;
+    }
+
+    if egui_key == egui::Key::Space
+        && !state
+            .inner
+            .borrow()
+            .text_agent
+            .as_ref()
+            .unwrap()
+            .has_focus()
+    {
+        // Space scrolls the web page, but we don't want that while canvas has focus
+        // However, don't prevent it if text agent has focus, or we can't type space!
+        return true;
+    }
+
+    matches!(
+        egui_key,
+        // Prevent browser from focusing the next HTML element.
+        // egui uses Tab to move focus within the egui app.
+        egui::Key::Tab
+
+        // So we don't go back to previous page while canvas has focus
+        | egui::Key::Backspace
+
+        // Don't scroll web page while canvas has focus.
+        // Also, cmd-left is "back" on Mac (https://github.com/emilk/egui/issues/58)
+        | egui::Key::ArrowDown | egui::Key::ArrowLeft | egui::Key::ArrowRight |  egui::Key::ArrowUp
+    )
+}
+
+fn install_keyup(state: &MainState, target: &EventTarget) -> Result<(), JsValue> {
+    state.add_event_listener(target, "keyup", on_keyup)
+}
+
+#[allow(clippy::needless_pass_by_value)] // So that we can pass it directly to `add_event_listener`
+pub(crate) fn on_keyup(event: web_sys::KeyboardEvent, state: &MainState) {
+    let modifiers = modifiers_from_kb_event(&event);
+    state
+        .channels
+        .send_custom(WebRunnerEvent::Modifiers(modifiers));
+
+    if let Some(key) = translate_key(&event.key()) {
+        state.channels.send(egui::Event::Key {
+            key,
+            physical_key: None, // TODO(fornwall)
+            pressed: false,
+            repeat: false,
+            modifiers,
+        });
+    }
+
+    if event.key() == "Meta" || event.key() == "Control" {
+        state
+            .channels
+            .send_custom(WebRunnerEvent::CommandKeyReleased);
+    }
+
+    //state.channels.send_custom(WebRunnerEvent::Repaint);
+
+    let has_focus = state.inner.borrow().has_focus;
+    if has_focus {
+        // Assume egui uses all key events, and don't let them propagate to parent elements.
+        event.stop_propagation();
+    }
+}
+
+fn install_copy_cut_paste(state: &MainState, target: &EventTarget) -> Result<(), JsValue> {
+    #[cfg(web_sys_unstable_apis)]
+    state.add_event_listener(target, "paste", |event: web_sys::ClipboardEvent, state| {
+        if let Some(data) = event.clipboard_data() {
+            if let Ok(text) = data.get_data("text") {
+                let text = text.replace("\r\n", "\n");
+                if !text.is_empty() && state.inner.borrow().has_focus {
+                    state.channels.send(egui::Event::Paste(text));
+                    //state.channels.send_custom(WebRunnerEvent::Repaint);
                 }
-            } else if egui_wants_keyboard {
-                matches!(
-                    event.key().as_str(),
-                    "Backspace" // so we don't go back to previous page when deleting text
-                    | "ArrowDown" | "ArrowLeft" | "ArrowRight" | "ArrowUp" // cmd-left is "back" on Mac (https://github.com/emilk/egui/issues/58)
-                )
-            } else {
-                // We never want to prevent:
-                // * F5 / cmd-R (refresh)
-                // * cmd-shift-C (debug tools)
-                // * cmd/ctrl-c/v/x (or we stop copy/past/cut events)
-                false
-            };
-
-            // log::debug!(
-            //     "On key-down {:?}, egui_wants_keyboard: {}, prevent_default: {}",
-            //     event.key().as_str(),
-            //     egui_wants_keyboard,
-            //     prevent_default
-            // );
-
-            if prevent_default {
+                event.stop_propagation();
                 event.prevent_default();
-                // event.stop_propagation();
             }
-        },
-    )?;
-
-    state.add_event_listener(
-        &document,
-        "keyup",
-        |event: web_sys::KeyboardEvent, state| {
-            let modifiers = modifiers_from_kb_event(&event);
-            state
-                .channels
-                .send_custom(WebRunnerEvent::Modifiers(modifiers));
-            if let Some(key) = translate_key(&event.key()) {
-                state.channels.send(egui::Event::Key {
-                    key,
-                    physical_key: None, // TODO(fornwall)
-                    pressed: false,
-                    repeat: false,
-                    modifiers,
-                });
-            }
-            //runner.needs_repaint.repaint_asap();
-        },
-    )?;
+        }
+    })?;
 
     #[cfg(web_sys_unstable_apis)]
-    state.add_event_listener(
-        &document,
-        "paste",
-        |event: web_sys::ClipboardEvent, state| {
-            if let Some(data) = event.clipboard_data() {
-                if let Ok(text) = data.get_data("text") {
-                    let text = text.replace("\r\n", "\n");
-                    if !text.is_empty() {
-                        state.channels.send(egui::Event::Paste(text));
-                        //runner.needs_repaint.repaint_asap();
-                    }
-                    event.stop_propagation();
-                    event.prevent_default();
-                }
-            }
-        },
-    )?;
+    state.add_event_listener(target, "cut", |event: web_sys::ClipboardEvent, state| {
+        if state.inner.borrow().has_focus {
+            state.channels.send(egui::Event::Cut);
 
-    #[cfg(web_sys_unstable_apis)]
-    state.add_event_listener(&document, "cut", |event: web_sys::ClipboardEvent, state| {
-        state.channels.send(egui::Event::Cut);
+            // In Safari we are only allowed to write to the clipboard during the
+            // event callback, which is why we run the app logic here and now:
+            //runner.logic();
 
-        // In Safari we are only allowed to write to the clipboard during the
-        // event callback, which is why we run the app logic here and now:
-        //runner.logic();
-
-        // Make sure we paint the output of the above logic call asap:
-        //runner.needs_repaint.repaint_asap();
+            // Make sure we paint the output of the above logic call asap:
+            //state.channels.send_custom(WebRunnerEvent::Repaint);
+        }
 
         event.stop_propagation();
         event.prevent_default();
     })?;
 
     #[cfg(web_sys_unstable_apis)]
-    state.add_event_listener(
-        &document,
-        "copy",
-        |event: web_sys::ClipboardEvent, state| {
+    state.add_event_listener(target, "copy", |event: web_sys::ClipboardEvent, state| {
+        if state.inner.borrow().has_focus {
             state.channels.send(egui::Event::Copy);
 
             // In Safari we are only allowed to write to the clipboard during the
@@ -314,57 +488,37 @@ pub(crate) fn install_document_events(state: &MainState) -> Result<(), JsValue> 
             //runner.logic();
 
             // Make sure we paint the output of the above logic call asap:
-            //runner.needs_repaint.repaint_asap();
+            //state.channels.send_custom(WebRunnerEvent::Repaint);
+        }
 
-            event.stop_propagation();
-            event.prevent_default();
-        },
-    )?;
+        event.stop_propagation();
+        event.prevent_default();
+    })?;
 
     Ok(())
 }
 
-pub(crate) fn install_window_events(state: &MainState) -> Result<(), JsValue> {
-    let window = web_sys::window().unwrap();
-
-    for event_name in ["blur", "focus"] {
-        let closure = move |_event: web_sys::MouseEvent, state: &MainState| {
-            // log::debug!("{event_name:?}");
-            let has_focus = event_name == "focus";
-
-            if !has_focus {
-                // We lost focus - good idea to save
-                state.channels.send_custom(WebRunnerEvent::Save);
-            }
-
-            state.channels.send_custom(WebRunnerEvent::Focus(has_focus));
-            //runner.egui_ctx().request_repaint();
-        };
-
-        state.add_event_listener(&window, event_name, closure)?;
-    }
-
-    /*
-
+fn install_window_events(state: &MainState, window: &web_sys::Window) -> Result<(), JsValue> {
     // Save-on-close
-    runner_ref.add_event_listener(&window, "onbeforeunload", |_: web_sys::Event, runner| {
-        runner.save();
+    state.add_event_listener(window, "onbeforeunload", |_: web_sys::Event, state| {
+        state.channels.send_custom(WebRunnerEvent::Save);
     })?;
 
-    for event_name in &["load", "pagehide", "pageshow", "resize"] {
-        runner_ref.add_event_listener(&window, event_name, move |_: web_sys::Event, runner| {
+    // NOTE: resize is handled by `ResizeObserver` below
+    for event_name in &["load", "pagehide", "pageshow"] {
+        state.add_event_listener(window, event_name, move |_: web_sys::Event, state| {
             // log::debug!("{event_name:?}");
-            runner.needs_repaint.repaint_asap();
+            state.channels.send_custom(WebRunnerEvent::Repaint);
         })?;
     }
 
-    runner_ref.add_event_listener(&window, "hashchange", |_: web_sys::Event, runner| {
+    state.add_event_listener(window, "hashchange", |_: web_sys::Event, state| {
         // `epi::Frame::info(&self)` clones `epi::IntegrationInfo`, but we need to modify the original here
-        runner.frame.info.web_info.location.hash = location_hash();
-        runner.needs_repaint.repaint_asap(); // tell the user about the new hash
+        state
+            .channels
+            .send_custom(WebRunnerEvent::Hash(location_hash()));
+        //state.channels.send_custom(WebRunnerEvent::Repaint); // tell the user about the new hash
     })?;
-
-    */
 
     let closure = {
         let window = window.clone();
@@ -391,21 +545,54 @@ pub(crate) fn install_window_events(state: &MainState) -> Result<(), JsValue> {
     closure(web_sys::Event::new("")?, state);
     state.add_event_listener(&window, "resize", closure)?;
 
+    {
+        let window = window.clone();
+        // The canvas automatically resizes itself whenever a frame is drawn.
+        // The resizing does not take window.devicePixelRatio into account,
+        // so this mutation observer is to detect canvas resizes and correct them.
+        let callback: Closure<dyn FnMut(_)> = Closure::new(move |mutations: js_sys::Array| {
+            if PANIC_LOCK.get().is_some() {
+                return;
+            }
+            let width = window.inner_width().unwrap().as_f64().unwrap() as u32;
+            let height = window.inner_height().unwrap().as_f64().unwrap() as u32;
+            mutations.for_each(&mut |mutation, _, _| {
+                let mutation = mutation.unchecked_into::<web_sys::MutationRecord>();
+                if mutation.type_().as_str() == "attributes" {
+                    let canvas = mutation
+                        .target()
+                        .unwrap()
+                        .unchecked_into::<web_sys::HtmlCanvasElement>();
+                    if canvas.width() != width || canvas.height() != height {
+                        let _ = canvas.set_attribute("width", width.to_string().as_str());
+                        let _ = canvas.set_attribute("height", height.to_string().as_str());
+                    }
+                }
+            });
+        });
+        let observer = web_sys::MutationObserver::new(callback.as_ref().unchecked_ref())?;
+        let mut options = web_sys::MutationObserverInit::new();
+        options.attributes(true);
+        observer.observe_with_options(&state.canvas, &options)?;
+        // We don't need to unregister this mutation observer on panic because it auto-deregisters
+        // when the target (the canvas) is removed from the DOM and garbage-collected
+        callback.forget();
+    }
+
     Ok(())
 }
 
-pub(crate) fn install_color_scheme_change_event(runner_ref: &WebRunner) -> Result<(), JsValue> {
+pub(crate) fn install_color_scheme_change_event(state: &MainState) -> Result<(), JsValue> {
     let window = web_sys::window().unwrap();
 
     if let Some(media_query_list) = prefers_color_scheme_dark(&window)? {
-        runner_ref.add_event_listener::<web_sys::MediaQueryListEvent>(
+        state.add_event_listener::<web_sys::MediaQueryListEvent>(
             &media_query_list,
             "change",
-            |event, runner| {
+            |event, state| {
                 let theme = theme_from_dark_mode(event.matches());
-                runner.frame.info.system_theme = Some(theme);
-                runner.egui_ctx().set_visuals(theme.egui_visuals());
-                runner.needs_repaint.repaint_asap();
+                state.channels.send_custom(WebRunnerEvent::Theme(theme));
+                //state.channels.send_custom(WebRunnerEvent::Repaint);
             },
         )?;
     }
@@ -413,206 +600,199 @@ pub(crate) fn install_color_scheme_change_event(runner_ref: &WebRunner) -> Resul
     Ok(())
 }
 
-pub(crate) fn install_canvas_events(state: &MainState) -> Result<(), JsValue> {
-    let window = web_sys::window().unwrap();
+fn prevent_default_and_stop_propagation(
+    state: &MainState,
+    target: &EventTarget,
+    event_names: &[&'static str],
+) -> Result<(), JsValue> {
+    for event_name in event_names {
+        let closure = move |event: web_sys::MouseEvent, _state: &MainState| {
+            event.prevent_default();
+            event.stop_propagation();
+            // log::debug!("Preventing event {event_name:?}");
+        };
 
-    {
-        let prevent_default_events = [
-            // By default, right-clicks open a context menu.
-            // We don't want to do that (right clicks is handled by egui):
-            "contextmenu",
-            // Allow users to use ctrl-p for e.g. a command palette:
-            "afterprint",
-        ];
-
-        for event_name in prevent_default_events {
-            let closure = move |event: web_sys::MouseEvent, _state: &_| {
-                event.prevent_default();
-                // event.stop_propagation();
-                // log::debug!("Preventing event {event_name:?}");
-            };
-
-            state.add_event_listener(&state.canvas, event_name, closure)?;
-        }
+        state.add_event_listener(target, event_name, closure)?;
     }
 
-    state.add_event_listener(
-        &state.canvas,
-        "mousedown",
-        |event: web_sys::MouseEvent, state| {
-            let modifiers = modifiers_from_mouse_event(&event);
-            state
-                .channels
-                .send_custom(WebRunnerEvent::Modifiers(modifiers));
-            if let Some(button) = button_from_mouse_event(&event) {
-                let pos = pos_from_mouse_event(&state.canvas, &event, state.channels.zoom_factor());
-                let modifiers = modifiers_from_mouse_event(&event);
-                state.channels.send(egui::Event::PointerButton {
-                    pos,
-                    button,
-                    pressed: true,
-                    modifiers,
-                });
+    Ok(())
+}
 
-                // In Safari we are only allowed to write to the clipboard during the
-                // event callback, which is why we run the app logic here and now:
-                //runner.logic();
-
-                // Make sure we paint the output of the above logic call asap:
-                //runner.needs_repaint.repaint_asap();
-            }
-            event.stop_propagation();
-            // Note: prevent_default breaks VSCode tab focusing, hence why we don't call it here.
-        },
-    )?;
-
-    state.add_event_listener(
-        &state.canvas,
-        "mousemove",
-        |event: web_sys::MouseEvent, state| {
-            let modifiers = modifiers_from_mouse_event(&event);
-            state
-                .channels
-                .send_custom(WebRunnerEvent::Modifiers(modifiers));
+fn install_mousedown(state: &MainState, target: &EventTarget) -> Result<(), JsValue> {
+    state.add_event_listener(target, "mousedown", |event: web_sys::MouseEvent, state| {
+        let modifiers = modifiers_from_mouse_event(&event);
+        state
+            .channels
+            .send_custom(WebRunnerEvent::Modifiers(modifiers));
+        if let Some(button) = button_from_mouse_event(&event) {
             let pos = pos_from_mouse_event(&state.canvas, &event, state.channels.zoom_factor());
-            state.channels.send(egui::Event::PointerMoved(pos));
-            //runner.needs_repaint.repaint_asap();
-            event.stop_propagation();
-            event.prevent_default();
-        },
-    )?;
-
-    state.add_event_listener(
-        &state.canvas,
-        "mouseup",
-        |event: web_sys::MouseEvent, state| {
             let modifiers = modifiers_from_mouse_event(&event);
-            state
-                .channels
-                .send_custom(WebRunnerEvent::Modifiers(modifiers));
-            if let Some(button) = button_from_mouse_event(&event) {
-                let pos = pos_from_mouse_event(&state.canvas, &event, state.channels.zoom_factor());
-                state.channels.send(egui::Event::PointerButton {
-                    pos,
-                    button,
-                    pressed: false,
-                    modifiers,
-                });
-
-                // In Safari we are only allowed to write to the clipboard during the
-                // event callback, which is why we run the app logic here and now:
-                //runner.logic();
-
-                // Make sure we paint the output of the above logic call asap:
-                //runner.needs_repaint.repaint_asap();
-
-                text_agent::update_text_agent(state);
-            }
-            event.stop_propagation();
-            event.prevent_default();
-        },
-    )?;
-
-    state.add_event_listener(
-        &state.canvas,
-        "mouseleave",
-        |event: web_sys::MouseEvent, state| {
-            state.channels.send_custom(WebRunnerEvent::Save);
-
-            state.channels.send(egui::Event::PointerGone);
-            //runner.needs_repaint.repaint_asap();
-            event.stop_propagation();
-            event.prevent_default();
-        },
-    )?;
-
-    state.add_event_listener(
-        &state.canvas,
-        "touchstart",
-        |event: web_sys::TouchEvent, state| {
-            let mut inner = state.inner.borrow_mut();
-
-            inner.touch_pos = pos_from_touch_event(
-                &state.canvas,
-                &event,
-                &mut inner.touch_id,
-                state.channels.zoom_factor(),
-            );
-            state
-                .channels
-                .send_custom(WebRunnerEvent::Touch(inner.touch_id, inner.touch_pos));
-            let modifiers = modifiers_from_touch_event(&event);
             state.channels.send(egui::Event::PointerButton {
-                pos: inner.touch_pos,
-                button: egui::PointerButton::Primary,
+                pos,
+                button,
                 pressed: true,
                 modifiers,
             });
 
-            push_touches(state, egui::TouchPhase::Start, &event);
-            //runner.needs_repaint.repaint_asap();
+            // In Safari we are only allowed to write to the clipboard during the
+            // event callback, which is why we run the app logic here and now:
+            //runner.logic();
+
+            // Make sure we paint the output of the above logic call asap:
+            //state.channels.send_custom(WebRunnerEvent::Repaint);
+        }
+        event.stop_propagation();
+        // Note: prevent_default breaks VSCode tab focusing, hence why we don't call it here.
+    })
+}
+
+/// Returns true if the cursor is above the canvas, or if we're dragging something.
+/// Pass in the position in browser viewport coordinates (usually event.clientX/Y).
+fn is_interested_in_pointer_event(state: &MainState, pos: egui::Pos2) -> bool {
+    let document = web_sys::window().unwrap().document().unwrap();
+    let is_hovering_canvas = document
+        .element_from_point(pos.x, pos.y)
+        .is_some_and(|element| element.eq(&state.canvas));
+    let is_pointer_down = state.channels.is_pointer_down();
+
+    is_hovering_canvas || is_pointer_down
+}
+
+fn install_mousemove(state: &MainState, target: &EventTarget) -> Result<(), JsValue> {
+    state.add_event_listener(target, "mousemove", |event: web_sys::MouseEvent, state| {
+        let modifiers = modifiers_from_mouse_event(&event);
+        state
+            .channels
+            .send_custom(WebRunnerEvent::Modifiers(modifiers));
+
+        let pos = pos_from_mouse_event(&state.canvas, &event, state.channels.zoom_factor());
+
+        if is_interested_in_pointer_event(
+            state,
+            egui::pos2(event.client_x() as f32, event.client_y() as f32),
+        ) {
+            state.channels.send(egui::Event::PointerMoved(pos));
+            //state.channels.send_custom(WebRunnerEvent::Repaint);
             event.stop_propagation();
             event.prevent_default();
-        },
-    )?;
+        }
+    })
+}
 
-    state.add_event_listener(
-        &state.canvas,
-        "touchmove",
-        |event: web_sys::TouchEvent, state| {
-            let mut inner = state.inner.borrow_mut();
+fn install_mouseup(state: &MainState, target: &EventTarget) -> Result<(), JsValue> {
+    state.add_event_listener(target, "mouseup", |event: web_sys::MouseEvent, state| {
+        let modifiers = modifiers_from_mouse_event(&event);
+        state
+            .channels
+            .send_custom(WebRunnerEvent::Modifiers(modifiers));
 
-            inner.touch_pos = pos_from_touch_event(
-                &state.canvas,
-                &event,
-                &mut inner.touch_id,
-                state.channels.zoom_factor(),
-            );
-            state
-                .channels
-                .send_custom(WebRunnerEvent::Touch(inner.touch_id, inner.touch_pos));
-            state
-                .channels
-                .send(egui::Event::PointerMoved(inner.touch_pos));
+        let pos = pos_from_mouse_event(&state.canvas, &event, state.channels.zoom_factor());
 
-            push_touches(state, egui::TouchPhase::Move, &event);
-            //runner.needs_repaint.repaint_asap();
-            event.stop_propagation();
-            event.prevent_default();
-        },
-    )?;
-
-    state.add_event_listener(
-        &state.canvas,
-        "touchend",
-        |event: web_sys::TouchEvent, state| {
-            let inner = state.inner.borrow();
-
-            if inner.touch_id.is_some() {
-                let modifiers = modifiers_from_touch_event(&event);
-                // First release mouse to click:
+        if is_interested_in_pointer_event(
+            state,
+            egui::pos2(event.client_x() as f32, event.client_y() as f32),
+        ) {
+            if let Some(button) = button_from_mouse_event(&event) {
                 state.channels.send(egui::Event::PointerButton {
-                    pos: inner.touch_pos,
-                    button: egui::PointerButton::Primary,
+                    pos,
+                    button,
                     pressed: false,
                     modifiers,
+                });
+
+                // In Safari we are only allowed to do certain things
+                // (like playing audio, start a download, etc)
+                // on user action, such as a click.
+                // So we need to run the app logic here and now:
+                //runner.logic();
+
+                // Make sure we paint the output of the above logic call asap:
+                //state.channels.send_custom(WebRunnerEvent::Repaint);
+
+                event.prevent_default();
+                event.stop_propagation();
+            }
+        }
+    })
+}
+
+fn install_mouseleave(state: &MainState, target: &EventTarget) -> Result<(), JsValue> {
+    state.add_event_listener(target, "mouseleave", |event: web_sys::MouseEvent, state| {
+        state.channels.send_custom(WebRunnerEvent::Save);
+
+        state.channels.send(egui::Event::PointerGone);
+        //state.channels.send_custom(WebRunnerEvent::Repaint);
+        event.stop_propagation();
+        event.prevent_default();
+    })
+}
+
+fn install_touchstart(state: &MainState, target: &EventTarget) -> Result<(), JsValue> {
+    state.add_event_listener(target, "touchstart", |event: web_sys::TouchEvent, state| {
+        if let Some((pos, _)) = primary_touch_pos(state, &event, state.channels.zoom_factor()) {
+            state.channels.send(egui::Event::PointerButton {
+                pos,
+                button: egui::PointerButton::Primary,
+                pressed: true,
+                modifiers: modifiers_from_touch_event(&event),
+            });
+        }
+
+        push_touches(state, egui::TouchPhase::Start, &event);
+        //state.channels.send_custom(WebRunnerEvent::Repaint);
+        event.stop_propagation();
+        event.prevent_default();
+    })
+}
+
+fn install_touchmove(state: &MainState, target: &EventTarget) -> Result<(), JsValue> {
+    state.add_event_listener(target, "touchmove", |event: web_sys::TouchEvent, state| {
+        if let Some((pos, touch)) = primary_touch_pos(state, &event, state.channels.zoom_factor()) {
+            if is_interested_in_pointer_event(
+                state,
+                egui::pos2(touch.client_x() as f32, touch.client_y() as f32),
+            ) {
+                state.channels.send(egui::Event::PointerMoved(pos));
+
+                push_touches(state, egui::TouchPhase::Move, &event);
+                //state.channels.send_custom(WebRunnerEvent::Repaint);
+                event.stop_propagation();
+                event.prevent_default();
+            }
+        }
+    })
+}
+
+fn install_touchend(state: &MainState, target: &EventTarget) -> Result<(), JsValue> {
+    state.add_event_listener(target, "touchend", |event: web_sys::TouchEvent, state| {
+        if let Some((pos, touch)) = primary_touch_pos(state, &event, state.channels.zoom_factor()) {
+            if is_interested_in_pointer_event(
+                state,
+                egui::pos2(touch.client_x() as f32, touch.client_y() as f32),
+            ) {
+                // First release mouse to click:
+                state.channels.send(egui::Event::PointerButton {
+                    pos,
+                    button: egui::PointerButton::Primary,
+                    pressed: false,
+                    modifiers: modifiers_from_touch_event(&event),
                 });
                 // Then remove hover effect:
                 state.channels.send(egui::Event::PointerGone);
 
                 push_touches(state, egui::TouchPhase::End, &event);
-                //runner.needs_repaint.repaint_asap();
+
+                //state.channels.send_custom(WebRunnerEvent::Repaint);
+                event.stop_propagation();
+                event.prevent_default();
             }
-            event.stop_propagation();
-            event.prevent_default();
+        }
+    })
+}
 
-            // Finally, focus or blur text agent to toggle mobile keyboard:
-            text_agent::update_text_agent(state);
-        },
-    )?;
-
+fn install_touchcancel(state: &MainState, target: &EventTarget) -> Result<(), JsValue> {
     state.add_event_listener(
-        &state.canvas,
+        target,
         "touchcancel",
         |event: web_sys::TouchEvent, state| {
             push_touches(state, egui::TouchPhase::Cancel, &event);
@@ -621,89 +801,72 @@ pub(crate) fn install_canvas_events(state: &MainState) -> Result<(), JsValue> {
         },
     )?;
 
-    state.add_event_listener(
-        &state.canvas,
-        "wheel",
-        |event: web_sys::WheelEvent, state| {
-            let unit = match event.delta_mode() {
-                web_sys::WheelEvent::DOM_DELTA_PIXEL => egui::MouseWheelUnit::Point,
-                web_sys::WheelEvent::DOM_DELTA_LINE => egui::MouseWheelUnit::Line,
-                web_sys::WheelEvent::DOM_DELTA_PAGE => egui::MouseWheelUnit::Page,
-                _ => return,
-            };
-            // delta sign is flipped to match native (winit) convention.
-            let delta = -egui::vec2(event.delta_x() as f32, event.delta_y() as f32);
-            let modifiers = modifiers_from_wheel_event(&event);
+    Ok(())
+}
 
-            state.channels.send(egui::Event::MouseWheel {
-                unit,
-                delta,
-                modifiers,
-            });
+fn install_wheel(state: &MainState, target: &EventTarget) -> Result<(), JsValue> {
+    state.add_event_listener(target, "wheel", |event: web_sys::WheelEvent, state| {
+        let unit = match event.delta_mode() {
+            web_sys::WheelEvent::DOM_DELTA_PIXEL => egui::MouseWheelUnit::Point,
+            web_sys::WheelEvent::DOM_DELTA_LINE => egui::MouseWheelUnit::Line,
+            web_sys::WheelEvent::DOM_DELTA_PAGE => egui::MouseWheelUnit::Page,
+            _ => return,
+        };
 
-            let scroll_multiplier = match unit {
-                egui::MouseWheelUnit::Page => {
-                    canvas_size_in_points(&state.canvas, state.channels.zoom_factor()).y
-                }
-                egui::MouseWheelUnit::Line => {
-                    #[allow(clippy::let_and_return)]
-                    let points_per_scroll_line = 8.0; // Note that this is intentionally different from what we use in winit.
-                    points_per_scroll_line
-                }
-                egui::MouseWheelUnit::Point => 1.0,
-            };
+        let delta = -egui::vec2(event.delta_x() as f32, event.delta_y() as f32);
 
-            let mut delta = scroll_multiplier * delta;
+        let modifiers = modifiers_from_wheel_event(&event);
 
-            // Report a zoom event in case CTRL (on Windows or Linux) or CMD (on Mac) is pressed.
-            // This if-statement is equivalent to how `Modifiers.command` is determined in
-            // `modifiers_from_event()`, but we cannot directly use that fn for a [`WheelEvent`].
-            if event.ctrl_key() || event.meta_key() {
-                let factor = (delta.y / 200.0).exp();
-                state.channels.send(egui::Event::Zoom(factor));
-            } else {
-                if event.shift_key() {
-                    // Treat as horizontal scrolling.
-                    // Note: one Mac we already get horizontal scroll events when shift is down.
-                    delta = egui::vec2(delta.x + delta.y, 0.0);
-                }
+        state
+            .channels
+            .send_custom(WebRunnerEvent::Wheel(unit, delta, modifiers));
 
-                state.channels.send(egui::Event::Scroll(delta));
-            }
+        //state.channels.send_custom(WebRunnerEvent::Repaint);
+        event.stop_propagation();
+        event.prevent_default();
+    })
+}
 
-            //runner.needs_repaint.repaint_asap();
-            event.stop_propagation();
-            event.prevent_default();
-        },
-    )?;
-
-    /* Luminol's web filesystem can't read files from egui's file drag and drop system
-
-    runner_ref.add_event_listener(&canvas, "dragover", |event: web_sys::DragEvent, runner| {
+fn install_drag_and_drop(runner_ref: &WebRunner, target: &EventTarget) -> Result<(), JsValue> {
+    runner_ref.add_event_listener(target, "dragover", |event: web_sys::DragEvent, runner| {
         if let Some(data_transfer) = event.data_transfer() {
             runner.input.raw.hovered_files.clear();
-            for i in 0..data_transfer.items().length() {
-                if let Some(item) = data_transfer.items().get(i) {
+
+            // NOTE: data_transfer.files() is always empty in dragover
+
+            let items = data_transfer.items();
+            for i in 0..items.length() {
+                if let Some(item) = items.get(i) {
                     runner.input.raw.hovered_files.push(egui::HoveredFile {
                         mime: item.type_(),
                         ..Default::default()
                     });
                 }
             }
+
+            if runner.input.raw.hovered_files.is_empty() {
+                // Fallback: just preview anything. Needed on Desktop Safari.
+                runner
+                    .input
+                    .raw
+                    .hovered_files
+                    .push(egui::HoveredFile::default());
+            }
+
             runner.needs_repaint.repaint_asap();
             event.stop_propagation();
             event.prevent_default();
         }
     })?;
 
-    runner_ref.add_event_listener(&canvas, "dragleave", |event: web_sys::DragEvent, runner| {
+    runner_ref.add_event_listener(target, "dragleave", |event: web_sys::DragEvent, runner| {
         runner.input.raw.hovered_files.clear();
         runner.needs_repaint.repaint_asap();
         event.stop_propagation();
         event.prevent_default();
     })?;
 
-    runner_ref.add_event_listener(&canvas, "drop", {
+    runner_ref.add_event_listener(target, "drop", {
         let runner_ref = runner_ref.clone();
 
         move |event: web_sys::DragEvent, runner| {
@@ -759,41 +922,94 @@ pub(crate) fn install_canvas_events(state: &MainState) -> Result<(), JsValue> {
         }
     })?;
 
-    */
+    Ok(())
+}
 
-    {
-        // The canvas automatically resizes itself whenever a frame is drawn.
-        // The resizing does not take window.devicePixelRatio into account,
-        // so this mutation observer is to detect canvas resizes and correct them.
-        let window = window.clone();
-        let callback: Closure<dyn FnMut(_)> = Closure::new(move |mutations: js_sys::Array| {
-            if PANIC_LOCK.get().is_some() {
-                return;
-            }
-            let width = window.inner_width().unwrap().as_f64().unwrap() as u32;
-            let height = window.inner_height().unwrap().as_f64().unwrap() as u32;
-            mutations.for_each(&mut |mutation, _, _| {
-                let mutation = mutation.unchecked_into::<web_sys::MutationRecord>();
-                if mutation.type_().as_str() == "attributes" {
-                    let canvas = mutation
-                        .target()
-                        .unwrap()
-                        .unchecked_into::<web_sys::HtmlCanvasElement>();
-                    if canvas.width() != width || canvas.height() != height {
-                        let _ = canvas.set_attribute("width", width.to_string().as_str());
-                        let _ = canvas.set_attribute("height", height.to_string().as_str());
+/// Install a `ResizeObserver` to observe changes to the size of the canvas.
+///
+/// This is the only way to ensure a canvas size change without an associated window `resize` event
+/// actually results in a resize of the canvas.
+///
+/// The resize observer is called the by the browser at `observe` time, instead of just on the first actual resize.
+/// We use that to trigger the first `request_animation_frame` _after_ updating the size of the canvas to the correct dimensions,
+/// to avoid [#4622](https://github.com/emilk/egui/issues/4622).
+pub(crate) fn install_resize_observer(runner_ref: &WebRunner) -> Result<(), JsValue> {
+    let closure = Closure::wrap(Box::new({
+        let runner_ref = runner_ref.clone();
+        move |entries: js_sys::Array| {
+            // Only call the wrapped closure if the egui code has not panicked
+            if let Some(mut runner_lock) = runner_ref.try_lock() {
+                let canvas = runner_lock.canvas();
+                let (width, height) = match get_display_size(&entries) {
+                    Ok(v) => v,
+                    Err(err) => {
+                        log::error!("{}", super::string_from_js_value(&err));
+                        return;
                     }
-                }
-            });
-        });
-        let observer = web_sys::MutationObserver::new(callback.as_ref().unchecked_ref())?;
-        let mut options = web_sys::MutationObserverInit::new();
-        options.attributes(true);
-        observer.observe_with_options(&state.canvas, &options)?;
-        // We don't need to unregister this mutation observer on panic because it auto-deregisters
-        // when the target (the canvas) is removed from the DOM and garbage-collected
-        callback.forget();
+                };
+                canvas.set_width(width);
+                canvas.set_height(height);
+
+                // force an immediate repaint
+                runner_lock.needs_repaint.repaint_asap();
+                paint_if_needed(&mut runner_lock);
+                drop(runner_lock);
+                // we rely on the resize observer to trigger the first `request_animation_frame`:
+                if let Err(err) = runner_ref.request_animation_frame() {
+                    log::error!("{}", super::string_from_js_value(&err));
+                };
+            }
+        }
+    }) as Box<dyn FnMut(js_sys::Array)>);
+
+    let observer = web_sys::ResizeObserver::new(closure.as_ref().unchecked_ref())?;
+    let mut options = web_sys::ResizeObserverOptions::new();
+    options.box_(web_sys::ResizeObserverBoxOptions::ContentBox);
+    if let Some(runner_lock) = runner_ref.try_lock() {
+        observer.observe_with_options(&runner_lock.canvas().clone().unchecked_into(), &options);
+        drop(runner_lock);
+        runner_ref.set_resize_observer(observer, closure);
     }
 
     Ok(())
+}
+
+// Code ported to Rust from:
+// https://webglfundamentals.org/webgl/lessons/webgl-resizing-the-canvas.html
+fn get_display_size(resize_observer_entries: &js_sys::Array) -> Result<(u32, u32), JsValue> {
+    let width;
+    let height;
+    let mut dpr = web_sys::window().unwrap().device_pixel_ratio();
+
+    let entry: web_sys::ResizeObserverEntry = resize_observer_entries.at(0).dyn_into()?;
+    if JsValue::from_str("devicePixelContentBoxSize").js_in(entry.as_ref()) {
+        // NOTE: Only this path gives the correct answer for most browsers.
+        // Unfortunately this doesn't work perfectly everywhere.
+        let size: web_sys::ResizeObserverSize =
+            entry.device_pixel_content_box_size().at(0).dyn_into()?;
+        width = size.inline_size();
+        height = size.block_size();
+        dpr = 1.0; // no need to apply
+    } else if JsValue::from_str("contentBoxSize").js_in(entry.as_ref()) {
+        let content_box_size = entry.content_box_size();
+        let idx0 = content_box_size.at(0);
+        if !idx0.is_undefined() {
+            let size: web_sys::ResizeObserverSize = idx0.dyn_into()?;
+            width = size.inline_size();
+            height = size.block_size();
+        } else {
+            // legacy
+            let size = JsValue::clone(content_box_size.as_ref());
+            let size: web_sys::ResizeObserverSize = size.dyn_into()?;
+            width = size.inline_size();
+            height = size.block_size();
+        }
+    } else {
+        // legacy
+        let content_rect = entry.content_rect();
+        width = content_rect.width();
+        height = content_rect.height();
+    }
+
+    Ok(((width.round() * dpr) as u32, (height.round() * dpr) as u32))
 }

--- a/crates/eframe/src/web/input.rs
+++ b/crates/eframe/src/web/input.rs
@@ -1,14 +1,14 @@
-use super::{canvas_origin, AppRunner};
+use super::{canvas_content_rect, AppRunner, WebRunnerEvent};
 
 pub fn pos_from_mouse_event(
     canvas: &web_sys::HtmlCanvasElement,
     event: &web_sys::MouseEvent,
     zoom_factor: f32,
 ) -> egui::Pos2 {
-    let rect = canvas.get_bounding_client_rect();
+    let rect = canvas_content_rect(canvas);
     egui::Pos2 {
-        x: (event.client_x() as f32 - rect.left() as f32) / zoom_factor,
-        y: (event.client_y() as f32 - rect.top() as f32) / zoom_factor,
+        x: (event.client_x() as f32 - rect.left()) / zoom_factor,
+        y: (event.client_y() as f32 - rect.top()) / zoom_factor,
     }
 }
 
@@ -26,43 +26,59 @@ pub fn button_from_mouse_event(event: &web_sys::MouseEvent) -> Option<egui::Poin
 /// A single touch is translated to a pointer movement. When a second touch is added, the pointer
 /// should not jump to a different position. Therefore, we do not calculate the average position
 /// of all touches, but we keep using the same touch as long as it is available.
-///
-/// `touch_id_for_pos` is the [`TouchId`](egui::TouchId) of the [`Touch`](web_sys::Touch) we previously used to determine the
-/// pointer position.
-pub fn pos_from_touch_event(
-    canvas: &web_sys::HtmlCanvasElement,
+pub fn primary_touch_pos(
+    state: &super::MainState,
     event: &web_sys::TouchEvent,
-    touch_id_for_pos: &mut Option<egui::TouchId>,
     zoom_factor: f32,
-) -> egui::Pos2 {
-    let touch_for_pos = if let Some(touch_id_for_pos) = touch_id_for_pos {
-        // search for the touch we previously used for the position
-        // (unfortunately, `event.touches()` is not a rust collection):
-        (0..event.touches().length())
-            .map(|i| event.touches().get(i).unwrap())
-            .find(|touch| egui::TouchId::from(touch.identifier()) == *touch_id_for_pos)
-    } else {
-        None
-    };
-    // Use the touch found above or pick the first, or return a default position if there is no
-    // touch at all. (The latter is not expected as the current method is only called when there is
-    // at least one touch.)
-    touch_for_pos
-        .or_else(|| event.touches().get(0))
-        .map_or(Default::default(), |touch| {
-            *touch_id_for_pos = Some(egui::TouchId::from(touch.identifier()));
-            pos_from_touch(canvas_origin(canvas), &touch, zoom_factor)
-        })
+) -> Option<(egui::Pos2, web_sys::Touch)> {
+    let all_touches: Vec<_> = (0..event.touches().length())
+        .filter_map(|i| event.touches().get(i))
+        // On touchend we don't get anything in `touches`, but we still get `changed_touches`, so include those:
+        .chain((0..event.changed_touches().length()).filter_map(|i| event.changed_touches().get(i)))
+        .collect();
+
+    let mut inner = state.inner.borrow_mut();
+
+    if let Some(primary_touch) = inner.touch_id {
+        // Is the primary touch is gone?
+        if !all_touches
+            .iter()
+            .any(|touch| primary_touch == egui::TouchId::from(touch.identifier()))
+        {
+            inner.touch_id = None;
+            state
+                .channels
+                .send_custom(WebRunnerEvent::Touch(inner.touch_id));
+        }
+    }
+
+    if inner.touch_id.is_none() {
+        inner.touch_id = all_touches
+            .first()
+            .map(|touch| egui::TouchId::from(touch.identifier()));
+        state
+            .channels
+            .send_custom(WebRunnerEvent::Touch(inner.touch_id));
+    }
+
+    let primary_touch = inner.touch_id;
+
+    if let Some(primary_touch) = primary_touch {
+        for touch in all_touches {
+            if primary_touch == egui::TouchId::from(touch.identifier()) {
+                let canvas_rect = canvas_content_rect(&state.canvas);
+                return Some((pos_from_touch(canvas_rect, &touch, zoom_factor), touch));
+            }
+        }
+    }
+
+    None
 }
 
-fn pos_from_touch(
-    canvas_origin: egui::Pos2,
-    touch: &web_sys::Touch,
-    zoom_factor: f32,
-) -> egui::Pos2 {
+fn pos_from_touch(canvas_rect: egui::Rect, touch: &web_sys::Touch, zoom_factor: f32) -> egui::Pos2 {
     egui::Pos2 {
-        x: (touch.page_x() as f32 - canvas_origin.x) / zoom_factor,
-        y: (touch.page_y() as f32 - canvas_origin.y) / zoom_factor,
+        x: (touch.client_x() as f32 - canvas_rect.left()) / zoom_factor,
+        y: (touch.client_y() as f32 - canvas_rect.top()) / zoom_factor,
     }
 }
 
@@ -71,54 +87,64 @@ pub fn push_touches(
     phase: egui::TouchPhase,
     event: &web_sys::TouchEvent,
 ) {
-    let canvas_origin = canvas_origin(&state.canvas);
+    let canvas_rect = canvas_content_rect(&state.canvas);
     for touch_idx in 0..event.changed_touches().length() {
         if let Some(touch) = event.changed_touches().item(touch_idx) {
             state.channels.send(egui::Event::Touch {
                 device_id: egui::TouchDeviceId(0),
                 id: egui::TouchId::from(touch.identifier()),
                 phase,
-                pos: pos_from_touch(canvas_origin, &touch, state.channels.zoom_factor()),
+                pos: pos_from_touch(canvas_rect, &touch, state.channels.zoom_factor()),
                 force: Some(touch.force()),
             });
         }
     }
 }
 
-/// Web sends all keys as strings, so it is up to us to figure out if it is
-/// a real text input or the name of a key.
-pub fn should_ignore_key(key: &str) -> bool {
+/// The text input from a keyboard event (e.g. `X` when pressing the `X` key).
+pub fn text_from_keyboard_event(event: &web_sys::KeyboardEvent) -> Option<String> {
+    let key = event.key();
+
     let is_function_key = key.starts_with('F') && key.len() > 1;
-    is_function_key
-        || matches!(
-            key,
-            "Alt"
-                | "ArrowDown"
-                | "ArrowLeft"
-                | "ArrowRight"
-                | "ArrowUp"
-                | "Backspace"
-                | "CapsLock"
-                | "ContextMenu"
-                | "Control"
-                | "Delete"
-                | "End"
-                | "Enter"
-                | "Esc"
-                | "Escape"
-                | "GroupNext" // https://github.com/emilk/egui/issues/510
-                | "Help"
-                | "Home"
-                | "Insert"
-                | "Meta"
-                | "NumLock"
-                | "PageDown"
-                | "PageUp"
-                | "Pause"
-                | "ScrollLock"
-                | "Shift"
-                | "Tab"
-        )
+    if is_function_key {
+        return None;
+    }
+
+    let is_control_key = matches!(
+        key.as_str(),
+        "Alt"
+      | "ArrowDown"
+      | "ArrowLeft"
+      | "ArrowRight"
+      | "ArrowUp"
+      | "Backspace"
+      | "CapsLock"
+      | "ContextMenu"
+      | "Control"
+      | "Delete"
+      | "End"
+      | "Enter"
+      | "Esc"
+      | "Escape"
+      | "GroupNext" // https://github.com/emilk/egui/issues/510
+      | "Help"
+      | "Home"
+      | "Insert"
+      | "Meta"
+      | "NumLock"
+      | "PageDown"
+      | "PageUp"
+      | "Pause"
+      | "ScrollLock"
+      | "Shift"
+      | "Tab"
+    );
+
+    if is_control_key {
+        return None;
+    }
+
+    Some(key)
 }
 
 /// Web sends all keys as strings, so it is up to us to figure out if it is

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -408,7 +408,7 @@ impl MainState {
                 .has_focus();
         let mut inner = self.inner.borrow_mut();
         if inner.has_focus != has_focus {
-            log::trace!("{} Focus changed to {has_focus}", self.canvas.id());
+            log::trace!("Focus changed to {has_focus}");
             inner.has_focus = has_focus;
 
             if !has_focus {

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -181,7 +181,7 @@ fn set_cursor_icon(cursor: egui::CursorIcon) -> Option<()> {
 }
 
 /// Set the clipboard text.
-//#[cfg(web_sys_unstable_apis)]
+#[cfg(web_sys_unstable_apis)]
 fn set_clipboard_text(s: &str) {
     if let Some(window) = web_sys::window() {
         if let Some(clipboard) = window.navigator().clipboard() {
@@ -496,7 +496,7 @@ enum WebRunnerEvent {
 /// A custom output that can be sent from the worker thread to the main thread.
 enum WebRunnerOutput {
     /// Miscellaneous egui output events
-    PlatformOutput(egui::PlatformOutput, bool, bool),
+    PlatformOutput(egui::PlatformOutput, bool),
     /// The runner wants to read a key from storage
     StorageGet(String, oneshot::Sender<Option<String>>),
     /// The runner wants to write a key to storage

--- a/crates/eframe/src/web/mod.rs
+++ b/crates/eframe/src/web/mod.rs
@@ -341,13 +341,6 @@ pub struct MainStateInner {
     /// The position relative to the canvas of the last received touch event. If no touch event has
     /// been received yet, this will be (0, 0).
     touch_pos: egui::Pos2,
-    /// If the user is typing something, the position of the text cursor (for IME) in screen
-    /// coordinates.
-    ime: Option<egui::output::IMEOutput>,
-    /// Whether or not the user is editing a mutable egui text box.
-    mutable_text_under_cursor: bool,
-    /// Whether or not egui is trying to receive text input.
-    wants_keyboard_input: bool,
     /// This should be set to `true` (HTML canvas is focused) or `false` (HTML canvas is blurred)
     /// every frame.
     has_focus: bool,

--- a/crates/eframe/src/web/text_agent.rs
+++ b/crates/eframe/src/web/text_agent.rs
@@ -7,6 +7,8 @@ use wasm_bindgen::prelude::*;
 
 use super::{AppRunner, MainState, WebRunner};
 
+const AGENT_ID: &str = "luminol-text-agent";
+
 pub struct TextAgent {
     input: web_sys::HtmlInputElement,
     prev_ime_output: Cell<Option<egui::output::IMEOutput>>,
@@ -17,10 +19,15 @@ impl TextAgent {
     pub fn attach(state: &super::MainState) -> Result<Self, JsValue> {
         let document = web_sys::window().unwrap().document().unwrap();
 
+        if let Some(input) = document.get_element_by_id(AGENT_ID) {
+            input.remove();
+        }
+
         // create an `<input>` element
         let input = document
             .create_element("input")?
             .dyn_into::<web_sys::HtmlInputElement>()?;
+        input.set_id(AGENT_ID);
         input.set_type("text");
 
         // append it to `<body>` and hide it outside of the viewport

--- a/crates/eframe/src/web/text_agent.rs
+++ b/crates/eframe/src/web/text_agent.rs
@@ -1,251 +1,188 @@
-//! The text agent is an `<input>` element used to trigger
-//! mobile keyboard and IME input.
-//!
-use std::{cell::Cell, rc::Rc};
+//! The text agent is a hidden `<input>` element used to capture
+//! IME and mobile keyboard input events.
+
+use std::cell::Cell;
 
 use wasm_bindgen::prelude::*;
 
-use super::{AppRunner, WebRunner};
+use super::{AppRunner, MainState, WebRunner};
 
-static AGENT_ID: &str = "egui_text_agent";
-
-pub fn text_agent() -> web_sys::HtmlInputElement {
-    web_sys::window()
-        .unwrap()
-        .document()
-        .unwrap()
-        .get_element_by_id(AGENT_ID)
-        .unwrap()
-        .dyn_into()
-        .unwrap()
+pub struct TextAgent {
+    input: web_sys::HtmlInputElement,
+    prev_ime_output: Cell<Option<egui::output::IMEOutput>>,
 }
 
-/// Text event handler,
-pub fn install_text_agent(state: &super::MainState) -> Result<(), JsValue> {
-    let window = web_sys::window().unwrap();
-    let document = window.document().unwrap();
-    let body = document.body().expect("document should have a body");
-    if let Some(input) = document.get_element_by_id(AGENT_ID) {
-        input.remove();
-    }
-    let input = document
-        .create_element("input")?
-        .dyn_into::<web_sys::HtmlInputElement>()?;
-    let input = std::rc::Rc::new(input);
-    input.set_id(AGENT_ID);
-    let is_composing = Rc::new(Cell::new(false));
-    {
+impl TextAgent {
+    /// Attach the agent to the document.
+    pub fn attach(state: &super::MainState) -> Result<Self, JsValue> {
+        let document = web_sys::window().unwrap().document().unwrap();
+
+        // create an `<input>` element
+        let input = document
+            .create_element("input")?
+            .dyn_into::<web_sys::HtmlInputElement>()?;
+        input.set_type("text");
+
+        // append it to `<body>` and hide it outside of the viewport
         let style = input.style();
-        // Transparent
-        style.set_property("opacity", "0").unwrap();
-        // Hide under canvas
-        style.set_property("z-index", "-1").unwrap();
-    }
-    // Set size as small as possible, in case user may click on it.
-    input.set_size(1);
-    input.set_autofocus(true);
-    input.set_hidden(true);
+        style.set_property("opacity", "0")?;
+        style.set_property("width", "1px")?;
+        style.set_property("height", "1px")?;
+        style.set_property("position", "absolute")?;
+        style.set_property("top", "0")?;
+        style.set_property("left", "0")?;
+        document.body().unwrap().append_child(&input)?;
 
-    // When IME is off
-    state.add_event_listener(&input, "input", {
-        let input_clone = input.clone();
-        let is_composing = is_composing.clone();
+        // attach event listeners
 
-        move |_event: web_sys::InputEvent, state| {
-            let text = input_clone.value();
-            if !text.is_empty() && !is_composing.get() {
-                input_clone.set_value("");
-                state.channels.send(egui::Event::Text(text));
-                //runner.needs_repaint.repaint_asap();
-            }
-        }
-    })?;
-
-    {
-        // When IME is on, handle composition event
-        state.add_event_listener(&input, "compositionstart", {
-            let input_clone = input.clone();
-            let is_composing = is_composing.clone();
-
-            move |_event: web_sys::CompositionEvent, state| {
-                is_composing.set(true);
-                input_clone.set_value("");
-
-                state.channels.send(egui::Event::CompositionStart);
-                //runner.needs_repaint.repaint_asap();
-            }
-        })?;
-
-        state.add_event_listener(
-            &input,
-            "compositionupdate",
-            move |event: web_sys::CompositionEvent, state| {
-                if let Some(event) = event.data().map(egui::Event::CompositionUpdate) {
+        let on_input = {
+            let input = input.clone();
+            move |event: web_sys::InputEvent, state: &MainState| {
+                let text = input.value();
+                // if `is_composing` is true, then user is using IME, for example: emoji, pinyin, kanji, hangul, etc.
+                // In that case, the browser emits both `input` and `compositionupdate` events,
+                // and we need to ignore the `input` event.
+                if !text.is_empty() && !event.is_composing() {
+                    input.set_value("");
+                    let event = egui::Event::Text(text);
                     state.channels.send(event);
-                    //runner.needs_repaint.repaint_asap();
-                }
-            },
-        )?;
-
-        state.add_event_listener(&input, "compositionend", {
-            let input_clone = input.clone();
-
-            move |event: web_sys::CompositionEvent, state| {
-                is_composing.set(false);
-                input_clone.set_value("");
-
-                if let Some(event) = event.data().map(egui::Event::CompositionEnd) {
-                    state.channels.send(event);
-                    //runner.needs_repaint.repaint_asap();
+                    //state.channels.send_custom(WebRunnerEvent::Repaint);
                 }
             }
-        })?;
-    }
+        };
 
-    // When input lost focus, focus on it again.
-    // It is useful when user click somewhere outside canvas.
-    let input_refocus = input.clone();
-    state.add_event_listener(
-        &input,
-        "focusout",
-        move |_event: web_sys::MouseEvent, _state| {
-            // Delay 10 ms, and focus again.
-            let input_refocus = input_refocus.clone();
-            call_after_delay(std::time::Duration::from_millis(10), move || {
-                input_refocus.focus().ok();
-            });
-        },
-    )?;
-
-    body.append_child(&input)?;
-
-    Ok(())
-}
-
-/// Focus or blur text agent to toggle mobile keyboard.
-pub fn update_text_agent(state: &super::MainState) -> Option<()> {
-    let inner = state.inner.borrow();
-
-    use web_sys::HtmlInputElement;
-    let window = web_sys::window()?;
-    let document = window.document()?;
-    let input: HtmlInputElement = document.get_element_by_id(AGENT_ID)?.dyn_into().unwrap();
-    let canvas_style = state.canvas.style();
-
-    if inner.mutable_text_under_cursor {
-        let is_already_editing = input.hidden();
-        if is_already_editing {
-            input.set_hidden(false);
-            input.focus().ok()?;
-
-            // Move up canvas so that text edit is shown at ~30% of screen height.
-            // Only on touch screens, when keyboard popups.
-            if inner.touch_id.is_some() {
-                let window_height = window.inner_height().ok()?.as_f64()? as f32;
-                let current_rel = inner.touch_pos.y / window_height;
-
-                // estimated amount of screen covered by keyboard
-                let keyboard_fraction = 0.5;
-
-                if current_rel > keyboard_fraction {
-                    // below the keyboard
-
-                    let target_rel = 0.3;
-
-                    // Note: `delta` is negative, since we are moving the canvas UP
-                    let delta = target_rel - current_rel;
-
-                    let delta = delta.max(-keyboard_fraction); // Don't move it crazy much
-
-                    let new_pos_percent = format!("{}%", (delta * 100.0).round());
-
-                    canvas_style.set_property("position", "absolute").ok()?;
-                    canvas_style.set_property("top", &new_pos_percent).ok()?;
-                }
+        let on_composition_start = {
+            let input = input.clone();
+            move |_: web_sys::CompositionEvent, state: &MainState| {
+                input.set_value("");
+                let event = egui::Event::Ime(egui::ImeEvent::Enabled);
+                state.channels.send(event);
+                // Repaint moves the text agent into place,
+                // see `move_to` in `AppRunner::handle_platform_output`.
+                //state.channels.send_custom(WebRunnerEvent::Repaint);
             }
-        }
+        };
 
-        // Blur and refocus the text agent (it gets refocused in the "focusout" event listener
-        // after we blur it here), otherwise in Firefox, IME composition sometimes causes the IME
-        // window to open in the wrong position
-        call_after_delay(std::time::Duration::from_millis(0), move || {
-            if input.blur().is_ok() {
-                call_after_delay(std::time::Duration::from_millis(20), move || {
-                    let _ = input.blur();
-                });
+        let on_composition_update = {
+            move |event: web_sys::CompositionEvent, state: &MainState| {
+                let Some(text) = event.data() else { return };
+                let event = egui::Event::Ime(egui::ImeEvent::Preedit(text));
+                state.channels.send(event);
+                //state.channels.send_custom(WebRunnerEvent::Repaint);
             }
-        });
-    } else {
-        // Holding the runner lock while calling input.blur() causes a panic.
-        // This is most probably caused by the browser running the event handler
-        // for the triggered blur event synchronously, meaning that the mutex
-        // lock does not get dropped by the time another event handler is called.
-        //
-        // Why this didn't exist before #1290 is a mystery to me, but it exists now
-        // and this apparently is the fix for it
-        //
-        // ¯\_(ツ)_/¯ - @DusterTheFirst
+        };
 
-        // So since we are inside a runner lock here, we just postpone the blur/hide:
+        let on_composition_end = {
+            let input = input.clone();
+            move |event: web_sys::CompositionEvent, state: &MainState| {
+                let Some(text) = event.data() else { return };
+                input.set_value("");
+                let event = egui::Event::Ime(egui::ImeEvent::Commit(text));
+                state.channels.send(event);
+                //state.channels.send_custom(WebRunnerEvent::Repaint);
+            }
+        };
 
-        call_after_delay(std::time::Duration::from_millis(0), move || {
-            input.blur().ok();
-            input.set_hidden(true);
-            canvas_style.set_property("position", "absolute").ok();
-            canvas_style.set_property("top", "0%").ok(); // move back to normal position
-        });
-    }
-    Some(())
-}
+        state.add_event_listener(&input, "input", on_input)?;
+        state.add_event_listener(&input, "compositionstart", on_composition_start)?;
+        state.add_event_listener(&input, "compositionupdate", on_composition_update)?;
+        state.add_event_listener(&input, "compositionend", on_composition_end)?;
 
-fn call_after_delay(delay: std::time::Duration, f: impl FnOnce() + 'static) {
-    use wasm_bindgen::prelude::*;
-    let window = web_sys::window().unwrap();
-    let closure = Closure::once(f);
-    let delay_ms = delay.as_millis() as _;
-    window
-        .set_timeout_with_callback_and_timeout_and_arguments_0(
-            closure.as_ref().unchecked_ref(),
-            delay_ms,
-        )
-        .unwrap();
-    closure.forget(); // We must forget it, or else the callback is canceled on drop
-}
+        // The canvas doesn't get keydown/keyup events when the text agent is focused,
+        // so we need to forward them to the runner:
+        state.add_event_listener(&input, "keydown", super::events::on_keydown)?;
+        state.add_event_listener(&input, "keyup", super::events::on_keyup)?;
 
-/// If context is running under mobile device?
-fn is_mobile() -> Option<bool> {
-    const MOBILE_DEVICE: [&str; 6] = ["Android", "iPhone", "iPad", "iPod", "webOS", "BlackBerry"];
-
-    let user_agent = web_sys::window()?.navigator().user_agent().ok()?;
-    let is_mobile = MOBILE_DEVICE.iter().any(|&name| user_agent.contains(name));
-    Some(is_mobile)
-}
-
-// Move text agent to text cursor's position, on desktop/laptop,
-// candidate window moves following text element (agent),
-// so it appears that the IME candidate window moves with text cursor.
-// On mobile devices, there is no need to do that.
-pub fn move_text_cursor(
-    ime: Option<egui::output::IMEOutput>,
-    canvas: &web_sys::HtmlCanvasElement,
-) -> Option<()> {
-    let style = text_agent().style();
-    // Note: moving agent on mobile devices will lead to unpredictable scroll.
-    if is_mobile() == Some(false) {
-        ime.as_ref().and_then(|ime| {
-            let egui::Pos2 { x, y } = ime.cursor_rect.left_top();
-
-            let bounding_rect = text_agent().get_bounding_client_rect();
-            let y = (y + (canvas.scroll_top() + canvas.offset_top()) as f32)
-                .min(canvas.client_height() as f32 - bounding_rect.height() as f32);
-            let x = x + (canvas.scroll_left() + canvas.offset_left()) as f32;
-            style.set_property("position", "absolute").ok()?;
-            style.set_property("top", &format!("{y}px")).ok()?;
-            style.set_property("left", &format!("{x}px")).ok()
+        Ok(Self {
+            input,
+            prev_ime_output: Default::default(),
         })
-    } else {
-        style.set_property("position", "absolute").ok()?;
-        style.set_property("top", "0px").ok()?;
-        style.set_property("left", "0px").ok()
     }
+
+    pub fn move_to(
+        &self,
+        ime: Option<egui::output::IMEOutput>,
+        canvas: &web_sys::HtmlCanvasElement,
+    ) -> Result<(), JsValue> {
+        // Mobile keyboards don't follow the text input it's writing to,
+        // instead typically being fixed in place on the bottom of the screen,
+        // so don't bother moving the text agent on mobile.
+        if is_mobile() {
+            return Ok(());
+        }
+
+        // Don't move the text agent unless the position actually changed:
+        if self.prev_ime_output.get() == ime {
+            return Ok(());
+        }
+        self.prev_ime_output.set(ime);
+
+        let Some(ime) = ime else { return Ok(()) };
+
+        let canvas_rect = super::canvas_content_rect(canvas);
+        let cursor_rect = ime.cursor_rect.translate(canvas_rect.min.to_vec2());
+
+        let style = self.input.style();
+
+        // This is where the IME input will point to:
+        style.set_property("left", &format!("{}px", cursor_rect.center().x))?;
+        style.set_property("top", &format!("{}px", cursor_rect.center().y))?;
+
+        Ok(())
+    }
+
+    pub fn set_focus(&self, on: bool) {
+        if on {
+            self.focus();
+        } else {
+            self.blur();
+        }
+    }
+
+    pub fn has_focus(&self) -> bool {
+        super::has_focus(&self.input)
+    }
+
+    pub fn focus(&self) {
+        if self.has_focus() {
+            return;
+        }
+
+        log::trace!("Focusing text agent");
+
+        if let Err(err) = self.input.focus() {
+            log::error!("failed to set focus: {}", super::string_from_js_value(&err));
+        };
+    }
+
+    pub fn blur(&self) {
+        if !self.has_focus() {
+            return;
+        }
+
+        log::trace!("Blurring text agent");
+
+        if let Err(err) = self.input.blur() {
+            log::error!("failed to set focus: {}", super::string_from_js_value(&err));
+        };
+    }
+}
+
+impl Drop for TextAgent {
+    fn drop(&mut self) {
+        self.input.remove();
+    }
+}
+
+/// Returns `true` if the app is likely running on a mobile device.
+fn is_mobile() -> bool {
+    fn try_is_mobile() -> Option<bool> {
+        const MOBILE_DEVICE: [&str; 6] =
+            ["Android", "iPhone", "iPad", "iPod", "webOS", "BlackBerry"];
+
+        let user_agent = web_sys::window()?.navigator().user_agent().ok()?;
+        let is_mobile = MOBILE_DEVICE.iter().any(|&name| user_agent.contains(name));
+        Some(is_mobile)
+    }
+    try_is_mobile().unwrap_or(false)
 }

--- a/crates/eframe/src/web/web_logger.rs
+++ b/crates/eframe/src/web/web_logger.rs
@@ -38,6 +38,8 @@ impl log::Log for WebLogger {
     }
 
     fn log(&self, record: &log::Record<'_>) {
+        #![allow(clippy::match_same_arms)]
+
         if !self.enabled(record.metadata()) {
             return;
         }
@@ -50,7 +52,9 @@ impl log::Log for WebLogger {
         };
 
         match record.level() {
-            log::Level::Trace => console::trace(&msg),
+            // NOTE: the `console::trace` includes a stack trace, which is super-noisy.
+            log::Level::Trace => console::debug(&msg),
+
             log::Level::Debug => console::debug(&msg),
             log::Level::Info => console::info(&msg),
             log::Level::Warn => console::warn(&msg),

--- a/crates/eframe/src/web/web_runner.rs
+++ b/crates/eframe/src/web/web_runner.rs
@@ -98,17 +98,8 @@ impl WebRunner {
                 };
 
                 match command {
-                    super::WebRunnerOutput::PlatformOutput(
-                        output,
-                        screen_reader_enabled,
-                        wants_keyboard_input,
-                    ) => {
-                        AppRunner::handle_platform_output(
-                            &state,
-                            output,
-                            screen_reader_enabled,
-                            wants_keyboard_input,
-                        );
+                    super::WebRunnerOutput::PlatformOutput(output, screen_reader_enabled) => {
+                        AppRunner::handle_platform_output(&state, output, screen_reader_enabled);
                     }
 
                     super::WebRunnerOutput::StorageGet(key, oneshot_tx) => {

--- a/crates/eframe/src/web/web_runner.rs
+++ b/crates/eframe/src/web/web_runner.rs
@@ -1,13 +1,10 @@
-use std::{
-    cell::{Cell, RefCell},
-    rc::Rc,
-};
+use std::{cell::RefCell, rc::Rc};
 
 use wasm_bindgen::prelude::*;
 
 use crate::{epi, App};
 
-use super::{events, AppRunner, PanicHandler};
+use super::{events, text_agent::TextAgent, AppRunner, PanicHandler};
 
 /// This is how `eframe` runs your wepp application
 ///
@@ -28,8 +25,10 @@ pub struct WebRunner {
     /// the panic handler, since they aren't `Send`.
     events_to_unsubscribe: Rc<RefCell<Vec<EventToUnsubscribe>>>,
 
-    /// Used in `destroy` to cancel a pending frame.
-    request_animation_frame_id: Cell<Option<i32>>,
+    /// Current animation frame in flight.
+    frame: Rc<RefCell<Option<AnimationFrameRequest>>>,
+
+    resize_observer: Rc<RefCell<Option<ResizeObserverContext>>>,
 }
 
 impl WebRunner {
@@ -47,7 +46,8 @@ impl WebRunner {
             panic_handler,
             runner: Rc::new(RefCell::new(None)),
             events_to_unsubscribe: Rc::new(RefCell::new(Default::default())),
-            request_animation_frame_id: Cell::new(None),
+            frame: Default::default(),
+            resize_observer: Default::default(),
         }
     }
 
@@ -56,6 +56,8 @@ impl WebRunner {
     pub fn setup_main_thread_hooks(
         state: super::MainState,
     ) -> Result<std::sync::Arc<parking_lot::Mutex<Option<oneshot::Sender<()>>>>, JsValue> {
+        state.inner.borrow_mut().text_agent = Some(TextAgent::attach(&state)?);
+
         let (panic_tx, panic_rx) = oneshot::channel();
 
         wasm_bindgen_futures::spawn_local(async move {
@@ -72,11 +74,16 @@ impl WebRunner {
             });
         });
 
+        events::install_event_handlers(&state)?;
+        events::install_color_scheme_change_event(&state)?;
+
         {
-            events::install_canvas_events(&state)?;
-            events::install_document_events(&state)?;
-            events::install_window_events(&state)?;
-            super::text_agent::install_text_agent(&state)?;
+            // Make sure the canvas can be given focus.
+            // https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex
+            state.canvas.set_tab_index(0);
+
+            // Don't outline the canvas when it has focus:
+            state.canvas.style().set_property("outline", "none")?;
         }
 
         wasm_bindgen_futures::spawn_local(async move {
@@ -120,7 +127,7 @@ impl WebRunner {
     /// Create the application, install callbacks, and start running the app.
     ///
     /// # Errors
-    /// Failing to initialize graphics.
+    /// Failing to initialize graphics, or failure to create app.
     pub async fn start(
         &self,
         canvas: web_sys::OffscreenCanvas,
@@ -131,11 +138,10 @@ impl WebRunner {
         self.destroy();
 
         let runner = AppRunner::new(canvas, web_options, app_creator, worker_options).await?;
+
         self.runner.replace(Some(runner));
 
-        {
-            self.request_animation_frame()?;
-        }
+        self.request_animation_frame()?;
 
         Ok(())
     }
@@ -165,15 +171,20 @@ impl WebRunner {
                 }
             }
         }
+
+        if let Some(context) = self.resize_observer.take() {
+            context.resize_observer.disconnect();
+            drop(context.closure);
+        }
     }
 
     /// Shut down eframe and clean up resources.
     pub fn destroy(&self) {
         self.unsubscribe_from_all_events();
 
-        if let Some(id) = self.request_animation_frame_id.get() {
+        if let Some(frame) = self.frame.take() {
             let window = web_sys::window().unwrap();
-            window.cancel_animation_frame(id).ok();
+            window.cancel_animation_frame(frame.id).ok();
         }
 
         if let Some(runner) = self.runner.replace(None) {
@@ -248,20 +259,67 @@ impl WebRunner {
         Ok(())
     }
 
+    /// Request an animation frame from the browser in which we can perform a paint.
+    ///
+    /// It is safe to call `request_animation_frame` multiple times in quick succession,
+    /// this function guarantees that only one animation frame is scheduled at a time.
     pub(crate) fn request_animation_frame(&self) -> Result<(), wasm_bindgen::JsValue> {
+        if self.frame.borrow().is_some() {
+            // there is already an animation frame in flight
+            return Ok(());
+        }
+
         let worker = luminol_web::bindings::worker().unwrap();
         let closure = Closure::once({
             let runner_ref = self.clone();
-            move || events::paint_and_schedule(&runner_ref)
+            move || {
+                // We can paint now, so clear the animation frame.
+                // This drops the `closure` and allows another
+                // animation frame to be scheduled
+                let _ = runner_ref.frame.take();
+                events::paint_and_schedule(&runner_ref)
+            }
         });
+
         let id = worker.request_animation_frame(closure.as_ref().unchecked_ref())?;
-        self.request_animation_frame_id.set(Some(id));
-        closure.forget(); // We must forget it, or else the callback is canceled on drop
+        self.frame.borrow_mut().replace(AnimationFrameRequest {
+            id,
+            _closure: closure,
+        });
+
         Ok(())
+    }
+
+    pub(crate) fn set_resize_observer(
+        &self,
+        resize_observer: web_sys::ResizeObserver,
+        closure: Closure<dyn FnMut(js_sys::Array)>,
+    ) {
+        self.resize_observer
+            .borrow_mut()
+            .replace(ResizeObserverContext {
+                resize_observer,
+                closure,
+            });
     }
 }
 
 // ----------------------------------------------------------------------------
+
+// https://rustwasm.github.io/wasm-bindgen/api/wasm_bindgen/closure/struct.Closure.html#using-fnonce-and-closureonce-with-requestanimationframe
+struct AnimationFrameRequest {
+    /// Represents the ID of a frame in flight.
+    id: i32,
+
+    /// The callback given to `request_animation_frame`, stored here both to prevent it
+    /// from being canceled, and from having to `.forget()` it.
+    _closure: Closure<dyn FnMut() -> Result<(), JsValue>>,
+}
+
+struct ResizeObserverContext {
+    resize_observer: web_sys::ResizeObserver,
+    closure: Closure<dyn FnMut(js_sys::Array)>,
+}
 
 pub(super) struct TargetEvent {
     pub(super) target: web_sys::EventTarget,

--- a/crates/eframe/src/web/web_runner.rs
+++ b/crates/eframe/src/web/web_runner.rs
@@ -56,7 +56,9 @@ impl WebRunner {
     pub fn setup_main_thread_hooks(
         state: super::MainState,
     ) -> Result<std::sync::Arc<parking_lot::Mutex<Option<oneshot::Sender<()>>>>, JsValue> {
-        state.inner.borrow_mut().text_agent = Some(TextAgent::attach(&state)?);
+        if state.text_agent.set(TextAgent::attach(&state)?).is_err() {
+            panic!("failed to set text agent");
+        }
 
         let (panic_tx, panic_rx) = oneshot::channel();
 

--- a/crates/egui-wgpu/CHANGELOG.md
+++ b/crates/egui-wgpu/CHANGELOG.md
@@ -6,6 +6,15 @@ This file is updated upon each release.
 Changes since the last release can be found at <https://github.com/emilk/egui/compare/latest...HEAD> or by running the `scripts/generate_changelog.py` script.
 
 
+## 0.28.1 - 2024-07-05
+Nothing new
+
+
+## 0.28.0 - 2024-07-03
+* Update to wgpu 0.20 [#4433](https://github.com/emilk/egui/pull/4433) by [@KeKsBoTer](https://github.com/KeKsBoTer)
+* Fix doclinks in egui-wgpu docs [#4677](https://github.com/emilk/egui/pull/4677) by [@emilk](https://github.com/emilk)
+
+
 ## 0.27.2 - 2024-04-02
 * Nothing new
 

--- a/crates/egui-wgpu/Cargo.toml
+++ b/crates/egui-wgpu/Cargo.toml
@@ -23,6 +23,9 @@ include = [
   "Cargo.toml",
 ]
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 all-features = true
 
@@ -47,7 +50,8 @@ x11 = ["winit?/x11"]
 egui = { workspace = true }
 epaint = { workspace = true, features = ["bytemuck"] }
 
-bytemuck = "1.7"
+ahash.workspace = true
+bytemuck.workspace = true
 document-features.workspace = true
 log.workspace = true
 thiserror.workspace = true

--- a/crates/egui-wgpu/README.md
+++ b/crates/egui-wgpu/README.md
@@ -1,5 +1,5 @@
 > [!IMPORTANT]
-> luminol-egui-wgpu is currently based on emilk/egui@0.27.2
+> luminol-egui-wgpu is currently based on emilk/egui@0.28.1
 
 > [!NOTE]
 > This is Luminol's modified version of egui-wgpu. The original version is dual-licensed under MIT and Apache 2.0.

--- a/crates/egui-wgpu/src/lib.rs
+++ b/crates/egui-wgpu/src/lib.rs
@@ -83,7 +83,7 @@ pub struct RenderState {
 }
 
 impl RenderState {
-    /// Creates a new `RenderState`, containing everything needed for drawing egui with wgpu.
+    /// Creates a new [`RenderState`], containing everything needed for drawing egui with wgpu.
     ///
     /// # Errors
     /// Wgpu initialization may fail due to incompatible hardware or driver for a given config.

--- a/crates/egui-wgpu/src/winit.rs
+++ b/crates/egui-wgpu/src/winit.rs
@@ -1,3 +1,6 @@
+#![allow(clippy::missing_errors_doc)]
+#![allow(clippy::undocumented_unsafe_blocks)]
+
 use std::{num::NonZeroU32, sync::Arc};
 
 use egui::{ViewportId, ViewportIdMap, ViewportIdSet};
@@ -206,7 +209,7 @@ impl Painter {
 
         if let Some(window) = window {
             let size = window.inner_size();
-            if self.surfaces.get(&viewport_id).is_none() {
+            if !self.surfaces.contains_key(&viewport_id) {
                 let surface = self.instance.create_surface(window)?;
                 self.add_surface(surface, viewport_id, size).await?;
             }
@@ -232,7 +235,7 @@ impl Painter {
 
         if let Some(window) = window {
             let size = window.inner_size();
-            if self.surfaces.get(&viewport_id).is_none() {
+            if !self.surfaces.contains_key(&viewport_id) {
                 let surface = unsafe {
                     self.instance
                         .create_surface_unsafe(wgpu::SurfaceTargetUnsafe::from_window(&window)?)?

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -65,10 +65,10 @@ luminol-web = { version = "0.4.0", path = "../web/" }
 flume.workspace = true
 oneshot.workspace = true
 
-wasm-bindgen = "0.2.87"
-wasm-bindgen-futures = "0.4"
-js-sys = "0.3"
-web-sys = { version = "0.3", features = [
+wasm-bindgen.workspace = true
+wasm-bindgen-futures.workspace = true
+js-sys.workspace = true
+web-sys = { workspace = true, features = [
     "Blob",
     "File",
     "FileSystemCreateWritableOptions",

--- a/crates/filesystem/src/path_cache.rs
+++ b/crates/filesystem/src/path_cache.rs
@@ -310,7 +310,7 @@ where
                                         "{key} ➡ {}",
                                         cache.get_path_from_cactus_index(cactus_index),
                                     ))
-                                    .truncate(true),
+                                    .truncate(),
                                 );
                             }
                         },

--- a/crates/graphics/Cargo.toml
+++ b/crates/graphics/Cargo.toml
@@ -24,8 +24,8 @@ luminol-egui-wgpu.workspace = true
 wgpu.workspace = true
 glam.workspace = true
 
-naga_oil = "0.12.0"
-naga = "0.19.0"
+naga.workspace = true
+naga_oil.workspace = true
 
 crossbeam.workspace = true
 dashmap.workspace = true

--- a/crates/graphics/src/primitives/collision/shader.rs
+++ b/crates/graphics/src/primitives/collision/shader.rs
@@ -60,11 +60,13 @@ pub fn create_render_pipeline(
             vertex: wgpu::VertexState {
                 module: &shader_module,
                 entry_point: "vs_main",
+                compilation_options: Default::default(),
                 buffers: &[Instances::desc()],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader_module,
                 entry_point: "fs_main",
+                compilation_options: Default::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     blend: Some(wgpu::BlendState::ALPHA_BLENDING),
                     ..render_state.target_format.into()

--- a/crates/graphics/src/primitives/grid/shader.rs
+++ b/crates/graphics/src/primitives/grid/shader.rs
@@ -67,11 +67,13 @@ pub fn create_render_pipeline(
             vertex: wgpu::VertexState {
                 module: &shader_module,
                 entry_point: "vs_main",
+                compilation_options: Default::default(),
                 buffers: &[],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader_module,
                 entry_point: "fs_main",
+                compilation_options: Default::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     blend: Some(wgpu::BlendState::ALPHA_BLENDING),
                     ..render_state.target_format.into()

--- a/crates/graphics/src/primitives/sprite/shader.rs
+++ b/crates/graphics/src/primitives/sprite/shader.rs
@@ -77,11 +77,13 @@ fn create_shader(
             vertex: wgpu::VertexState {
                 module: &shader_module,
                 entry_point: "vs_main",
+                compilation_options: Default::default(),
                 buffers: &[Vertex::desc()],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader_module,
                 entry_point: "fs_main",
+                compilation_options: Default::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     blend: Some(target),
                     ..render_state.target_format.into()

--- a/crates/graphics/src/primitives/tiles/shader.rs
+++ b/crates/graphics/src/primitives/tiles/shader.rs
@@ -116,11 +116,13 @@ pub fn create_render_pipeline(
             vertex: wgpu::VertexState {
                 module: &shader_module,
                 entry_point: "vs_main",
+                compilation_options: Default::default(),
                 buffers: &[Instances::desc()],
             },
             fragment: Some(wgpu::FragmentState {
                 module: &shader_module,
                 entry_point: "fs_main",
+                compilation_options: Default::default(),
                 targets: &[Some(wgpu::ColorTargetState {
                     blend: Some(wgpu::BlendState::ALPHA_BLENDING),
                     ..render_state.target_format.into()

--- a/crates/modals/src/database_modal/mod.rs
+++ b/crates/modals/src/database_modal/mod.rs
@@ -201,7 +201,7 @@ where
                     luminol_components::close_options_ui(ui, &mut keep_open, &mut needs_save);
 
                     if let Some(size) = new_size {
-                        ui.add(egui::DragValue::new(size).clamp_range(1..=usize::MAX));
+                        ui.add(egui::DragValue::new(size).range(1..=usize::MAX));
                         if ui.button("Set Maximum").clicked() {
                             M::resize(update_state, *size);
                         }

--- a/crates/term/src/widget/mod.rs
+++ b/crates/term/src/widget/mod.rs
@@ -493,8 +493,24 @@ where
         Ok(())
     }
 
-    fn handle_scroll(&mut self, cursor_pos: Option<RCursor>, scroll_delta: egui::Vec2) {
-        self.scroll_pt += scroll_delta.y;
+    fn handle_scroll(
+        &mut self,
+        cursor_pos: Option<RCursor>,
+        unit: egui::MouseWheelUnit,
+        scroll_delta: egui::Vec2,
+    ) {
+        match unit {
+            egui::MouseWheelUnit::Point => {
+                self.scroll_pt += scroll_delta.y;
+            }
+            egui::MouseWheelUnit::Line => {
+                self.scroll_pt += scroll_delta.y * 16.;
+            }
+            egui::MouseWheelUnit::Page => {
+                let (width, _height) = self.backend.size();
+                self.scroll_pt += scroll_delta.y * 16. * width as f32;
+            }
+        }
         let delta = (self.scroll_pt / 16.).trunc() as i32;
         self.scroll_pt %= 16.;
 
@@ -612,12 +628,13 @@ where
                     }
                     term_modified = true;
                 }
-                egui::Event::Scroll(scroll_delta) => self.handle_scroll(
+                egui::Event::MouseWheel { unit, delta, .. } => self.handle_scroll(
                     hover_pos.map(|pos| galley.cursor_from_pos(pos.to_vec2()).rcursor),
-                    scroll_delta,
+                    unit,
+                    delta,
                 ),
-                egui::Event::CompositionUpdate(text) => self.ime_text = Some(text),
-                egui::Event::CompositionEnd(text) => {
+                egui::Event::Ime(egui::ImeEvent::Preedit(text)) => self.ime_text = Some(text),
+                egui::Event::Ime(egui::ImeEvent::Commit(text)) => {
                     self.ime_text = None;
                     self.backend.send(text.into_bytes());
                     term_modified = true;

--- a/crates/term/src/widget/mod.rs
+++ b/crates/term/src/widget/mod.rs
@@ -507,8 +507,8 @@ where
                 self.scroll_pt += scroll_delta.y * 16.;
             }
             egui::MouseWheelUnit::Page => {
-                let (width, _height) = self.backend.size();
-                self.scroll_pt += scroll_delta.y * 16. * width as f32;
+                let (_width, height) = self.backend.size();
+                self.scroll_pt += scroll_delta.y * 16. * height as f32;
             }
         }
         let delta = (self.scroll_pt / 16.).trunc() as i32;

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -28,7 +28,7 @@ luminol-modals.workspace = true
 luminol-macros.workspace = true
 
 egui.workspace = true
-egui-modal = "0.3.6"
+egui-modal.workspace = true
 
 camino.workspace = true
 

--- a/crates/ui/src/tabs/map/brush.rs
+++ b/crates/ui/src/tabs/map/brush.rs
@@ -23,7 +23,6 @@
 // Program grant you additional permission to convey the resulting work.
 
 use itertools::Itertools;
-use std::usize;
 
 impl super::Tab {
     pub(super) fn handle_brush(

--- a/crates/ui/src/tabs/map/mod.rs
+++ b/crates/ui/src/tabs/map/mod.rs
@@ -223,112 +223,126 @@ impl luminol_core::Tab for Tab {
         // Display the toolbar.
         // FIXME: find a proper place for this toolbar! it looks very out of place right now.
         egui::TopBottomPanel::top(format!("map_{}_toolbar", self.id)).show_inside(ui, |ui| {
-            ui.horizontal_wrapped(|ui| {
-                ui.add(
-                    egui::Slider::new(&mut self.view.scale, 15.0..=300.)
-                        .text("Scale")
-                        .logarithmic(true)
-                        .fixed_decimals(0),
-                );
-
-                ui.separator();
-
-                ui.menu_button(
-                    // Format the text based on what layer is selected.
-                    match self.view.selected_layer {
-                        luminol_components::SelectedLayer::Events => "Events ⏷".to_string(),
-                        luminol_components::SelectedLayer::Tiles(layer) => {
-                            format!("Layer {} ⏷", layer + 1)
-                        }
-                    },
-                    |ui| {
-                        // TODO: Add layer enable button
-                        // Display all layers.
-                        egui::Grid::new(self.id().with("layer_select"))
-                            .striped(true)
-                            .show(ui, |ui| {
-                                ui.label(egui::RichText::new("Panorama").underline());
-                                ui.checkbox(&mut self.view.map.pano_enabled, "👁");
-                                ui.end_row();
-
-                                for (index, layer) in
-                                    self.view.map.tiles.enabled_layers.iter_mut().enumerate()
-                                {
-                                    ui.columns(1, |columns| {
-                                        columns[0].selectable_value(
-                                            &mut self.view.selected_layer,
-                                            luminol_components::SelectedLayer::Tiles(index),
-                                            format!("Layer {}", index + 1),
-                                        );
-                                    });
-                                    ui.checkbox(layer, "👁");
-                                    ui.end_row();
-                                }
-
-                                // Display event layer.
-                                ui.columns(1, |columns| {
-                                    columns[0].selectable_value(
-                                        &mut self.view.selected_layer,
-                                        luminol_components::SelectedLayer::Events,
-                                        egui::RichText::new("Events").italics(),
-                                    );
-                                });
-                                ui.checkbox(&mut self.view.map.event_enabled, "👁");
-                                ui.end_row();
-
-                                ui.label(egui::RichText::new("Fog").underline());
-                                ui.checkbox(&mut self.view.map.fog_enabled, "👁");
-                                ui.end_row();
-
-                                ui.label(egui::RichText::new("Collision").underline());
-                                ui.checkbox(&mut self.view.map.coll_enabled, "👁");
-                                ui.end_row();
-
-                                ui.label(egui::RichText::new("Grid").underline());
-                                ui.checkbox(&mut self.view.map.grid_enabled, "👁");
-                                ui.end_row();
-                            });
-                    },
-                );
-
-                ui.separator();
-
-                ui.menu_button("Display options ⏷", |ui| {
-                    ui.checkbox(&mut self.view.visible_display, "Display visible area")
-                        .on_hover_text("Display the visible area in-game (640x480)");
-                    ui.checkbox(&mut self.view.move_preview, "Preview event move routes")
-                        .on_hover_text("Preview event page move routes");
-                    ui.checkbox(&mut self.view.snap_to_grid, "Snap to grid")
-                        .on_hover_text("Snaps the viewport to the tile grid");
-                    ui.checkbox(
-                        &mut self.view.darken_unselected_layers,
-                        "Darken unselected layers",
-                    )
-                    .on_hover_text("Toggles darkening unselected layers");
-                    ui.checkbox(&mut self.view.display_tile_ids, "Display tile IDs")
-                        .on_disabled_hover_text(
-                            "Display the tile IDs of the currently selected layer",
+            egui::Frame::none()
+                .outer_margin(egui::Margin {
+                    bottom: ui.spacing().item_spacing.y,
+                    ..egui::Margin::ZERO
+                })
+                .show(ui, |ui| {
+                    ui.horizontal_wrapped(|ui| {
+                        ui.add(
+                            egui::Slider::new(&mut self.view.scale, 15.0..=300.)
+                                .text("Scale")
+                                .logarithmic(true)
+                                .fixed_decimals(0),
                         );
+
+                        ui.separator();
+
+                        ui.menu_button(
+                            // Format the text based on what layer is selected.
+                            match self.view.selected_layer {
+                                luminol_components::SelectedLayer::Events => "Events ⏷".to_string(),
+                                luminol_components::SelectedLayer::Tiles(layer) => {
+                                    format!("Layer {} ⏷", layer + 1)
+                                }
+                            },
+                            |ui| {
+                                // TODO: Add layer enable button
+                                // Display all layers.
+                                egui::Grid::new(self.id().with("layer_select"))
+                                    .striped(true)
+                                    .show(ui, |ui| {
+                                        ui.label(egui::RichText::new("Panorama").underline());
+                                        ui.checkbox(&mut self.view.map.pano_enabled, "👁");
+                                        ui.end_row();
+
+                                        for (index, layer) in self
+                                            .view
+                                            .map
+                                            .tiles
+                                            .enabled_layers
+                                            .iter_mut()
+                                            .enumerate()
+                                        {
+                                            ui.columns(1, |columns| {
+                                                columns[0].selectable_value(
+                                                    &mut self.view.selected_layer,
+                                                    luminol_components::SelectedLayer::Tiles(index),
+                                                    format!("Layer {}", index + 1),
+                                                );
+                                            });
+                                            ui.checkbox(layer, "👁");
+                                            ui.end_row();
+                                        }
+
+                                        // Display event layer.
+                                        ui.columns(1, |columns| {
+                                            columns[0].selectable_value(
+                                                &mut self.view.selected_layer,
+                                                luminol_components::SelectedLayer::Events,
+                                                egui::RichText::new("Events").italics(),
+                                            );
+                                        });
+                                        ui.checkbox(&mut self.view.map.event_enabled, "👁");
+                                        ui.end_row();
+
+                                        ui.label(egui::RichText::new("Fog").underline());
+                                        ui.checkbox(&mut self.view.map.fog_enabled, "👁");
+                                        ui.end_row();
+
+                                        ui.label(egui::RichText::new("Collision").underline());
+                                        ui.checkbox(&mut self.view.map.coll_enabled, "👁");
+                                        ui.end_row();
+
+                                        ui.label(egui::RichText::new("Grid").underline());
+                                        ui.checkbox(&mut self.view.map.grid_enabled, "👁");
+                                        ui.end_row();
+                                    });
+                            },
+                        );
+
+                        ui.separator();
+
+                        ui.menu_button("Display options ⏷", |ui| {
+                            ui.checkbox(&mut self.view.visible_display, "Display visible area")
+                                .on_hover_text("Display the visible area in-game (640x480)");
+                            ui.checkbox(&mut self.view.move_preview, "Preview event move routes")
+                                .on_hover_text("Preview event page move routes");
+                            ui.checkbox(&mut self.view.snap_to_grid, "Snap to grid")
+                                .on_hover_text("Snaps the viewport to the tile grid");
+                            ui.checkbox(
+                                &mut self.view.darken_unselected_layers,
+                                "Darken unselected layers",
+                            )
+                            .on_hover_text("Toggles darkening unselected layers");
+                            ui.checkbox(&mut self.view.display_tile_ids, "Display tile IDs")
+                                .on_disabled_hover_text(
+                                    "Display the tile IDs of the currently selected layer",
+                                );
+                        });
+
+                        ui.separator();
+
+                        if ui.button("Save map preview").clicked()
+                            && self.save_as_image_promise.is_none()
+                        {
+                            self.save_as_image_promise =
+                                Some(luminol_core::spawn_future(self.view.save_as_image(
+                                    &update_state.graphics,
+                                    &update_state.data.get_map(self.id),
+                                )))
+                        }
+
+                        /*
+                        if map.preview_move_route.is_some()
+                        && ui.button("Clear move route preview").clicked()
+                        {
+                            map.preview_move_route = None;
+                        }
+                        */
+                    });
                 });
-
-                ui.separator();
-
-                if ui.button("Save map preview").clicked() && self.save_as_image_promise.is_none() {
-                    self.save_as_image_promise =
-                        Some(luminol_core::spawn_future(self.view.save_as_image(
-                            &update_state.graphics,
-                            &update_state.data.get_map(self.id),
-                        )))
-                }
-
-                /*
-                if map.preview_move_route.is_some()
-                && ui.button("Clear move route preview").clicked()
-                {
-                    map.preview_move_route = None;
-                }
-                */
-            });
         });
 
         // Display the tilepicker.

--- a/crates/ui/src/windows/actors.rs
+++ b/crates/ui/src/windows/actors.rs
@@ -176,7 +176,7 @@ fn draw_exp(ui: &mut egui::Ui, actor: &luminol_data::rpg::Actor, total: &mut boo
                             let i = i + actor.initial_level.max(1) as usize - 1;
 
                             ui.horizontal(|ui| {
-                                ui.style_mut().wrap = Some(true);
+                                ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Wrap);
 
                                 ui.with_layout(
                                     egui::Layout {
@@ -196,7 +196,7 @@ fn draw_exp(ui: &mut egui::Ui, actor: &luminol_data::rpg::Actor, total: &mut boo
                                             } else {
                                                 (exp[i + 1] - exp[i]).to_string()
                                             })
-                                            .truncate(true),
+                                            .truncate(),
                                         );
 
                                         ui.with_layout(
@@ -207,7 +207,7 @@ fn draw_exp(ui: &mut egui::Ui, actor: &luminol_data::rpg::Actor, total: &mut boo
                                             |ui| {
                                                 ui.add(
                                                     egui::Label::new(format!("Level {}", i + 1))
-                                                        .truncate(true),
+                                                        .truncate(),
                                                 );
                                             },
                                         );

--- a/crates/ui/src/windows/armor.rs
+++ b/crates/ui/src/windows/armor.rs
@@ -138,32 +138,28 @@ impl luminol_core::Window for Window {
                                 modified |= columns[0]
                                     .add(luminol_components::Field::new(
                                         "Price",
-                                        egui::DragValue::new(&mut armor.price)
-                                            .clamp_range(0..=i32::MAX),
+                                        egui::DragValue::new(&mut armor.price).range(0..=i32::MAX),
                                     ))
                                     .changed();
 
                                 modified |= columns[1]
                                     .add(luminol_components::Field::new(
                                         "EVA",
-                                        egui::DragValue::new(&mut armor.eva)
-                                            .clamp_range(0..=i32::MAX),
+                                        egui::DragValue::new(&mut armor.eva).range(0..=i32::MAX),
                                     ))
                                     .changed();
 
                                 modified |= columns[2]
                                     .add(luminol_components::Field::new(
                                         "PDEF",
-                                        egui::DragValue::new(&mut armor.pdef)
-                                            .clamp_range(0..=i32::MAX),
+                                        egui::DragValue::new(&mut armor.pdef).range(0..=i32::MAX),
                                     ))
                                     .changed();
 
                                 modified |= columns[3]
                                     .add(luminol_components::Field::new(
                                         "MDEF",
-                                        egui::DragValue::new(&mut armor.mdef)
-                                            .clamp_range(0..=i32::MAX),
+                                        egui::DragValue::new(&mut armor.mdef).range(0..=i32::MAX),
                                     ))
                                     .changed();
                             });

--- a/crates/ui/src/windows/common_event_edit.rs
+++ b/crates/ui/src/windows/common_event_edit.rs
@@ -71,7 +71,7 @@ impl luminol_core::Window for Window {
     }
 }
 
-struct CommonEventTab {
+pub struct CommonEventTab {
     event: luminol_data::rpg::CommonEvent,
     force_close: bool,
     switch_modal: database_modal::SwitchModal,

--- a/crates/ui/src/windows/enemies.rs
+++ b/crates/ui/src/windows/enemies.rs
@@ -137,16 +137,14 @@ impl Window {
                     modified |= columns[0]
                         .add(luminol_components::Field::new(
                             "Turn Offset",
-                            egui::DragValue::new(&mut action.condition_turn_a)
-                                .clamp_range(0..=i32::MAX),
+                            egui::DragValue::new(&mut action.condition_turn_a).range(0..=i32::MAX),
                         ))
                         .changed();
 
                     modified |= columns[1]
                         .add(luminol_components::Field::new(
                             "Turn Interval",
-                            egui::DragValue::new(&mut action.condition_turn_b)
-                                .clamp_range(0..=i32::MAX),
+                            egui::DragValue::new(&mut action.condition_turn_b).range(0..=i32::MAX),
                         ))
                         .changed();
                 });
@@ -370,32 +368,28 @@ impl luminol_core::Window for Window {
                                 modified |= columns[0]
                                     .add(luminol_components::Field::new(
                                         "EXP",
-                                        egui::DragValue::new(&mut enemy.exp)
-                                            .clamp_range(0..=i32::MAX),
+                                        egui::DragValue::new(&mut enemy.exp).range(0..=i32::MAX),
                                     ))
                                     .changed();
 
                                 modified |= columns[1]
                                     .add(luminol_components::Field::new(
                                         "Gold",
-                                        egui::DragValue::new(&mut enemy.gold)
-                                            .clamp_range(0..=i32::MAX),
+                                        egui::DragValue::new(&mut enemy.gold).range(0..=i32::MAX),
                                     ))
                                     .changed();
 
                                 modified |= columns[2]
                                     .add(luminol_components::Field::new(
                                         "Max HP",
-                                        egui::DragValue::new(&mut enemy.maxhp)
-                                            .clamp_range(0..=i32::MAX),
+                                        egui::DragValue::new(&mut enemy.maxhp).range(0..=i32::MAX),
                                     ))
                                     .changed();
 
                                 modified |= columns[3]
                                     .add(luminol_components::Field::new(
                                         "Max SP",
-                                        egui::DragValue::new(&mut enemy.maxsp)
-                                            .clamp_range(0..=i32::MAX),
+                                        egui::DragValue::new(&mut enemy.maxsp).range(0..=i32::MAX),
                                     ))
                                     .changed();
                             });
@@ -406,32 +400,28 @@ impl luminol_core::Window for Window {
                                 modified |= columns[0]
                                     .add(luminol_components::Field::new(
                                         "STR",
-                                        egui::DragValue::new(&mut enemy.str)
-                                            .clamp_range(0..=i32::MAX),
+                                        egui::DragValue::new(&mut enemy.str).range(0..=i32::MAX),
                                     ))
                                     .changed();
 
                                 modified |= columns[1]
                                     .add(luminol_components::Field::new(
                                         "DEX",
-                                        egui::DragValue::new(&mut enemy.dex)
-                                            .clamp_range(0..=i32::MAX),
+                                        egui::DragValue::new(&mut enemy.dex).range(0..=i32::MAX),
                                     ))
                                     .changed();
 
                                 modified |= columns[2]
                                     .add(luminol_components::Field::new(
                                         "AGI",
-                                        egui::DragValue::new(&mut enemy.agi)
-                                            .clamp_range(0..=i32::MAX),
+                                        egui::DragValue::new(&mut enemy.agi).range(0..=i32::MAX),
                                     ))
                                     .changed();
 
                                 modified |= columns[3]
                                     .add(luminol_components::Field::new(
                                         "INT",
-                                        egui::DragValue::new(&mut enemy.int)
-                                            .clamp_range(0..=i32::MAX),
+                                        egui::DragValue::new(&mut enemy.int).range(0..=i32::MAX),
                                     ))
                                     .changed();
                             });
@@ -442,32 +432,28 @@ impl luminol_core::Window for Window {
                                 modified |= columns[0]
                                     .add(luminol_components::Field::new(
                                         "ATK",
-                                        egui::DragValue::new(&mut enemy.atk)
-                                            .clamp_range(0..=i32::MAX),
+                                        egui::DragValue::new(&mut enemy.atk).range(0..=i32::MAX),
                                     ))
                                     .changed();
 
                                 modified |= columns[1]
                                     .add(luminol_components::Field::new(
                                         "EVA",
-                                        egui::DragValue::new(&mut enemy.eva)
-                                            .clamp_range(0..=i32::MAX),
+                                        egui::DragValue::new(&mut enemy.eva).range(0..=i32::MAX),
                                     ))
                                     .changed();
 
                                 modified |= columns[2]
                                     .add(luminol_components::Field::new(
                                         "PDEF",
-                                        egui::DragValue::new(&mut enemy.pdef)
-                                            .clamp_range(0..=i32::MAX),
+                                        egui::DragValue::new(&mut enemy.pdef).range(0..=i32::MAX),
                                     ))
                                     .changed();
 
                                 modified |= columns[3]
                                     .add(luminol_components::Field::new(
                                         "MDEF",
-                                        egui::DragValue::new(&mut enemy.mdef)
-                                            .clamp_range(0..=i32::MAX),
+                                        egui::DragValue::new(&mut enemy.mdef).range(0..=i32::MAX),
                                     ))
                                     .changed();
                             });

--- a/crates/ui/src/windows/event_edit.rs
+++ b/crates/ui/src/windows/event_edit.rs
@@ -260,7 +260,7 @@ impl luminol_core::Window for Window {
 
                         left.label("Options");
                         left.group(|ui| {
-                            ui.style_mut().wrap = Some(false);
+                            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
                             modified |= ui
                                 .checkbox(&mut page.walk_anime, "Move Animation")
                                 .changed();

--- a/crates/ui/src/windows/items.rs
+++ b/crates/ui/src/windows/items.rs
@@ -241,8 +241,7 @@ impl luminol_core::Window for Window {
                                 modified |= columns[0]
                                     .add(luminol_components::Field::new(
                                         "Price",
-                                        egui::DragValue::new(&mut item.price)
-                                            .clamp_range(0..=i32::MAX),
+                                        egui::DragValue::new(&mut item.price).range(0..=i32::MAX),
                                     ))
                                     .changed();
 
@@ -282,7 +281,7 @@ impl luminol_core::Window for Window {
                                         .add(luminol_components::Field::new(
                                             "Parameter Increment",
                                             egui::DragValue::new(&mut item.parameter_points)
-                                                .clamp_range(0..=i32::MAX),
+                                                .range(0..=i32::MAX),
                                         ))
                                         .changed();
                                 });
@@ -303,7 +302,7 @@ impl luminol_core::Window for Window {
                                     .add(luminol_components::Field::new(
                                         "Recover HP Points",
                                         egui::DragValue::new(&mut item.recover_hp)
-                                            .clamp_range(0..=i32::MAX),
+                                            .range(0..=i32::MAX),
                                     ))
                                     .changed();
                             });
@@ -323,7 +322,7 @@ impl luminol_core::Window for Window {
                                     .add(luminol_components::Field::new(
                                         "Recover SP Points",
                                         egui::DragValue::new(&mut item.recover_sp)
-                                            .clamp_range(0..=i32::MAX),
+                                            .range(0..=i32::MAX),
                                     ))
                                     .changed();
                             });

--- a/crates/ui/src/windows/misc.rs
+++ b/crates/ui/src/windows/misc.rs
@@ -124,7 +124,7 @@ impl luminol_core::Window for WgpuDebugInfo {
     ) {
         egui::Window::new("WGPU Debug Info")
             .open(open)
-            .scroll2([false, true])
+            .scroll([false, true])
             .show(ctx, |ui| {
                 if !self.downlevel_caps.is_webgpu_compliant() {
                     ui.label(

--- a/crates/ui/src/windows/preferences.rs
+++ b/crates/ui/src/windows/preferences.rs
@@ -267,11 +267,11 @@ impl luminol_core::Window for Window {
                     ui.horizontal(|ui| {
                         ui.label("Initial terminal size:");
                         egui::DragValue::new(&mut config.initial_size.0)
-                            .clamp_range(1..=999)
+                            .range(1..=999)
                             .ui(ui);
                         ui.label("column(s)");
                         egui::DragValue::new(&mut config.initial_size.1)
-                            .clamp_range(1..=999)
+                            .range(1..=999)
                             .ui(ui);
                         ui.label("rows(s)");
                     });
@@ -407,7 +407,7 @@ fn gallery_grid_contents(ui: &mut egui::Ui) {
     egui::ComboBox::from_label("Take your pick")
         .selected_text("First")
         .show_ui(ui, |ui| {
-            ui.style_mut().wrap = Some(false);
+            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
             ui.set_min_width(60.0);
             ui.selectable_value(&mut 0, 0, "First");
             ui.selectable_value(&mut 0, 1, "Second");

--- a/crates/ui/src/windows/reporter.rs
+++ b/crates/ui/src/windows/reporter.rs
@@ -150,7 +150,7 @@ impl luminol_core::Window for Window {
                                                 )
                                                 .into_galley(
                                                     ui,
-                                                    Some(false),
+                                                    Some(egui::TextWrapMode::Extend),
                                                     wrap_width,
                                                     egui::TextStyle::Monospace,
                                                 )

--- a/crates/ui/src/windows/script_edit.rs
+++ b/crates/ui/src/windows/script_edit.rs
@@ -172,7 +172,9 @@ impl luminol_core::Tab for ScriptTab {
                 let mut scripts = update_state.data.scripts();
                 scripts.modified = true;
 
-                scripts.data[self.index].script_text = self.script_text.clone();
+                scripts.data[self.index]
+                    .script_text
+                    .clone_from(&self.script_text);
             }
         });
 

--- a/crates/ui/src/windows/skills.rs
+++ b/crates/ui/src/windows/skills.rs
@@ -202,7 +202,7 @@ impl luminol_core::Window for Window {
                                     .add(luminol_components::Field::new(
                                         "SP Cost",
                                         egui::DragValue::new(&mut skill.sp_cost)
-                                            .clamp_range(0..=i32::MAX),
+                                            .range(0..=i32::MAX),
                                     ))
                                     .changed();
 

--- a/crates/ui/src/windows/states.rs
+++ b/crates/ui/src/windows/states.rs
@@ -173,7 +173,7 @@ impl luminol_core::Window for Window {
                                 modified |= columns[0]
                                     .add(luminol_components::Field::new(
                                         "Rating",
-                                        egui::DragValue::new(&mut state.rating).clamp_range(0..=10),
+                                        egui::DragValue::new(&mut state.rating).range(0..=10),
                                     ))
                                     .changed();
 
@@ -294,7 +294,7 @@ impl luminol_core::Window for Window {
                                     .add(luminol_components::Field::new(
                                         "Auto Release Interval",
                                         egui::DragValue::new(&mut state.hold_turn)
-                                            .clamp_range(0..=i32::MAX),
+                                            .range(0..=i32::MAX),
                                     ))
                                     .changed();
                             });

--- a/crates/ui/src/windows/weapons.rs
+++ b/crates/ui/src/windows/weapons.rs
@@ -147,32 +147,28 @@ impl luminol_core::Window for Window {
                                 modified |= columns[0]
                                     .add(luminol_components::Field::new(
                                         "Price",
-                                        egui::DragValue::new(&mut weapon.price)
-                                            .clamp_range(0..=i32::MAX),
+                                        egui::DragValue::new(&mut weapon.price).range(0..=i32::MAX),
                                     ))
                                     .changed();
 
                                 modified |= columns[1]
                                     .add(luminol_components::Field::new(
                                         "ATK",
-                                        egui::DragValue::new(&mut weapon.atk)
-                                            .clamp_range(0..=i32::MAX),
+                                        egui::DragValue::new(&mut weapon.atk).range(0..=i32::MAX),
                                     ))
                                     .changed();
 
                                 modified |= columns[2]
                                     .add(luminol_components::Field::new(
                                         "PDEF",
-                                        egui::DragValue::new(&mut weapon.pdef)
-                                            .clamp_range(0..=i32::MAX),
+                                        egui::DragValue::new(&mut weapon.pdef).range(0..=i32::MAX),
                                     ))
                                     .changed();
 
                                 modified |= columns[3]
                                     .add(luminol_components::Field::new(
                                         "MDEF",
-                                        egui::DragValue::new(&mut weapon.mdef)
-                                            .clamp_range(0..=i32::MAX),
+                                        egui::DragValue::new(&mut weapon.mdef).range(0..=i32::MAX),
                                     ))
                                     .changed();
                             });

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -16,12 +16,12 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-wasm-bindgen = "0.2.87"
-wasm-bindgen-futures = "0.4"
+wasm-bindgen.workspace = true
+wasm-bindgen-futures.workspace = true
 indexed_db_futures = "0.4.1"
 
-js-sys = "0.3"
-web-sys = { version = "0.3", features = [
+js-sys.workspace = true
+web-sys = { workspace = true, features = [
     "DedicatedWorkerGlobalScope",
     "FileSystemDirectoryHandle",
     "FileSystemHandle",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2024-02-01"
+channel = "nightly-2024-05-19"

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -169,6 +169,19 @@ impl App {
                     writeln!(message_description, "---------").unwrap();
                     message_description.push_str(&description);
                 }
+                wgpu::Error::Internal {
+                    source,
+                    description,
+                } => {
+                    message_description.push_str("wgpu error: Internal error\n");
+                    writeln!(message_description, "{source}").unwrap();
+                    writeln!(message_description, "---------").unwrap();
+                    writeln!(message_description, "{}", source.source().unwrap()).unwrap();
+                    writeln!(message_description, "---------").unwrap();
+                    writeln!(message_description, "{source:#?}").unwrap();
+                    writeln!(message_description, "---------").unwrap();
+                    message_description.push_str(&description);
+                }
             }
             rfd::MessageDialog::new()
                 .set_title("Luminol has crashed!")

--- a/src/main.rs
+++ b/src/main.rs
@@ -423,6 +423,8 @@ pub fn luminol_main_start() {
         *before_unload_cell.borrow_mut() = Some(closure);
     }
 
+    canvas.focus().expect("could not focus the canvas");
+
     let mut worker_options = web_sys::WorkerOptions::new();
     worker_options.name("luminol-primary");
     worker_options.type_(web_sys::WorkerType::Module);

--- a/src/main.rs
+++ b/src/main.rs
@@ -388,6 +388,7 @@ pub fn luminol_main_start() {
     let runner_panic_tx =
         luminol_eframe::WebRunner::setup_main_thread_hooks(luminol_eframe::web::MainState {
             inner: Default::default(),
+            text_agent: Default::default(),
             canvas: canvas.clone(),
             channels: runner_main_channels,
         })

--- a/src/main.rs
+++ b/src/main.rs
@@ -240,7 +240,7 @@ fn main() {
                 .set(cc.egui_ctx.clone())
                 .expect("egui context cell already set (this shouldn't happen!)");
 
-            Box::new(app::App::new(
+            Ok(Box::new(app::App::new(
                 cc,
                 report,
                 Default::default(),
@@ -248,7 +248,7 @@ fn main() {
                 std::env::args_os().nth(1),
                 #[cfg(feature = "steamworks")]
                 steamworks,
-            ))
+            )))
         }),
     )
     .expect("failed to start luminol");
@@ -461,7 +461,7 @@ pub async fn luminol_worker_start(canvas: web_sys::OffscreenCanvas) {
         .start(
             canvas,
             web_options,
-            Box::new(|cc| Box::new(app::App::new(cc, report, modified, audio))),
+            Box::new(|cc| Ok(Box::new(app::App::new(cc, report, modified, audio)))),
             luminol_eframe::web::WorkerOptions {
                 prefers_color_scheme_dark,
                 channels: runner_worker_channels,

--- a/src/steam.rs
+++ b/src/steam.rs
@@ -25,16 +25,15 @@
 const APPID: u32 = 2501490;
 
 pub struct Steamworks {
-    pub client: steamworks::Client<steamworks::ClientManager>,
     pub single: parking_lot::Mutex<steamworks::SingleClient<steamworks::ClientManager>>,
 }
 
 impl Steamworks {
     pub fn new() -> Result<Self, steamworks::SteamError> {
-        let (client, single) = steamworks::Client::init_app(APPID)?;
+        let (_, single) = steamworks::Client::init_app(APPID)?;
         let single = parking_lot::Mutex::new(single);
 
-        let steamworks = Steamworks { client, single };
+        let steamworks = Steamworks { single };
 
         Ok(steamworks)
     }


### PR DESCRIPTION
**Description**

This pull request updates egui to 0.28.1 and wgpu to 0.20.1.

In web builds, wgpu now requires a version of wasm-bindgen-futures that won't compile with Rust nightly toolchain versions earlier than 2024-02-06 if the +atomics compiler feature is enabled, so I updated the Rust toolchain to 2024-05-19, the latest nightly version that I could get all of our dependencies to compile with.

Make sure to update the toolchain version for luminol-website as well or it won't build anymore after this pull request.

**Testing**

I checked that the following things still work in native and web builds:

* Opening maps and creating, deleting and moving around events in the map editor
* Saving map previews as PNG files
* Opening database editors
* Opening the event editor
* Opening the script editor
* Opening the sound test
* Opening the graphic picker modals in the event editor and database editors
* Opening, scrolling and using IME in the terminal in native builds (the scrolling and IME events changed in egui 0.28.0)
* The rendering of the graphic in the about window

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown -Z build-std=std,panic_abort`
- [x] Run `cargo build --release`
- [x] If applicable, run `trunk build --release`
