### PR TITLE
Egui 0.28 update fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5648,9 +5648,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -5669,9 +5669,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/assets/themes/catppuccin_frappe.ron
+++ b/assets/themes/catppuccin_frappe.ron
@@ -149,9 +149,15 @@ Visuals(
         color: Color32((48, 52, 70, 255)),
     ),
     resize_corner_size: 12.0,
-    text_cursor: Stroke(
-        width: 2.0,
-        color: Color32((192, 222, 255, 255)),
+    text_cursor: TextCursorStyle(
+        stroke: Stroke(
+            width: 2.0,
+            color: Color32((192, 222, 255, 255)),
+        ),
+        preview: false,
+        blink: true,
+        on_duration: 0.5,
+        off_duration: 0.5,
     ),
     text_cursor_preview: false,
     clip_rect_margin: 3.0,

--- a/assets/themes/catppuccin_latte.ron
+++ b/assets/themes/catppuccin_latte.ron
@@ -149,9 +149,15 @@ Visuals(
         color: Color32((239, 241, 245, 255)),
     ),
     resize_corner_size: 12.0,
-    text_cursor: Stroke(
-        width: 2.0,
-        color: Color32((192, 222, 255, 255)),
+    text_cursor: TextCursorStyle(
+        stroke: Stroke(
+            width: 2.0,
+            color: Color32((192, 222, 255, 255)),
+        ),
+        preview: false,
+        blink: true,
+        on_duration: 0.5,
+        off_duration: 0.5,
     ),
     text_cursor_preview: false,
     clip_rect_margin: 3.0,

--- a/assets/themes/catppuccin_macchiato.ron
+++ b/assets/themes/catppuccin_macchiato.ron
@@ -149,9 +149,15 @@ Visuals(
         color: Color32((36, 39, 58, 255)),
     ),
     resize_corner_size: 12.0,
-    text_cursor: Stroke(
-        width: 2.0,
-        color: Color32((192, 222, 255, 255)),
+    text_cursor: TextCursorStyle(
+        stroke: Stroke(
+            width: 2.0,
+            color: Color32((192, 222, 255, 255)),
+        ),
+        preview: false,
+        blink: true,
+        on_duration: 0.5,
+        off_duration: 0.5,
     ),
     text_cursor_preview: false,
     clip_rect_margin: 3.0,

--- a/assets/themes/catppuccin_mocha.ron
+++ b/assets/themes/catppuccin_mocha.ron
@@ -149,9 +149,15 @@ Visuals(
         color: Color32((30, 30, 46, 255)),
     ),
     resize_corner_size: 12.0,
-    text_cursor: Stroke(
-        width: 2.0,
-        color: Color32((192, 222, 255, 255)),
+    text_cursor: TextCursorStyle(
+        stroke: Stroke(
+            width: 2.0,
+            color: Color32((192, 222, 255, 255)),
+        ),
+        preview: false,
+        blink: true,
+        on_duration: 0.5,
+        off_duration: 0.5,
     ),
     text_cursor_preview: false,
     clip_rect_margin: 3.0,

--- a/assets/themes/luminol.ron
+++ b/assets/themes/luminol.ron
@@ -149,9 +149,15 @@ Visuals(
         color: Color32((0, 0, 0, 96)),
     ),
     resize_corner_size: 12.0,
-    text_cursor: Stroke(
-        width: 2.0,
-        color: Color32((192, 222, 255, 255)),
+    text_cursor: TextCursorStyle(
+        stroke: Stroke(
+            width: 2.0,
+            color: Color32((192, 222, 255, 255)),
+        ),
+        preview: false,
+        blink: true,
+        on_duration: 0.5,
+        off_duration: 0.5,
     ),
     text_cursor_preview: false,
     clip_rect_margin: 3.0,

--- a/crates/components/src/lib.rs
+++ b/crates/components/src/lib.rs
@@ -167,6 +167,7 @@ pub struct EnumComboBox<'a, H, T> {
     reference: &'a mut T,
 
     max_width: f32,
+    wrap_mode: egui::TextWrapMode,
 }
 
 impl<'a, H, T> EnumComboBox<'a, H, T>
@@ -180,11 +181,18 @@ where
             id_source,
             reference,
             max_width: f32::INFINITY,
+            wrap_mode: egui::TextWrapMode::Wrap,
         }
     }
 
-    pub fn max_width(self, max_width: f32) -> Self {
-        Self { max_width, ..self }
+    pub fn max_width(mut self, max_width: f32) -> Self {
+        self.max_width = max_width;
+        self
+    }
+
+    pub fn wrap_mode(mut self, wrap_mode: egui::TextWrapMode) -> Self {
+        self.wrap_mode = wrap_mode;
+        self
     }
 }
 
@@ -202,7 +210,7 @@ where
             .width(width)
             .selected_text(self.reference.to_string())
             .show_ui(ui, |ui| {
-                ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Wrap);
+                ui.style_mut().wrap_mode = Some(self.wrap_mode);
 
                 for (i, variant) in T::iter().enumerate() {
                     ui.with_stripe(i % 2 != 0, |ui| {
@@ -409,7 +417,7 @@ where
                 }
             },
             |this, ui, ids, first_row_is_faint, show_none| {
-                ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Wrap);
+                ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Truncate);
 
                 if show_none
                     && ui
@@ -465,7 +473,7 @@ where
             ui,
             |this| (this.formatter)(*this.reference),
             |this, ui, ids, first_row_is_faint, _| {
-                ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Wrap);
+                ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Truncate);
 
                 let mut is_faint = first_row_is_faint;
 

--- a/crates/ui/src/tabs/map/mod.rs
+++ b/crates/ui/src/tabs/map/mod.rs
@@ -248,6 +248,8 @@ impl luminol_core::Tab for Tab {
                                 }
                             },
                             |ui| {
+                                ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
+
                                 // TODO: Add layer enable button
                                 // Display all layers.
                                 egui::Grid::new(self.id().with("layer_select"))
@@ -305,6 +307,8 @@ impl luminol_core::Tab for Tab {
                         ui.separator();
 
                         ui.menu_button("Display options ⏷", |ui| {
+                            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
+
                             ui.checkbox(&mut self.view.visible_display, "Display visible area")
                                 .on_hover_text("Display the visible area in-game (640x480)");
                             ui.checkbox(&mut self.view.move_preview, "Preview event move routes")

--- a/crates/ui/src/windows/command_gen/mod.rs
+++ b/crates/ui/src/windows/command_gen/mod.rs
@@ -124,6 +124,8 @@ impl luminol_core::window::Window for CommandGeneratorWindow {
                                     ui.menu_button(
                                         format!("{} ⏷", <&str>::from(&command.kind)),
                                         |ui| {
+                                            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
+
                                             for kind in CommandKind::iter() {
                                                 let text =<&str>::from(&kind);
                                                 ui.selectable_value(

--- a/crates/ui/src/windows/command_gen/parameter_ui.rs
+++ b/crates/ui/src/windows/command_gen/parameter_ui.rs
@@ -33,6 +33,8 @@ pub fn parameter_ui(
 ) {
     ui.horizontal(|ui| {
             ui.menu_button(format!("{} ⏷", <&str>::from(&*parameter)), |ui| {
+                ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
+
                 for iter_kind in Parameter::iter() {
                     if let Parameter::Group {ref mut guid , ..}
                     | Parameter::Selection { ref mut  guid, .. } = parameter {
@@ -164,6 +166,8 @@ pub fn parameter_ui(
             ui.horizontal(|ui| {
                 ui.label("Type: ");
                 ui.menu_button(format!("{} ⏷", <&str>::from(&*kind)), |ui| {
+                    ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
+
                     for iter_kind in ParameterKind::iter() {
                         let text: &str = (&iter_kind).into();
                         ui.selectable_value(kind, iter_kind, text);

--- a/crates/ui/src/windows/command_gen/ui_example.rs
+++ b/crates/ui/src/windows/command_gen/ui_example.rs
@@ -120,6 +120,8 @@ impl UiExample {
                     ParameterKind::Enum { ref variants } => {
                         let (first_name, mut first_id) = variants.first().unwrap();
                         ui.menu_button(format!("{first_name} ⏷"), |ui| {
+                            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
+
                             for (name, id) in variants.iter() {
                                 ui.selectable_value(&mut first_id, *id, name);
                             }
@@ -127,6 +129,8 @@ impl UiExample {
                     }
                     ParameterKind::SelfSwitch => {
                         ui.menu_button("A ⏷", |ui| {
+                            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
+
                             for char in ['A', 'B', 'C', 'D'] {
                                 ui.selectable_value(&mut 'A', char, char.to_string());
                             }

--- a/crates/ui/src/windows/preferences.rs
+++ b/crates/ui/src/windows/preferences.rs
@@ -313,7 +313,8 @@ impl luminol_core::Window for Window {
                             "luminol_term_config_ui_cursor_blinking",
                             &mut config.cursor_blinking,
                         )
-                        .max_width(12.),
+                        .max_width(12.)
+                        .wrap_mode(egui::TextWrapMode::Extend),
                     )
                     .ui(ui);
                     ui.add_space(6.);

--- a/src/app/top_bar.rs
+++ b/src/app/top_bar.rs
@@ -61,6 +61,8 @@ impl TopBar {
         ui.separator();
 
         ui.menu_button("File", |ui| {
+            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
+
             // Hide this menu if the unsaved changes modal or a file/folder picker is open
             if update_state.project_manager.is_modal_open()
                 || update_state.project_manager.is_picker_open()
@@ -115,6 +117,8 @@ impl TopBar {
         ui.separator();
 
         ui.menu_button("Edit", |ui| {
+            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
+
             // Hide this menu if the unsaved changes modal or a file/folder picker is open
             if update_state.project_manager.is_modal_open()
                 || update_state.project_manager.is_picker_open()
@@ -147,6 +151,8 @@ impl TopBar {
         ui.separator();
 
         ui.menu_button("Data", |ui| {
+            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
+
             // Hide this menu if the unsaved changes modal or a file/folder picker is open
             if update_state.project_manager.is_modal_open()
                 || update_state.project_manager.is_picker_open()
@@ -260,6 +266,8 @@ impl TopBar {
         ui.separator();
 
         ui.menu_button("Tools", |ui| {
+            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
+
             // Hide this menu if the unsaved changes modal or a file/folder picker is open
             if update_state.project_manager.is_modal_open()
                 || update_state.project_manager.is_picker_open()
@@ -283,6 +291,8 @@ impl TopBar {
         ui.separator();
 
         ui.menu_button("Help", |ui| {
+            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
+
             // Hide this menu if the unsaved changes modal or a file/folder picker is open
             if update_state.project_manager.is_modal_open()
                 || update_state.project_manager.is_picker_open()
@@ -300,6 +310,8 @@ impl TopBar {
         });
 
         ui.menu_button("Debug", |ui| {
+            ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);
+
             // Hide this menu if the unsaved changes modal or a file/folder picker is open
             if update_state.project_manager.is_modal_open()
                 || update_state.project_manager.is_picker_open()

--- a/src/app/top_bar.rs
+++ b/src/app/top_bar.rs
@@ -46,6 +46,8 @@ impl TopBar {
                     .ctx
                     .send_viewport_cmd(egui::ViewportCommand::Fullscreen(self.fullscreen));
             }
+
+            ui.separator();
         }
 
         let mut open_project = ui.input(|i| i.modifiers.command && i.key_pressed(egui::Key::O))
@@ -57,8 +59,6 @@ impl TopBar {
                 .edit_windows
                 .add_window(luminol_ui::windows::new_project::Window::default());
         }
-
-        ui.separator();
 
         ui.menu_button("File", |ui| {
             ui.style_mut().wrap_mode = Some(egui::TextWrapMode::Extend);


### PR DESCRIPTION
**Connections**
* #143 

**Description**
This fixes some problems caused by the egui update in #143, namely the preset visuals tab in the preferences causing a panic and the wrap modes of several of the menus being broken.

I also updated the time crate to fix a compilation error when using certain new Rust compiler versions and fixed a problem where blank lines sometimes appear at the bottom of the filesystem debug window, although these problems existed before the egui update.

**Testing**
* The preset visuals tab in the preferences shouldn't cause a panic anymore.
* None of the items in any of the menus, e.g. the menus in the top bar, the database editor dropdown menus and the "Cursor blinking" setting in the terminal settings in the preferences, should have wrapping text anymore.
* There should be no blank lines at the bottom of the filesystem debug window when opening a project with the standard RTP for RPG Maker XP placed in the RTP subdirectory of the project directory.
* It should be possible to compile Luminol with nightly Rust versions later than 2024-05-19.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown -Z build-std=std,panic_abort`
- [x] Run `cargo build --release`
- [ ] If applicable, run `trunk build --release`
