### PR TITLE
Update RFD to 1.14.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -141,7 +141,7 @@ qp-trie = "0.8.2"
 
 itertools = "0.11.0"
 
-rfd = "0.12.0"
+rfd = "0.14.1"
 tempfile = "3.8.1"
 
 rand = "0.8.5"


### PR DESCRIPTION
**Connections**
None

**Description**
The current rfd version (1.12.0) does not support xdg-desktop-portal by default, which means that Luminol will show GTK3 file pickers in any desktop environment, even non-GNOME. Version 1.14.1 fixes that.

**Testing**
The change can be tested by simply trying to open any project. No issues on KDE Plasma 6 with xdg-desktop-portal-kde package installed.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown -Z build-std=std,panic_abort`
- [x] Run `cargo build --release`
- [ ] If applicable, run `trunk build --release`
