### PR TITLE
Fix animation editor cellpicker clipping

### DIFF
--- a/crates/components/src/animation_frame_view.rs
+++ b/crates/components/src/animation_frame_view.rs
@@ -77,9 +77,7 @@ impl AnimationFrameView {
     ) -> egui::InnerResponse<Option<(i16, i16)>> {
         let canvas_rect = ui.max_rect();
         let canvas_center = canvas_rect.center();
-        let egui_painter = ui
-            .painter()
-            .with_clip_rect(canvas_rect.intersect(clip_rect));
+        ui.set_clip_rect(canvas_rect.intersect(clip_rect));
 
         let mut response = ui.allocate_rect(canvas_rect, egui::Sense::click_and_drag());
 
@@ -153,16 +151,17 @@ impl AnimationFrameView {
         );
 
         let painter = luminol_graphics::Painter::new(self.frame.prepare(&update_state.graphics));
-        egui_painter.add(luminol_egui_wgpu::Callback::new_paint_callback(
-            canvas_rect,
-            painter,
-        ));
+        ui.painter()
+            .add(luminol_egui_wgpu::Callback::new_paint_callback(
+                canvas_rect,
+                painter,
+            ));
 
         let screen_alpha = (egui::ecolor::linear_from_gamma(screen_color.alpha as f32 / 255.)
             * 255.)
             .round() as u8;
         if screen_alpha > 0 {
-            egui_painter.rect_filled(
+            ui.painter().rect_filled(
                 egui::Rect::EVERYTHING,
                 egui::Rounding::ZERO,
                 egui::Color32::from_rgba_unmultiplied(
@@ -178,21 +177,21 @@ impl AnimationFrameView {
 
         // Draw the grid lines and the border of the animation frame
         if draw_rects {
-            egui_painter.line_segment(
+            ui.painter().line_segment(
                 [
                     egui::pos2(-(FRAME_WIDTH as f32 / 2.), 0.) * scale + offset,
                     egui::pos2(FRAME_WIDTH as f32 / 2., 0.) * scale + offset,
                 ],
                 egui::Stroke::new(1., egui::Color32::DARK_GRAY),
             );
-            egui_painter.line_segment(
+            ui.painter().line_segment(
                 [
                     egui::pos2(0., -(FRAME_HEIGHT as f32 / 2.)) * scale + offset,
                     egui::pos2(0., FRAME_HEIGHT as f32 / 2.) * scale + offset,
                 ],
                 egui::Stroke::new(1., egui::Color32::DARK_GRAY),
             );
-            egui_painter.rect_stroke(
+            ui.painter().rect_stroke(
                 egui::Rect::from_center_size(
                     offset.to_pos2(),
                     egui::vec2(FRAME_WIDTH as f32, FRAME_HEIGHT as f32) * scale,
@@ -269,7 +268,7 @@ impl AnimationFrameView {
                     .iter()
                     .map(|(_, cell)| (cell.rect * scale).translate(offset))
                 {
-                    egui_painter.rect_stroke(
+                    ui.painter().rect_stroke(
                         cell_rect,
                         5.,
                         egui::Stroke::new(1., egui::Color32::DARK_GRAY),
@@ -284,7 +283,7 @@ impl AnimationFrameView {
                 .iter()
                 .map(|(_, cell)| (cell.rect * scale).translate(offset))
             {
-                egui_painter.rect_stroke(
+                ui.painter().rect_stroke(
                     cell_rect,
                     5.,
                     egui::Stroke::new(
@@ -301,7 +300,7 @@ impl AnimationFrameView {
             // Draw a yellow rectangle on the border of the hovered cell
             if let Some(i) = self.hovered_cell_index {
                 let cell_rect = (self.frame.cells()[i].rect * scale).translate(offset);
-                egui_painter.rect_stroke(
+                ui.painter().rect_stroke(
                     cell_rect,
                     5.,
                     egui::Stroke::new(3., egui::Color32::YELLOW),
@@ -311,7 +310,7 @@ impl AnimationFrameView {
             // Draw a magenta rectangle on the border of the selected cell
             if let Some(i) = self.selected_cell_index {
                 let cell_rect = (self.frame.cells()[i].rect * scale).translate(offset);
-                egui_painter.rect_stroke(
+                ui.painter().rect_stroke(
                     cell_rect,
                     5.,
                     egui::Stroke::new(3., egui::Color32::from_rgb(255, 0, 255)),

--- a/crates/ui/src/windows/animations/frame_edit.rs
+++ b/crates/ui/src/windows/animations/frame_edit.rs
@@ -914,7 +914,9 @@ pub fn show_frame_edit(
         state.frame_needs_update = false;
     }
 
-    egui::ScrollArea::horizontal().show_viewport(ui, |ui, scroll_rect| {
+    egui::ScrollArea::horizontal().show_viewport(ui, |ui, mut scroll_rect| {
+        scroll_rect
+            .set_height(luminol_graphics::primitives::cells::CELL_SIZE as f32 * cellpicker.scale);
         cellpicker.ui(update_state, ui, scroll_rect);
     });
 


### PR DESCRIPTION
**Description**
This fixes a bug where if you scroll the main part of the animation editor window to the top, then resize the animation editor window vertically so that only half of the cellpicker is visible, then scroll the animation editor window down, the bottom half of the cellpicker texture is not rendered.

![screenshot](https://github.com/user-attachments/assets/03254dd1-6bec-4604-9210-fe1b3a54a061)

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown -Z build-std=std,panic_abort`
- [x] Run `cargo build --release`
- [ ] If applicable, run `trunk build --release`
