### PR TITLE
Fix FileSystem::write docstring

### DIFF
--- a/crates/filesystem/src/lib.rs
+++ b/crates/filesystem/src/lib.rs
@@ -247,7 +247,8 @@ pub trait FileSystem: Send + Sync {
     }
 
     /// Corresponds to [`std::fs::write()`].
-    /// Will open a file at the path, create it if it exists (and truncate it) and then write the provided bytes.
+    /// Will open a file at the path, create it if it does not exist (and truncate it)
+    /// and then write the provided bytes.
     fn write(&self, path: impl AsRef<camino::Utf8Path>, data: impl AsRef<[u8]>) -> Result<()> {
         use std::io::Write;
 


### PR DESCRIPTION
It does not make sense to create a file when it exists. I guess it must be the opposite, create it when it does *not* exist.

<!-- 
Thanks for filing a pull request! The codeowners file will automatically request reviews.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown -Z build-std=std,panic_abort`
- [ ] Run `cargo build --release`
- [ ] If applicable, run `trunk build --release`
