### PR TITLE
More build diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -995,11 +995,13 @@ checksum = "c59e92b5a388f549b863a7bea62612c09f24c8393560709a54558a9abdfb3b9c"
 
 [[package]]
 name = "cc"
-version = "1.0.88"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02f341c093d19155a6e41631ce5971aac4e9a868262212153124c15fa22d1cdc"
+checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
 dependencies = [
+ "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -1185,6 +1187,32 @@ dependencies = [
  "getrandom",
  "once_cell",
  "tiny-keccak",
+]
+
+[[package]]
+name = "const_fn"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
+
+[[package]]
+name = "const_format"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a214c7af3d04997541b18d432afaff4c455e79e2029079647e72fc2bd27673"
+dependencies = [
+ "const_format_proc_macros",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f6ff08fd20f4f299298a28e2dfa8a8ba1036e6cd2460ac1de7b425d76f2500"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2221,6 +2249,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2552,6 +2593,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows-core 0.52.0",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icrate"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2719,6 +2783,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "is_debug"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d198e9919d9822d5f7083ba8530e04de87841eaf21ead9af8f2304efd57c89"
+
+[[package]]
 name = "iter-read"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2778,6 +2848,15 @@ name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "jpeg-decoder"
@@ -2888,6 +2967,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2934,6 +3025,18 @@ name = "libyml"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e281a65eeba3d4503a2839252f86374528f9ceafe6fed97c1d3b52e1fb625c1"
+
+[[package]]
+name = "libz-sys"
+version = "1.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc53a7799a7496ebc9fd29f31f7df80e83c9bda5299768af5f9e59eeea74647"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "line-wrap"
@@ -3039,6 +3142,7 @@ dependencies = [
  "parking_lot",
  "poll-promise",
  "rfd",
+ "shadow-rs",
  "steamworks",
  "strum",
  "tempfile",
@@ -3827,6 +3931,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.51",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -5145,6 +5258,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "shadow-rs"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25d4535372eab969a98536e39dd272bca49fc338b09b25babea715968d15eeae"
+dependencies = [
+ "const_format",
+ "git2",
+ "is_debug",
+ "time",
+ "tzdb",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5621,7 +5747,9 @@ checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -5937,6 +6065,35 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "tz-rs"
+version = "0.6.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
+dependencies = [
+ "const_fn",
+]
+
+[[package]]
+name = "tzdb"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b580f6b365fa89f5767cdb619a55d534d04a4e14c2d7e5b9a31e94598687fb1"
+dependencies = [
+ "iana-time-zone",
+ "tz-rs",
+ "tzdb_data",
+]
+
+[[package]]
+name = "tzdb_data"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1889fdffac09d65c1d95c42d5202e9b21ad8c758f426e9fe09088817ea998d6"
+dependencies = [
+ "tz-rs",
+]
 
 [[package]]
 name = "uds_windows"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1190,12 +1190,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const_fn"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373e9fafaa20882876db20562275ff58d50e0caa2590077fe7ce7bef90211d0d"
-
-[[package]]
 name = "const_format"
 version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2249,19 +2243,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "git2"
-version = "0.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
-dependencies = [
- "bitflags 2.6.0",
- "libc",
- "libgit2-sys",
- "log",
- "url",
-]
-
-[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2590,29 +2571,6 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
-]
-
-[[package]]
-name = "iana-time-zone"
-version = "0.1.60"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
-dependencies = [
- "android_system_properties",
- "core-foundation-sys",
- "iana-time-zone-haiku",
- "js-sys",
- "wasm-bindgen",
- "windows-core 0.52.0",
-]
-
-[[package]]
-name = "iana-time-zone-haiku"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -2967,18 +2925,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "libgit2-sys"
-version = "0.17.0+1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
-dependencies = [
- "cc",
- "libc",
- "libz-sys",
- "pkg-config",
-]
-
-[[package]]
 name = "libloading"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3025,18 +2971,6 @@ name = "libyml"
 version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e281a65eeba3d4503a2839252f86374528f9ceafe6fed97c1d3b52e1fb625c1"
-
-[[package]]
-name = "libz-sys"
-version = "1.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc53a7799a7496ebc9fd29f31f7df80e83c9bda5299768af5f9e59eeea74647"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "line-wrap"
@@ -5264,10 +5198,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25d4535372eab969a98536e39dd272bca49fc338b09b25babea715968d15eeae"
 dependencies = [
  "const_format",
- "git2",
  "is_debug",
  "time",
- "tzdb",
 ]
 
 [[package]]
@@ -6065,35 +5997,6 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
-
-[[package]]
-name = "tz-rs"
-version = "0.6.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33851b15c848fad2cf4b105c6bb66eb9512b6f6c44a4b13f57c53c73c707e2b4"
-dependencies = [
- "const_fn",
-]
-
-[[package]]
-name = "tzdb"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b580f6b365fa89f5767cdb619a55d534d04a4e14c2d7e5b9a31e94598687fb1"
-dependencies = [
- "iana-time-zone",
- "tz-rs",
- "tzdb_data",
-]
-
-[[package]]
-name = "tzdb_data"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1889fdffac09d65c1d95c42d5202e9b21ad8c758f426e9fe09088817ea998d6"
-dependencies = [
- "tz-rs",
-]
 
 [[package]]
 name = "uds_windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,7 +208,7 @@ async-std.workspace = true
 futures-lite.workspace = true
 
 git-version = "0.3.9"
-shadow-rs = "0.32.0"
+shadow-rs = { version = "0.32.0", default-features = false }
 
 # Native
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -266,7 +266,7 @@ features = ["webgpu", "webgl"]
 steamworks = ["dep:steamworks"]
 
 [build-dependencies]
-shadow-rs = "0.32.0"
+shadow-rs = { version = "0.32.0", default-features = false }
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,6 +208,7 @@ async-std.workspace = true
 futures-lite.workspace = true
 
 git-version = "0.3.9"
+shadow-rs = "0.32.0"
 
 # Native
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -263,6 +264,9 @@ features = ["webgpu", "webgl"]
 
 [features]
 steamworks = ["dep:steamworks"]
+
+[build-dependencies]
+shadow-rs = "0.32.0"
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"

--- a/build.rs
+++ b/build.rs
@@ -35,4 +35,6 @@ fn main() {
 
         let _ = res.compile();
     }
+
+    shadow_rs::new().unwrap();
 }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -88,7 +88,16 @@ pub struct UpdateState<'res> {
     pub modified_during_prev_frame: &'res mut bool,
     pub project_manager: &'res mut ProjectManager,
 
+    pub build_diagnostics: &'static BuildDiagnostics,
+}
+
+pub struct BuildDiagnostics {
+    pub build_time: &'static str,
     pub git_revision: &'static str,
+    pub rustc_version: &'static str,
+    pub cargo_version: &'static str,
+    pub build_os: &'static str,
+    pub is_debug: bool,
 }
 
 /// This stores whether or not there are unsaved changes in any file in the current project and is
@@ -206,7 +215,7 @@ impl<'res> UpdateState<'res> {
             modified: self.modified.clone(),
             modified_during_prev_frame: self.modified_during_prev_frame,
             project_manager: self.project_manager,
-            git_revision: self.git_revision,
+            build_diagnostics: self.build_diagnostics,
         }
     }
 
@@ -230,7 +239,7 @@ impl<'res> UpdateState<'res> {
             modified: self.modified.clone(),
             modified_during_prev_frame: self.modified_during_prev_frame,
             project_manager: self.project_manager,
-            git_revision: self.git_revision,
+            build_diagnostics: self.build_diagnostics,
         }
     }
 

--- a/crates/ui/src/windows/about.rs
+++ b/crates/ui/src/windows/about.rs
@@ -65,7 +65,28 @@ impl luminol_core::Window for Window {
 
                     ui.separator();
                     ui.label(format!("Luminol version {}", env!("CARGO_PKG_VERSION")));
-                    ui.label(format!("git-rev {}", update_state.git_revision));
+                    if update_state.build_diagnostics.is_debug {
+                        ui.label("Debug build");
+                    } else {
+                        ui.label("Release build");
+                    }
+                    ui.label(format!(
+                        "git-rev {}",
+                        update_state.build_diagnostics.git_revision
+                    ));
+                    ui.label(format!(
+                        "built on {}",
+                        update_state.build_diagnostics.build_time
+                    ));
+                    ui.label(format!(
+                        "built with {} {}",
+                        update_state.build_diagnostics.rustc_version,
+                        update_state.build_diagnostics.cargo_version
+                    ));
+                    ui.label(format!(
+                        "build OS: {}",
+                        update_state.build_diagnostics.build_os
+                    ));
                     ui.separator();
 
                     ui.label("Luminol is a FOSS version of the RPG Maker XP editor.");

--- a/crates/ui/src/windows/about.rs
+++ b/crates/ui/src/windows/about.rs
@@ -64,12 +64,18 @@ impl luminol_core::Window for Window {
                     ui.heading("Luminol");
 
                     ui.separator();
+
+                    ui.label("Luminol is a FOSS version of the RPG Maker XP editor.");
+                    ui.separator();
+
+                    ui.label(format!(
+                        "Authors: \n{}",
+                        env!("CARGO_PKG_AUTHORS").replace(':', "\n")
+                    ));
+                    ui.separator();
+
                     ui.label(format!("Luminol version {}", env!("CARGO_PKG_VERSION")));
-                    if update_state.build_diagnostics.is_debug {
-                        ui.label("Debug build");
-                    } else {
-                        ui.label("Release build");
-                    }
+                    ui.label("--- Build time info ---");
                     ui.label(format!(
                         "git-rev {}",
                         update_state.build_diagnostics.git_revision
@@ -79,23 +85,17 @@ impl luminol_core::Window for Window {
                         update_state.build_diagnostics.build_time
                     ));
                     ui.label(format!(
-                        "built with {} {}",
-                        update_state.build_diagnostics.rustc_version,
-                        update_state.build_diagnostics.cargo_version
-                    ));
-                    ui.label(format!(
                         "build OS: {}",
                         update_state.build_diagnostics.build_os
                     ));
-                    ui.separator();
-
-                    ui.label("Luminol is a FOSS version of the RPG Maker XP editor.");
-                    ui.separator();
-
-                    ui.label(format!(
-                        "Authors: \n{}",
-                        env!("CARGO_PKG_AUTHORS").replace(':', "\n")
-                    ))
+                    ui.label("--- Build info ---");
+                    ui.label(update_state.build_diagnostics.rustc_version);
+                    ui.label(update_state.build_diagnostics.cargo_version);
+                    if update_state.build_diagnostics.is_debug {
+                        ui.label("Debug build");
+                    } else {
+                        ui.label("Release build");
+                    }
                 })
             });
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -24,9 +24,9 @@
 
 use std::sync::Arc;
 
-use crate::lumi::Lumi;
 #[cfg(feature = "steamworks")]
 use crate::steam::Steamworks;
+use crate::{lumi::Lumi, BUILD_DIAGNOSTIC};
 
 #[cfg(not(target_arch = "wasm32"))]
 mod log_window;
@@ -344,7 +344,7 @@ impl luminol_eframe::App for App {
             modified: self.modified.clone(),
             modified_during_prev_frame: &mut self.modified_during_prev_frame,
             project_manager: &mut self.project_manager,
-            git_revision: crate::git_revision(),
+            build_diagnostics: &BUILD_DIAGNOSTIC,
         };
 
         // If a file/folder picker is open, prevent the user from interacting with the application

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,6 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with Luminol.  If not, see <http://www.gnu.org/licenses/>.
-//cargo r
 //     Additional permission under GNU GPL version 3 section 7
 //
 // If you modify this Program, or any covered work, by linking or combining
@@ -24,6 +23,8 @@
 #![cfg_attr(target_arch = "wasm32", allow(clippy::arc_with_non_send_sync))]
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")] // hide console window on Windows in release
 #![cfg_attr(target_arch = "wasm32", no_main)] // there is no main function in web builds
+
+shadow_rs::shadow!(build);
 
 #[cfg(not(target_arch = "wasm32"))]
 use std::io::{Read, Write};
@@ -49,7 +50,7 @@ compile_error!("Steamworks is not supported on webassembly");
 #[cfg(feature = "steamworks")]
 mod steam;
 
-pub fn git_revision() -> &'static str {
+const fn git_revision() -> &'static str {
     #[cfg(not(target_arch = "wasm32"))]
     {
         git_version::git_version!()
@@ -57,6 +58,15 @@ pub fn git_revision() -> &'static str {
     #[cfg(target_arch = "wasm32")]
     option_env!("LUMINOL_VERSION").unwrap_or(git_version::git_version!())
 }
+
+pub const BUILD_DIAGNOSTIC: luminol_core::BuildDiagnostics = luminol_core::BuildDiagnostics {
+    build_time: build::BUILD_TIME,
+    rustc_version: build::RUST_VERSION,
+    cargo_version: build::CARGO_VERSION,
+    build_os: build::BUILD_OS,
+    git_revision: git_revision(),
+    is_debug: cfg!(debug_assertions),
+};
 
 #[cfg(not(target_arch = "wasm32"))]
 fn main() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,8 +55,12 @@ const fn git_revision() -> &'static str {
     {
         git_version::git_version!()
     }
+    // I would reach for unwrap_or but it's not const fn yet
     #[cfg(target_arch = "wasm32")]
-    option_env!("LUMINOL_VERSION").unwrap_or(git_version::git_version!())
+    match option_env!("LUMINOL_VERSION") {
+        Some(v) => v,
+        None => git_version::git_version!(),
+    }
 }
 
 pub const BUILD_DIAGNOSTIC: luminol_core::BuildDiagnostics = luminol_core::BuildDiagnostics {


### PR DESCRIPTION
Adds some extra build time info which is handy to have around. The build date is especially useful- it's hard to tell based on solely the git revision when a build of Luminol is from.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown -Z build-std=std,panic_abort`
- [x] Run `cargo build --release`
- [ ] If applicable, run `trunk build --release`
