### PR TITLE
Document dependencies of Luminol and it's crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,6 +177,7 @@ qp-trie = "0.8.2" # An idiomatic and fast QP-trie implementation
 itertools = "0.11.0" # Extra iterator adaptors, methods, functions and macros
 rand = "0.8.5" # Random number generators and other randomness functionality
 lexical-sort = "0.3.1" # Functions that compare and sort strings lexicographically
+indexmap = "2.2.6" # A hash table with consistent order and fast iteration
 
 # Fast and performant.
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,10 +45,13 @@ categories = ["games"]
 
 # Shared dependencies
 [workspace.dependencies]
-egui = "0.28.1"
-egui_extras = { version = "0.28.1", features = ["svg", "image"] }
-epaint = "0.28.1"
-
+# * Window management, graphical user interface and 3D rendering * #
+egui = "0.28.1" # Real-time stateless graphical user interface framework
+egui_extras = { version = "0.28.1", features = [
+    "svg",
+    "image",
+] } # Official add-ons to egui, like "Table", "TableBody", "Column", "DatePickerButton", etc.
+epaint = "0.28.1" # 2D graphics library for turning simple two dimensional shapes into textured triangles
 luminol-eframe = { version = "0.4.0", path = "crates/eframe/", features = [
     "wgpu",
     "accesskit",
@@ -56,89 +59,103 @@ luminol-eframe = { version = "0.4.0", path = "crates/eframe/", features = [
     "default_fonts",
     "x11",
     "wayland",
-], default-features = false }
-luminol-egui-wgpu = { version = "0.4.0", path = "crates/egui-wgpu/" }
-egui-winit = "0.28.1"
+], default-features = false } # Egui initialisation library. Responsible for creating and managing the main window and all appropriate graphics contexts
+luminol-egui-wgpu = { version = "0.4.0", path = "crates/egui-wgpu/" } # Bindings between wgpu and egui
+egui-winit = "0.28.1" # Winit event translation library for egui
+egui_dock = "0.13.0" # Docking support for egui
+egui-notify = "0.15.0" # In-app toast notification library for egui
+egui-modal = "0.4.0" # "Modals" for egui. A "Modal" is a window with custom content that requires user's immediate attention
+rfd = "0.14.1" # File picker and message dialogs
 
-egui_dock = "0.13.0"
-egui-notify = "0.15.0"
-egui-modal = "0.4.0"
+raw-window-handle = "0.6.0"                              # Window interoperability library that provides a platform-specific native handle to the specified window
+winit = { version = "0.29.4", default-features = false } # Window creation and management library
 
-wgpu = { version = "0.20.0", features = ["naga-ir"] }
-naga = "0.20.0"
-naga_oil = "0.14.0"
-glam = { version = "0.24.2", features = ["bytemuck"] }
-image = { version = "0.25.0", features = ["png"] }
+wgpu = { version = "0.20.0", features = [
+    "naga-ir",
+] } # An abstraction layer for OpenGL, Vulkan, DirectX/Direct3D and Metal
+naga = "0.20.0" # Wgpu shader parser
+naga_oil = "0.14.0" # An extension to naga. Allows combining and manipulating wgpu shaders (for example, through '#import' statements)
+glutin = "0.31" # Cross-platform OpenGL context provider
+glutin-winit = "0.4" # Bootstrapping helpers with winit for Glutin
 
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-serde_yml = "0.0.10"
-alox-48 = { version = "0.6.0" }
-ron = "0.8.1"
-rust-ini = "0.20.0"
+image = { version = "0.25.0", features = [
+    "png",
+] } # Image processing library. Supported image formats: https://crates.io/crates/image#supported-image-formats
 
+alacritty_terminal = "0.22.0" # A library for writing terminal emulators, based on Alacritty, a fast, cross-platform OpenGL terminal emulator
+
+# * Data processing * #
+serde = { version = "1.0", features = [
+    "derive",
+] } # Data serialisation/deserialisation framework
+serde_json = "1.0" # JSON (de)serialisation library, based on serde 
+serde_yml = "0.0.10" # YAML (de)serialisation library, based on serde
+alox-48 = { version = "0.6.0" } # An in-house Ruby Marshal data format (de)serialisation library
+ron = "0.8.1" # RON (de)serialisation library, based on serde
+rust-ini = "0.20.0" # INI (de)serialisation library
+
+# * Mathematics * #
+glam = { version = "0.24.2", features = [
+    "bytemuck",
+] } # 3D math library, adds types like two/three dimensional vectors and supplementary methods
 bytemuck = { version = "1.14.0", features = [
     "extern_crate_alloc",
     "derive",
     "min_const_generics",
-] }
+] } # Bit casting between data types
 
-tracing = "0.1.37"
+# * Logging and diagnostics * #
+log = { version = "0.4", features = [
+    "std",
+] } # Logging facade to be replaced by a proper logger
+tracing = "0.1.37" # Structured, event-based, application-level diagnostics
+color-eyre = "0.6.2" # An error report handler for panics, based on the 'eyre' crate
+puffin = "0.19" # Instrumentation profiler
 
-strum = { version = "0.25.0", features = ["derive"] }
-paste = "1.0.14"
-thiserror = "1.0.37"
-bitflags = "2.4.0"
-color-eyre = "0.6.2"
+# * Useful procedural macros * #
+strum = { version = "0.25.0", features = [
+    "derive",
+] } # Useful 'derive' macros for enumerations, like 'EnumString' which converts strings to enum variants
+paste = "1.0.14" # A flexible way ot paste together identifiers in a macro, including using pasted identifiers to define new ones. Does not rely on a nightly feature 'concat_idents'
+thiserror = "1.0.37" # derive(Error)
+bitflags = "2.4.0" # A way to generate bitflags out of enumerations
+document-features = "0.2.8" # Macro that extracts documentation comments from Cargo.toml
 
-puffin = "0.19"
-raw-window-handle = "0.6.0"
-winit = { version = "0.29.4", default-features = false }
-log = { version = "0.4", features = ["std"] }
-document-features = "0.2.8"
-web-time = "0.2"
-ahash = "0.8.11"
-glutin = "0.31"
-glutin-winit = "0.4"
+# * Platform interoperability interfaces * #
+web-time = "0.2" # Drop-in replacement for std::time on WebAssembly platforms
 
+# * Cryptography and hashing * #
+ahash = "0.8.11"  # A non-cryptographic hash function using AES-NI
+murmur3 = "0.5.2" # An implementation of the Murmur3 hash
+
+# * More efficient implementations of individual components of Rust's Standard Library * #
 parking_lot = { version = "0.12.3", features = [
     "nightly",            # This is required for parking_lot to work properly in WebAssembly builds with atomics support
     "deadlock_detection",
-] }
-once_cell = "1.18.0"
-crossbeam = "0.8.2"
-dashmap = "5.5.3"
-flume = "0.11.0"
-oneshot = "0.1.6"
-futures-lite = "2.1.0"
-async-std = "1.12.0"
-pin-project = "1"
-fragile = "2.0"
+] } # More compact and efficient implementations of the standard synchronisation primitives (Mutex, RwLock, Condvar and Once)
+once_cell = "1.18.0" # Single assignment cells and lazy values
+crossbeam = "0.8.2" # Functions for better concurrent programming (replaces functions like std::sync::mpsc:channel)
+dashmap = "5.5.3" # More efficient replacement of the HashMap structure
+futures-lite = "2.1.0" # Lightweight, more safe replacement of 'futures'
 
-poll-promise = { version = "0.3.0" }
+# * Tools to aid concurrent programming * #
+flume = "0.11.0"       # Fast multi-producer, multi-consumer channel
+oneshot = "0.1.6"      # Oneshot single-producer, single-consumer channels
+async-std = "1.12.0"   # Asynchronous version of the Rust Standard Library
+fragile = "2.0"        # Provides wrapper types for sending non-Send values to other threads
+poll-promise = "0.3.0" # A crate for polling the result of an asynchronous operation
 
-camino = "1.1.6"
+# * File system interfaces * #
+camino = "1.1.6"   # UTF-8 paths
+tempfile = "3.8.1" # A crate for creating and managing temporary directories and files
 
-slab = { version = "0.4.9", features = ["serde"] }
-qp-trie = "0.8.2"
+# * Adapters for web APIs * #
+wasm-bindgen = "0.2.91"         # Easy support for interacting between Javacript and Rust
+wasm-bindgen-futures = "0.4.42" # Conversion between Rust's Futures and JavaScript's Promises
+web-sys = "0.3.67"              # Bindings for all web APIs
+js-sys = "0.3"                  # Bindings for all JS objects and functions
 
-itertools = "0.11.0"
-
-rfd = "0.14.1"
-tempfile = "3.8.1"
-
-rand = "0.8.5"
-murmur3 = "0.5.2"
-
-alacritty_terminal = "0.22.0"
-
-wasm-bindgen = "0.2.91"
-wasm-bindgen-futures = "0.4.42"
-web-sys = "0.3.67"
-js-sys = "0.3"
-
-lexical-sort = "0.3.1"
-
+# * Luminol's crates * #
 luminol-audio = { version = "0.4.0", path = "crates/audio/" }
 luminol-config = { version = "0.4.0", path = "crates/config/" }
 luminol-core = { version = "0.4.0", path = "crates/core/" }
@@ -151,8 +168,15 @@ luminol-term = { version = "0.4.0", path = "crates/term/" }
 luminol-ui = { version = "0.4.0", path = "crates/ui/" }
 luminol-result = { version = "0.4.0", path = "crates/result" }
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
+# * Misc. * #
+pin-project = "1" # Safe and ergonomic pin-projection
+slab = { version = "0.4.9", features = [
+    "serde",
+] } # Pre-allocated storage for a uniform data type
+qp-trie = "0.8.2" # An idiomatic and fast QP-trie implementation
+itertools = "0.11.0" # Extra iterator adaptors, methods, functions and macros
+rand = "0.8.5" # Random number generators and other randomness functionality
+lexical-sort = "0.3.1" # Functions that compare and sort strings lexicographically
 
 # Fast and performant.
 [profile.release]

--- a/crates/audio/Cargo.toml
+++ b/crates/audio/Cargo.toml
@@ -17,31 +17,50 @@ categories.workspace = true
 workspace = true
 
 [dependencies]
-rustysynth = "1.3.1"
+# * Audio * #
+rustysynth = "1.3.1" # SoundFont MIDI synthesizer
 
-strum.workspace = true
-parking_lot.workspace = true
-camino.workspace = true
-once_cell.workspace = true
-
+# * Logging and diagnostics * #
 color-eyre.workspace = true
+
+# * Useful procedural macros * #
+strum.workspace = true
 thiserror.workspace = true
 
-luminol-config.workspace = true
-luminol-filesystem.workspace = true
+# * More efficient implementations of individual components of Rust's Standard Library * #
+parking_lot.workspace = true
+once_cell.workspace = true
+
+# * Tools to aid concurrent programming * #
 fragile.workspace = true
 
+# * File system interfaces * #
+camino.workspace = true
+
+# * Luminol's crates * #
+luminol-config.workspace = true
+luminol-filesystem.workspace = true
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-rodio = "0.19.0"
+# * Audio * #
+rodio = "0.19.0" # Audio playback
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-rodio = { version = "0.19.0", features = ["wasm-bindgen"] }
+# * Audio * #
+rodio = { version = "0.19.0", features = [
+    "wasm-bindgen",
+] } # Audio playback (web)
 
-web-sys.workspace = true
-wasm-bindgen-futures.workspace = true
+# * More efficient implementations of individual components of Rust's Standard Library * #
+once_cell.workspace = true
 
+# * Tools to aid concurrent programming * #
 flume.workspace = true
 oneshot.workspace = true
 
-once_cell.workspace = true
+# * Adapters for web APIs * #
+web-sys.workspace = true
+wasm-bindgen-futures.workspace = true
+
+# * Misc. * #
 slab.workspace = true

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -35,7 +35,7 @@ once_cell.workspace = true
 luminol-data.workspace = true
 
 # * Misc. * #
-indexmap = "2.2.6" # A hash table with consistent order and fast iteration
+indexmap.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 # * Window management, graphical user interface and 3D rendering * #

--- a/crates/config/Cargo.toml
+++ b/crates/config/Cargo.toml
@@ -17,17 +17,26 @@ categories.workspace = true
 workspace = true
 
 [dependencies]
+# * Window management, graphical user interface and 3D rendering * #
 egui.workspace = true
-rust-ini.workspace = true
+
+# * Data processing * #
 serde.workspace = true
-
-strum.workspace = true
 ron.workspace = true
+rust-ini.workspace = true
 
+# * Useful procedural macros * #
+strum.workspace = true
+
+# * More efficient implementations of individual components of Rust's Standard Library * #
 once_cell.workspace = true
 
+# * Luminol's crates * #
 luminol-data.workspace = true
-indexmap = "2.2.6"
+
+# * Misc. * #
+indexmap = "2.2.6" # A hash table with consistent order and fast iteration
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# * Window management, graphical user interface and 3D rendering * #
 alacritty_terminal.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -17,32 +17,42 @@ categories.workspace = true
 workspace = true
 
 [dependencies]
+# * Window management, graphical user interface and 3D rendering * #
 egui.workspace = true
 egui_dock.workspace = true
 egui-notify.workspace = true
 egui-modal.workspace = true
 
-poll-promise.workspace = true
-once_cell.workspace = true
+# * Data processing * #
+serde.workspace = true
+serde_path_to_error = "0.1.0" # Path to the element that failed to deserialise
+alox-48.workspace = true
+serde_json.workspace = true
+ron.workspace = true
 
+# * Logging and diagnostics * #
 tracing.workspace = true
 color-eyre.workspace = true
 
+# * Useful procedural macros * #
+strum.workspace = true
+
+# * More efficient implementations of individual components of Rust's Standard Library * #
+once_cell.workspace = true
+
+# * Tools to aid concurrent programming * #
+poll-promise.workspace = true
+
+# * File system interfaces * #
 camino.workspace = true
 
-itertools.workspace = true
-
-strum.workspace = true
-serde.workspace = true
-serde_path_to_error = "0.1.0"
-alox-48.workspace = true
-serde_json = "1.0.120"
-ron.workspace = true
-
-rand.workspace = true
-
+# * Luminol's crates * #
 luminol-audio.workspace = true
 luminol-config.workspace = true
 luminol-data.workspace = true
 luminol-filesystem.workspace = true
 luminol-graphics.workspace = true
+
+# * Misc. * #
+itertools.workspace = true
+rand.workspace = true

--- a/crates/data/Cargo.toml
+++ b/crates/data/Cargo.toml
@@ -17,16 +17,24 @@ categories.workspace = true
 workspace = true
 
 [dependencies]
-num_enum = "0.7.0"
-
-rand.workspace = true
-
-flate2 = "1.0"
-base64 = "0.22.1"
-
+# * Data processing * #
 serde.workspace = true
 alox-48.workspace = true
+
+# * Mathematics * #
 bytemuck.workspace = true
+
+# * Useful procedural macros * #
+num_enum = "0.7.0"     # Procedural macros to make inter-operation between primitives and enums easier
 strum.workspace = true
 paste.workspace = true
+
+# * Cryptography and hashing * #
+base64 = "0.22.1" # Implementation of the base64 hashing algorithm
+
+# * File system interfaces * #
 camino.workspace = true
+
+# * Misc * #
+rand.workspace = true
+flate2 = "1.0"        # DEFLATE compression and decompression exposed as Read/BufRead/Write streams

--- a/crates/filesystem/Cargo.toml
+++ b/crates/filesystem/Cargo.toml
@@ -17,54 +17,69 @@ categories.workspace = true
 workspace = true
 
 [dependencies]
-rfd.workspace = true
-
-color-eyre.workspace = true
-thiserror.workspace = true
-bitflags.workspace = true
-
-camino.workspace = true
-
-itertools.workspace = true
-
-dashmap.workspace = true
-parking_lot.workspace = true
-futures-lite.workspace = true
-async-std.workspace = true
-pin-project.workspace = true
-
+# * Window management, graphical user interface and 3D rendering * #
 egui.workspace = true
 
+rfd.workspace = true
+
+# * Data processing * #
 ron.workspace = true
 rust-ini.workspace = true
 
+# * Logging and diagnostics * #
 tracing.workspace = true
+color-eyre.workspace = true
 
+# * Useful procedural macros * #
+thiserror.workspace = true
+bitflags.workspace = true
+
+# * More efficient implementations of individual components of Rust's Standard Library * #
+parking_lot.workspace = true
+dashmap.workspace = true
+futures-lite.workspace = true
+
+# * Tools to aid concurrent programming * #
+async-std.workspace = true
+async_io_stream = "0.3.3"  # Better futures-util::IntoAsyncRead
+
+# * File system interfaces * #
+camino.workspace = true
+
+# * Luminol's crates * #
 luminol-config.workspace = true
 
-rand.workspace = true
-
-iter-read = "1.0.1"
-async_io_stream = "0.3.3"
-
-qp-trie.workspace = true
+# * Misc. * #
+pin-project.workspace = true
 slab.workspace = true
+qp-trie.workspace = true
+itertools.workspace = true
+rand.workspace = true
+iter-read = "1.0.1"          # A Read implementation for iterators over u8 and related data types
 
 [target.'cfg(windows)'.dependencies]
-winreg = "0.51.0"
+# * System calls * #
+winreg = "0.51.0" # Rust bindings to the Windows Registry API
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# * More efficient implementations of individual components of Rust's Standard Library * #
+async-fs = "2.1.0" # Asynchronous version of `std::fs`
+
+# * File system interfaces * #
 tempfile.workspace = true
-async-fs = "2.1.0"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+# * More efficient implementations of individual components of Rust's Standard Library * #
 once_cell.workspace = true
 
-luminol-web = { version = "0.4.0", path = "../web/" }
-
+# * Tools to aid concurrent programming * #
 flume.workspace = true
 oneshot.workspace = true
 
+# * Luminol's crates * #
+luminol-web = { version = "0.4.0", path = "../web/" }
+
+# * Adapters for web APIs * #
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true
 js-sys.workspace = true

--- a/crates/graphics/Cargo.toml
+++ b/crates/graphics/Cargo.toml
@@ -17,30 +17,38 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-image = "0.24.7"
-
+# * Window management, graphical user interface and 3D rendering * #
 egui.workspace = true
 luminol-egui-wgpu.workspace = true
-wgpu.workspace = true
-glam.workspace = true
 
+wgpu.workspace = true
 naga.workspace = true
 naga_oil.workspace = true
 
-crossbeam.workspace = true
-dashmap.workspace = true
-parking_lot.workspace = true
+image = "0.24.7"
 
-color-eyre.workspace = true
-
+# * Mathematics * #
+glam.workspace = true
 bytemuck.workspace = true
 
-itertools.workspace = true
+# * Logging and diagnostics * #
+color-eyre.workspace = true
 
+# * More efficient implementations of individual components of Rust's Standard Library * #
+parking_lot.workspace = true
+crossbeam.workspace = true
+dashmap.workspace = true
+
+# * Tools to aid concurrent programming * #
+fragile.workspace = true
+
+# * File system interfaces * #
 camino.workspace = true
 
+# * Luminol's crates * #
 luminol-data.workspace = true
 luminol-filesystem.workspace = true
 luminol-macros.workspace = true
 
-fragile.workspace = true
+# * Misc. * #
+itertools.workspace = true

--- a/crates/launcher/Cargo.toml
+++ b/crates/launcher/Cargo.toml
@@ -14,49 +14,55 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-luminol-eframe.workspace = true
-luminol-egui-wgpu.workspace = true
-luminol-macros.workspace = true
+# * Window management, graphical user interface and 3D rendering * #
 egui.workspace = true
 egui_extras.workspace = true
+luminol-eframe.workspace = true
+luminol-egui-wgpu.workspace = true
+rfd.workspace = true
 
 wgpu.workspace = true
 
-rfd.workspace = true
-
-parking_lot.workspace = true
-once_cell.workspace = true
-
 image.workspace = true
 
-tracing-subscriber = "0.3.17"
+# * Logging and diagnostics * #
+tracing-subscriber = "0.3.17" # Utilities for implementing `tracing` subscribers
 color-eyre.workspace = true
 
+# * Useful procedural macros * #
+strum.workspace = true
+
+# * More efficient implementations of individual components of Rust's Standard Library * #
+parking_lot.workspace = true
+once_cell.workspace = true
+futures-lite.workspace = true
+
+# * Tools to aid concurrent programming * #
+async-std.workspace = true
+
+# * File system interfaces * #
+camino.workspace = true
+
+# * Luminol's crates * #
 luminol-audio.workspace = true
 luminol-core.workspace = true
 luminol-config.workspace = true
 luminol-filesystem.workspace = true
 luminol-graphics.workspace = true
+luminol-macros.workspace = true
 luminol-ui.workspace = true
 luminol-result.workspace = true
 # luminol-windows = { version = "0.1.0", path = "../windows/" }
 # luminol-tabs = { version = "0.1.0", path = "../tabs/" }
 
-camino.workspace = true
-
-strum.workspace = true
-
-zstd = "0.13.0"
-
-async-std.workspace = true
-futures-lite.workspace = true
-
-git-version = "0.3.9"
-shadow-rs = { version = "0.32.0", default-features = false }
+# * Misc * #
+zstd = "0.13.0"                                              # Bindings to the zstd compression library
+git-version = "0.3.9"                                        # Git version and dirty state in compile time
+shadow-rs = { version = "0.32.0", default-features = false } # Build-time information about the project and it's git repository
 
 # Native
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-steamworks = { version = "0.10.0", optional = true }
+# * Tools to aid concurrent programming * #
 tokio = { version = "1.33", features = [
     "sync",
     "macros",
@@ -64,8 +70,15 @@ tokio = { version = "1.33", features = [
     "rt-multi-thread",
     "parking_lot",
 ] } # *sigh*
+
+# * File system interfaces * #
 tempfile.workspace = true
+
+# * Luminol's crates * #
 luminol-term.workspace = true
+
+# * Misc. * #
+steamworks = { version = "0.10.0", optional = true } # Bindings to the Steamworks API
 
 # Set poll promise features here based on the target
 # I'd much rather do it in the workspace, but cargo doesn't support that yet
@@ -80,19 +93,23 @@ workspace = true
 features = ["web"]
 
 # Web
-# Look into somehow pinning these as workspace dependencies
+# FIXME: Look into somehow pinning these as workspace dependencies
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+# * Logging and diagnostics * #
+tracing.workspace = true
+tracing-wasm = "0.2"     # tracing subscriber for WebAssembly
+tracing-log = "0.1.3"    # Provides compatibility between `tracing` and `log` crates
+
+# * Tools to aid concurrent programming * #
+oneshot.workspace = true
+
+# * Luminol's crates * #
+luminol-web = { version = "0.4.0", path = "../web/" }
+
+# * Adapters for web APIs * #
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true
 js-sys.workspace = true
-
-oneshot.workspace = true
-
-luminol-web = { version = "0.4.0", path = "../web/" }
-
-tracing-wasm = "0.2"
-tracing-log = "0.1.3"
-tracing.workspace = true
 
 web-sys = { workspace = true, features = [
     "BeforeUnloadEvent",
@@ -113,10 +130,10 @@ features = ["webgpu", "webgl"]
 steamworks = ["dep:steamworks", "luminol-result/steamworks"]
 
 [build-dependencies]
-shadow-rs = { version = "0.32.0", default-features = false }
+shadow-rs = { version = "0.32.0", default-features = false } # Build-time information about the project and it's git repository
 
 [target.'cfg(windows)'.build-dependencies]
-winres = "0.1"
+winres = "0.1" # Metainformation and icons for Windows
 
 [package.metadata.winres]
 OriginalFilename = "Luminol.exe"

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -11,6 +11,7 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
+# * Luminol's crates * #
 luminol-proc-macros.workspace = true
 
 [lints]

--- a/crates/proc-macros/Cargo.toml
+++ b/crates/proc-macros/Cargo.toml
@@ -20,5 +20,6 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-syn = "2.0"
-quote = "1.0"
+# * Misc. * #
+syn = "2.0"   # Rust source code parser
+quote = "1.0" # Quasi-quoating macro

--- a/crates/result/Cargo.toml
+++ b/crates/result/Cargo.toml
@@ -16,16 +16,24 @@ categories.workspace = true
 workspace = true
 
 [dependencies]
-thiserror.workspace = true
-color-eyre.workspace = true
-tempfile.workspace = true
+# * Window management, graphical user interface and 3D rendering * #
 image.workspace = true
 
+# * Logging and diagnostics * #
+color-eyre.workspace = true
+
+# * Useful procedural macros * #
+thiserror.workspace = true
+
+# * File system interfaces * #
+tempfile.workspace = true
+
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-tracing-log = "0.1.3"
+tracing-log = "0.1.3" # Provides compatibility between `tracing` and `log` crates
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-steamworks = { optional = true, version = "0.10.0" }
+steamworks = { optional = true, version = "0.10.0" } # Bindings to the Steamworks API
 
 [features]
 steamworks = ["dep:steamworks"]

--- a/crates/term/Cargo.toml
+++ b/crates/term/Cargo.toml
@@ -17,19 +17,25 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# * Window management, graphical user interface and 3D rendering * #
 egui.workspace = true
 
+# * Data processing * #
 serde.workspace = true
 
+# * Useful procedural macros * #
+strum.workspace = true
+
+# * Luminol's crates * #
 luminol-core.workspace = true
 luminol-config.workspace = true
 luminol-macros.workspace = true
 luminol-audio.workspace = true
 color-eyre.workspace = true
 
-strum.workspace = true
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-crossbeam-channel = "0.5"
+# * Window management, graphical user interface and 3D rendering * #
+alacritty_terminal.workspace = true
 
-alacritty_terminal = "0.22.0"
+# * More efficient implementations of individual components of Rust's Standard Library * #
+crossbeam-channel = "0.5" # Multi-producer multi-consumer channels

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -76,7 +76,6 @@ zip = { version = "0.6.6", default-features = false, features = [
     "deflate",
 ] } # Library to support the reading and writing of zip files
 indextree = "4.6.0" # Arena based tree structure by using indices instead of reference counted pointers
-indexmap = "2.2.6" # A hash table with consistent order and fast iteration
 fuzzy-matcher = "0.3.7" # Fuzzy matching algorithms
 syntect = { version = "5.1.0", default-features = false, features = [
     "default-fancy",
@@ -84,6 +83,7 @@ syntect = { version = "5.1.0", default-features = false, features = [
 qp-trie.workspace = true
 lexical-sort.workspace = true
 itertools.workspace = true
+indexmap.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 luminol-term = { version = "0.4.0", path = "../term/" }

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -17,6 +17,49 @@ workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+# * Window management, graphical user interface and 3D rendering * #
+egui.workspace = true
+egui-modal.workspace = true
+
+wgpu.workspace = true
+
+image.workspace = true
+
+# * Data processing * #
+serde.workspace = true
+serde_json.workspace = true
+serde_yml.workspace = true
+alox-48.workspace = true
+ron.workspace = true
+
+# * Mathematics * #
+glam.workspace = true
+
+# * Logging and diagnostics * #
+color-eyre.workspace = true
+
+# * Useful procedural macros * #
+strum.workspace = true
+target-triple = "0.1.2" # $TARGET and $HOST triples in runtime source code
+
+# * Cryptography and hashing * #
+murmur3.workspace = true
+
+# * More efficient implementations of individual components of Rust's Standard Library * #
+parking_lot.workspace = true
+once_cell.workspace = true
+futures-lite.workspace = true
+
+# * Tools to aid concurrent programming * #
+futures-util = "0.3.30"       # Common utilities and extension traits for the futures-rs library
+oneshot.workspace = true
+async-std.workspace = true
+poll-promise.workspace = true
+
+# * File system interfaces * #
+camino.workspace = true
+
+# * Luminol's crates * #
 luminol-audio.workspace = true
 luminol-core.workspace = true
 luminol-config.workspace = true
@@ -26,57 +69,21 @@ luminol-filesystem.workspace = true
 luminol-macros.workspace = true
 luminol-egui-wgpu.workspace = true
 
-egui.workspace = true
-egui-modal.workspace = true
-
-camino.workspace = true
-
-strum.workspace = true
-
-serde.workspace = true
-serde_json.workspace = true
-serde_yml.workspace = true
-ron.workspace = true
-
-target-triple = "0.1.2"
-
-strip-ansi-escapes = "0.2.0"
-
-poll-promise.workspace = true
-async-std.workspace = true
-futures-lite.workspace = true
-futures-util = "0.3.30"
-reqwest = { version = "0.11.23", features = ["json"] }
-
-zip = { version = "0.6.6", default-features = false, features = ["deflate"] }
-
-parking_lot.workspace = true
-once_cell.workspace = true
-qp-trie.workspace = true
-indextree = "4.6.0"
-lexical-sort.workspace = true
-
-itertools.workspace = true
-
-color-eyre.workspace = true
-
-wgpu.workspace = true
-
-murmur3.workspace = true
-indexmap = "2.2.6"
-alox-48.workspace = true
-
-fuzzy-matcher = "0.3.7"
-
-glam.workspace = true
-
-oneshot.workspace = true
-
-image.workspace = true
-
+# * Misc. #
+strip-ansi-escapes = "0.2.0" # Strip ANSI escape sequences from byte streams
+reqwest = { version = "0.11.23", features = ["json"] } # HTTP client
+zip = { version = "0.6.6", default-features = false, features = [
+    "deflate",
+] } # Library to support the reading and writing of zip files
+indextree = "4.6.0" # Arena based tree structure by using indices instead of reference counted pointers
+indexmap = "2.2.6" # A hash table with consistent order and fast iteration
+fuzzy-matcher = "0.3.7" # Fuzzy matching algorithms
 syntect = { version = "5.1.0", default-features = false, features = [
     "default-fancy",
-] }
+] } # High-quality syntax highlighting and code intelligence using Sublime Text's grammars
+qp-trie.workspace = true
+lexical-sort.workspace = true
+itertools.workspace = true
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 luminol-term = { version = "0.4.0", path = "../term/" }

--- a/crates/web/Cargo.toml
+++ b/crates/web/Cargo.toml
@@ -13,13 +13,11 @@ categories.workspace = true
 [lints]
 workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
+# * Adapters for web APIs * #
+indexed_db_futures = "0.4.1" # Future bindings for IndexedDB
 wasm-bindgen.workspace = true
 wasm-bindgen-futures.workspace = true
-indexed_db_futures = "0.4.1"
-
 js-sys.workspace = true
 web-sys = { workspace = true, features = [
     "DedicatedWorkerGlobalScope",


### PR DESCRIPTION
**Connections**
None

**Description**
Dependencies are declared in an illogical order in Luminol and it's crates (`audio`, `config`, etc.), which can make it hard to pinpoint them when needed. It's also a head-scratcher when you want to add a new dependency, because you don't know if you should place it in the end of the `[dependencies]` section or somewhere specific.

**Testing**
- `cargo build`
- `trunk build`

<!-- 
Thanks for filing a pull request! The codeowners file will automatically request reviews.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown -Z build-std=std,panic_abort`
- [x] Run `cargo build --release`
- [x] If applicable, run `trunk build --release`
