### PR TITLE
Update flume to 0.11.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,9 @@
 #! Rust Build Output
 /target
-/marshal/target
-/crates/launcher/dist
+dist/
 
 #! GDB-related files
 .gdb_*
-
-#! Ruby Output Files
-/marshal_ruby
-/marshal_luminol
 
 #! conventional commits config
 git-conventional-commits.yaml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1955,8 +1955,9 @@ checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
 
 [[package]]
 name = "flume"
-version = "0.11.0"
-source = "git+https://github.com/Astrabit-ST/flume?rev=d323799efea329c87a3a5a5b45cc76f46da278c2#d323799efea329c87a3a5a5b45cc76f46da278c2"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3050,6 +3051,7 @@ dependencies = [
  "color-eyre",
  "egui",
  "egui_extras",
+ "flume",
  "futures-lite 2.2.0",
  "git-version",
  "image 0.25.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,7 +139,7 @@ dashmap = "5.5.3" # More efficient replacement of the HashMap structure
 futures-lite = "2.1.0" # Lightweight, more safe replacement of 'futures'
 
 # * Tools to aid concurrent programming * #
-flume = "0.11.0"       # Fast multi-producer, multi-consumer channel
+flume = "0.11.1"       # Fast multi-producer, multi-consumer channel
 oneshot = "0.1.6"      # Oneshot single-producer, single-consumer channels
 async-std = "1.12.0"   # Asynchronous version of the Rust Standard Library
 fragile = "2.0"        # Provides wrapper types for sending non-Send values to other threads
@@ -218,12 +218,6 @@ opt-level = 3
 
 # See why config is set up this way.
 # https://bevy-cheatbook.github.io/pitfalls/performance.html#why-not-use---release
-
-[patch.crates-io]
-# flume's global spinlock uses `thread::sleep` which doesn't work in the main thread in WebAssembly.
-# This is a patched version with `thread::sleep` removed in WebAssembly builds.
-# See https://github.com/zesterer/flume/issues/137.
-flume = { git = "https://github.com/Astrabit-ST/flume", rev = "d323799efea329c87a3a5a5b45cc76f46da278c2" }
 
 # If you want to use the bleeding edge version of egui and eframe:
 # egui = { git = "https://github.com/emilk/egui", branch = "master" }

--- a/crates/launcher/Cargo.toml
+++ b/crates/launcher/Cargo.toml
@@ -80,7 +80,7 @@ luminol-term.workspace = true
 # * Misc. * #
 steamworks = { version = "0.10.0", optional = true } # Bindings to the Steamworks API
 
-# Enable the spin feature on web, because we can't block the main thread (see 
+# Enable the spin feature on web, because we can't block the main thread (see https://github.com/zesterer/flume/issues/137)
 [target.'cfg(target_arch = "wasm32")'.dependencies.flume]
 workspace = true
 features = ["spin"]

--- a/crates/launcher/Cargo.toml
+++ b/crates/launcher/Cargo.toml
@@ -80,6 +80,11 @@ luminol-term.workspace = true
 # * Misc. * #
 steamworks = { version = "0.10.0", optional = true } # Bindings to the Steamworks API
 
+# Enable the spin feature on web, because we can't block the main thread (see 
+[target.'cfg(target_arch = "wasm32")'.dependencies.flume]
+workspace = true
+features = ["spin"]
+
 # Set poll promise features here based on the target
 # I'd much rather do it in the workspace, but cargo doesn't support that yet
 #


### PR DESCRIPTION
**Connections**
https://github.com/zesterer/flume/issues/137
https://github.com/zesterer/flume/pull/138

**Description**
This PR removes our last git dependency by updating flume to `0.11.1`, meaning we can publish to crates.io!

**Testing**
I ran Luminol in the browser and it didn't crash! There seems to an unrelated crash when opening certain maps that I need to investigate. I have a feeling it's caused by [this code](https://github.com/Astrabit-ST/Luminol/blob/dev/crates/graphics/src/primitives/tiles/display.rs#L81) but I'm not entirely sure because I don't have a backtrace.

<!-- 
Thanks for filing a pull request! The codeowners file will automatically request reviews.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [ ] Run `cargo fmt`.
- [ ] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown -Z build-std=std,panic_abort`
- [x] Run `cargo build --release`
- [x] If applicable, run `trunk build --release`
