### PR TITLE
Fix `TargetAlignmentGreaterAndInputNotAligned` panic when loading maps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
 
 [[package]]
+name = "aligned-vec"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e0966165eaf052580bd70eb1b32cb3d6245774c0104d1b2793e9650bf83b52a"
+dependencies = [
+ "equator",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,6 +1788,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "equator"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c35da53b5a021d2484a7cc49b2ac7f2d840f8236a286f84202369bd338d761ea"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bf679796c0322556351f287a51b49e48f7c4986e727b5dd78c972d30e2e16cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.51",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3273,6 +3302,7 @@ dependencies = [
 name = "luminol-graphics"
 version = "0.4.0"
 dependencies = [
+ "aligned-vec 0.6.1",
  "bytemuck",
  "camino",
  "color-eyre",
@@ -3289,6 +3319,7 @@ dependencies = [
  "luminol-macros",
  "naga",
  "naga_oil",
+ "num-integer",
  "parking_lot",
  "wgpu",
 ]
@@ -6079,7 +6110,7 @@ version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f32aaa24bacd11e488aa9ba66369c7cd514885742c9fe08cfe85884db3e92b"
 dependencies = [
- "aligned-vec",
+ "aligned-vec 0.5.0",
  "num-traits",
  "wasm-bindgen",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ naga = "0.20.0" # Wgpu shader parser
 naga_oil = "0.14.0" # An extension to naga. Allows combining and manipulating wgpu shaders (for example, through '#import' statements)
 glutin = "0.31" # Cross-platform OpenGL context provider
 glutin-winit = "0.4" # Bootstrapping helpers with winit for Glutin
+aligned-vec = "0.6.1" # Implementations of `Vec` and `Box` with runtime-definable memory alignment
 
 image = { version = "0.25.0", features = [
     "png",
@@ -105,6 +106,7 @@ bytemuck = { version = "1.14.0", features = [
     "derive",
     "min_const_generics",
 ] } # Bit casting between data types
+num-integer = "0.1.46" # Integer trait and implementations of some integer algorithms such as GCD and LCM
 
 # * Logging and diagnostics * #
 log = { version = "0.4", features = [

--- a/crates/graphics/Cargo.toml
+++ b/crates/graphics/Cargo.toml
@@ -26,12 +26,14 @@ luminol-egui-wgpu.workspace = true
 wgpu.workspace = true
 naga.workspace = true
 naga_oil.workspace = true
+aligned-vec.workspace = true
 
 image = "0.24.7"
 
 # * Mathematics * #
 glam.workspace = true
 bytemuck.workspace = true
+num-integer.workspace = true
 
 # * Logging and diagnostics * #
 color-eyre.workspace = true

--- a/crates/graphics/src/primitives/tiles/display.rs
+++ b/crates/graphics/src/primitives/tiles/display.rs
@@ -22,6 +22,7 @@
 // terms of the Steamworks API by Valve Corporation, the licensors of this
 // Program grant you additional permission to convey the resulting work.
 
+use num_integer::Integer;
 use wgpu::util::DeviceExt;
 
 use crate::{BindGroupLayoutBuilder, GraphicsState};
@@ -34,8 +35,8 @@ pub struct Display {
 
 #[derive(Debug)]
 struct LayerData {
-    data: Vec<u8>,
-    min_alignment_size: u32,
+    data: aligned_vec::AVec<u8, aligned_vec::RuntimeAlign>,
+    min_alignment_size: usize,
 }
 
 #[repr(C, align(16))]
@@ -47,11 +48,8 @@ pub struct Data {
 }
 
 impl Data {
-    fn aligned_size_of(min_alignment_size: u32) -> usize {
-        wgpu::util::align_to(
-            std::mem::size_of::<Self>(),
-            (min_alignment_size as usize).max(std::mem::align_of::<Data>()),
-        )
+    fn aligned_size_of(min_alignment_size: usize) -> usize {
+        wgpu::util::align_to(std::mem::size_of::<Self>(), min_alignment_size)
     }
 }
 
@@ -90,11 +88,12 @@ impl Display {
         layers: usize,
     ) -> Self {
         let limits = graphics_state.render_state.device.limits();
-        let min_alignment_size = limits.min_uniform_buffer_offset_alignment;
+        let min_alignment_size = (limits.min_uniform_buffer_offset_alignment as usize)
+            .lcm(&std::mem::align_of::<Data>());
 
         let data_size = Data::aligned_size_of(min_alignment_size);
         let mut layer_data = LayerData {
-            data: vec![0; data_size * layers],
+            data: aligned_vec::avec_rt![[min_alignment_size]| 0; data_size * layers],
             min_alignment_size,
         };
 


### PR DESCRIPTION
**Description**
This pull request fixes a bug in web builds where loading maps sometimes results in a panic in bytemuck's `from_bytes_mut` function with the error `TargetAlignmentGreaterAndInputNotAligned`, by aligning the data of the tilemap shader properly.

**Testing**
The web build shouldn't randomly crash anymore when loading maps.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown -Z build-std=std,panic_abort`
- [x] Run `cargo build --release`
- [x] If applicable, run `trunk build --release`
