### PR TITLE
Create .luminol directory when saving data_cache & mark resources as modified by default

### DIFF
--- a/crates/core/src/data_cache.rs
+++ b/crates/core/src/data_cache.rs
@@ -181,7 +181,13 @@ impl Data {
 
     pub fn from_defaults() -> Self {
         let mut map_infos = std::collections::HashMap::with_capacity(16);
-        map_infos.insert(1, rpg::MapInfo::default());
+        map_infos.insert(
+            1,
+            rpg::MapInfo {
+                order: 1,
+                ..Default::default()
+            },
+        );
         let map_infos = RefCell::new(rpg::MapInfos {
             data: map_infos,
             modified: true,
@@ -201,7 +207,13 @@ impl Data {
         });
 
         let mut maps = std::collections::HashMap::with_capacity(32);
-        maps.insert(1, rpg::Map::default());
+        maps.insert(
+            1,
+            rpg::Map {
+                modified: true,
+                ..Default::default()
+            },
+        );
         let maps = RefCell::new(maps);
 
         Self::Loaded {

--- a/crates/core/src/data_cache.rs
+++ b/crates/core/src/data_cache.rs
@@ -74,7 +74,7 @@ macro_rules! from_defaults {
     ($parent:ident, $child:ident) => {
         RefCell::new(rpg::$parent {
             data: vec![rpg::$child::default()],
-            ..Default::default()
+            modified: true,
         })
     };
 }
@@ -184,11 +184,12 @@ impl Data {
         map_infos.insert(1, rpg::MapInfo::default());
         let map_infos = RefCell::new(rpg::MapInfos {
             data: map_infos,
-            ..Default::default()
+            modified: true,
         });
 
         let system = rpg::System {
             magic_number: rand::random(),
+            modified: true,
             ..Default::default()
         };
         let system = RefCell::new(system);
@@ -196,7 +197,7 @@ impl Data {
         let scripts = vec![]; // FIXME legality of providing defualt scripts is unclear
         let scripts = RefCell::new(rpg::Scripts {
             data: scripts,
-            ..Default::default()
+            modified: true,
         });
 
         let mut maps = std::collections::HashMap::with_capacity(32);
@@ -319,6 +320,12 @@ impl Data {
         let pretty_config = ron::ser::PrettyConfig::new()
             .struct_names(true)
             .enumerate_arrays(true);
+
+        // this is autocreated on load. however:
+        // since we're creating project config now, we need this directory
+        filesystem
+            .create_dir(".luminol")
+            .wrap_err("While creating .luminol")?;
 
         let project_config = ron::ser::to_string_pretty(&config.project, pretty_config.clone())
             .wrap_err("While serializing .luminol/config")?;

--- a/crates/data/src/rmxp/tileset.rs
+++ b/crates/data/src/rmxp/tileset.rs
@@ -28,7 +28,7 @@ pub struct Tileset {
     #[serde(with = "optional_path_serde")]
     #[marshal(with = "optional_path_alox")]
     pub tileset_name: Path,
-    pub autotile_names: Vec<String>,
+    pub autotile_names: [String; 7],
     #[serde(with = "optional_path_serde")]
     #[marshal(with = "optional_path_alox")]
     pub panorama_name: Path,


### PR DESCRIPTION
**Connections**
None known.

**Description**
When creating a new project, Luminol would fail to save any files in `Data` (preventing loading the project), and would encounter an error saving the `.luminol` files due to the directory not existing (preventing creating it in the first place).

After submitting the PR, I noticed that Tileset `autotile_names` did not have the array size fixed to 7 (leading to a corrupt object), so I have committed a fix for that too.

This was tested with an RGSS1 project.

**Testing**
This change was tested by running Luminol, creating a new project in an empty directory, and then loading the project.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown -Z build-std=std,panic_abort`
- [x] Run `cargo build --release`
- [ ] If applicable, run `trunk build --release`
