### PR TITLE
Improve detection of available graphics backends in web builds

### DIFF
--- a/crates/launcher/src/entrypoint/web/runner/mod.rs
+++ b/crates/launcher/src/entrypoint/web/runner/mod.rs
@@ -307,11 +307,7 @@ impl Runner {
                 power_preference: _,
                 native_adapter_selector: _,
                 device_descriptor: _,
-            }) => wgpu::Instance::new(&wgpu::InstanceDescriptor {
-                backends: instance_descriptor.backends,
-                flags: wgpu::InstanceFlags::default(),
-                backend_options: wgpu::BackendOptions::default(),
-            }),
+            }) => wgpu::util::new_instance_with_webgpu_detection(&instance_descriptor).await,
             egui_wgpu::WgpuSetup::Existing(egui_wgpu::WgpuSetupExisting {
                 instance,
                 adapter: _,


### PR DESCRIPTION
**Description**

Before this pull request, the web builds would decide whether to use WebGPU or WebGL by checking if `navigator.gpu` is defined in JavaScript (in the worker thread that most of Luminol's code runs in, not in the main thread), and then use WebGPU if it is or WebGL if it isn't. However, some browsers define `navigator.gpu` when WebGPU isn't supported, and the web builds would crash in such cases because wgpu would choose WebGPU based on the fact that `navigator.gpu` was defined, fail to create a WebGPU instance and then give up instead of falling back to WebGL.

This pull request changes the web runner initialization to use a utility function provided by wgpu to check if a WebGPU instance can be successfully initialized and then choose WebGPU or WebGL depending on the outcome.

**Testing**

In Firefox 141 on Arch Linux, I noticed that `navigator.gpu` is defined in the worker thread even though WebGPU doesn't work. It wasn't defined when I was testing #170, so this might be a recent development.

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [x] `--target wasm32-unknown-unknown -Z build-std=std,panic_abort`
- [x] Run `cargo build --release`
- [x] If applicable, run `trunk build --release`
