### PR TITLE
Allow the script manager to extract scripts with empty or non-unique names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2834,15 +2834,6 @@ checksum = "a598c1abae8e3456ebda517868b254b6bc2a9bb6501ffd5b9d0875bf332e048b"
 
 [[package]]
 name = "itertools"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
@@ -2855,6 +2846,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b4baf93f58d4425749ca49a51c50ebab072c5df6994d08fed93541c331481dc"
 dependencies = [
  "either",
 ]
@@ -3162,7 +3162,7 @@ dependencies = [
  "ron 0.8.1",
  "shadow-rs",
  "steamworks",
- "strum 0.25.0",
+ "strum 0.28.0",
  "tempfile",
  "tokio",
  "tracing",
@@ -3193,7 +3193,7 @@ dependencies = [
  "rodio",
  "rustysynth",
  "slab",
- "strum 0.25.0",
+ "strum 0.28.0",
  "thiserror 1.0.69",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3211,7 +3211,7 @@ dependencies = [
  "ron 0.8.1",
  "rust-ini",
  "serde",
- "strum 0.25.0",
+ "strum 0.28.0",
 ]
 
 [[package]]
@@ -3224,7 +3224,7 @@ dependencies = [
  "egui",
  "egui-notify",
  "egui_dock",
- "itertools 0.11.0",
+ "itertools 0.15.0",
  "luminol-audio",
  "luminol-config",
  "luminol-data",
@@ -3238,7 +3238,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "strum 0.25.0",
+ "strum 0.28.0",
  "tracing",
 ]
 
@@ -3256,7 +3256,7 @@ dependencies = [
  "paste",
  "rand",
  "serde",
- "strum 0.25.0",
+ "strum 0.28.0",
 ]
 
 [[package]]
@@ -3282,7 +3282,7 @@ dependencies = [
  "flume",
  "futures-lite 2.6.0",
  "iter-read",
- "itertools 0.11.0",
+ "itertools 0.15.0",
  "js-sys",
  "luminol-config",
  "luminol-web",
@@ -3320,7 +3320,7 @@ dependencies = [
  "fragile",
  "glam",
  "image 0.24.9",
- "itertools 0.11.0",
+ "itertools 0.15.0",
  "luminol-data",
  "luminol-filesystem",
  "luminol-macros",
@@ -3371,7 +3371,7 @@ dependencies = [
  "luminol-core",
  "luminol-macros",
  "serde",
- "strum 0.25.0",
+ "strum 0.28.0",
 ]
 
 [[package]]
@@ -3391,7 +3391,7 @@ dependencies = [
  "image 0.25.2",
  "indexmap",
  "indextree",
- "itertools 0.11.0",
+ "itertools 0.15.0",
  "lexical-sort",
  "luminol-audio",
  "luminol-config",
@@ -3414,7 +3414,7 @@ dependencies = [
  "serde_json",
  "serde_yml",
  "strip-ansi-escapes",
- "strum 0.25.0",
+ "strum 0.28.0",
  "syntect",
  "target-triple",
  "wgpu",
@@ -5520,15 +5520,6 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
-dependencies = [
- "strum_macros 0.25.3",
-]
-
-[[package]]
-name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
@@ -5537,16 +5528,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "strum_macros"
-version = "0.25.3"
+name = "strum"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.104",
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -5559,6 +5546,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
  "syn 2.0.104",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ tracing = "0.1.37" # Structured, event-based, application-level diagnostics
 color-eyre = "0.6.2" # An error report handler for panics, based on the 'eyre' crate
 
 # * Useful procedural macros * #
-strum = { version = "0.25.0", features = [
+strum = { version = "0.28.0", features = [
     "derive",
 ] } # Useful 'derive' macros for enumerations, like 'EnumString' which converts strings to enum variants
 paste = "1.0.14" # A flexible way ot paste together identifiers in a macro, including using pasted identifiers to define new ones. Does not rely on a nightly feature 'concat_idents'
@@ -165,7 +165,7 @@ slab = { version = "0.4.9", features = [
     "serde",
 ] } # Pre-allocated storage for a uniform data type
 qp-trie = "0.8.2" # An idiomatic and fast QP-trie implementation
-itertools = "0.11.0" # Extra iterator adaptors, methods, functions and macros
+itertools = "0.15.0" # Extra iterator adaptors, methods, functions and macros
 rand = "0.8.5" # Random number generators and other randomness functionality
 lexical-sort = "0.3.1" # Functions that compare and sort strings lexicographically
 indexmap = "2.2.6" # A hash table with consistent order and fast iteration

--- a/crates/filesystem/src/archiver/filesystem/impls.rs
+++ b/crates/filesystem/src/archiver/filesystem/impls.rs
@@ -818,7 +818,7 @@ where
         );
         if let Some(iter) = trie.iter_dir(path) {
             iter.map(|(name, _)| {
-                let path = if path == "" {
+                let path: camino::Utf8PathBuf = if path == "" {
                     name.into()
                 } else {
                     format!("{path}/{name}").into()
@@ -829,7 +829,10 @@ where
                         format!("While getting the metadata of {path:?} in the archive")
                     })
                     .wrap_err_with(|| c.clone())?;
-                Ok(DirEntry { path, metadata })
+                Ok(DirEntry {
+                    name: name.to_string(),
+                    metadata,
+                })
             })
             .try_collect()
         } else {

--- a/crates/filesystem/src/lib.rs
+++ b/crates/filesystem/src/lib.rs
@@ -121,31 +121,13 @@ pub struct Metadata {
 
 #[derive(Clone, PartialEq, Eq, Hash, Debug)]
 pub struct DirEntry {
-    pub path: camino::Utf8PathBuf,
+    pub name: String,
     pub metadata: Metadata,
 }
 
 impl DirEntry {
-    pub fn new(path: camino::Utf8PathBuf, metadata: Metadata) -> Self {
-        Self { path, metadata }
-    }
-
-    pub fn path(&self) -> &camino::Utf8Path {
-        &self.path
-    }
-
-    pub fn metadata(&self) -> Metadata {
-        self.metadata
-    }
-
-    pub fn file_name(&self) -> &str {
-        self.path
-            .file_name()
-            .expect("path created through DirEntry must have a filename")
-    }
-
-    pub fn into_path(self) -> camino::Utf8PathBuf {
-        self.path
+    pub fn new(name: String, metadata: Metadata) -> Self {
+        Self { name, metadata }
     }
 }
 

--- a/crates/filesystem/src/native.rs
+++ b/crates/filesystem/src/native.rs
@@ -191,6 +191,7 @@ impl crate::FileSystem for FileSystem {
         path.read_dir_utf8()
             .wrap_err_with(|| c.clone())?
             .map_ok(|entry| {
+                let name = entry.file_name().to_string();
                 let path = entry.into_path();
                 let path = path
                     .strip_prefix(&self.root_path)
@@ -202,7 +203,7 @@ impl crate::FileSystem for FileSystem {
                 let path = path.into_string().replace('\\', "/").into();
 
                 let metadata = self.metadata(&path).wrap_err_with(|| c.clone())?;
-                Ok(DirEntry::new(path, metadata))
+                Ok(DirEntry::new(name, metadata))
             })
             .flatten()
             .try_collect()

--- a/crates/filesystem/src/native.rs
+++ b/crates/filesystem/src/native.rs
@@ -200,7 +200,7 @@ impl crate::FileSystem for FileSystem {
 
                 // i hate windows.
                 #[cfg(windows)]
-                let path = path.into_string().replace('\\', "/").into();
+                let path = camino::Utf8PathBuf::from(path.into_string().replace('\\', "/"));
 
                 let metadata = self.metadata(&path).wrap_err_with(|| c.clone())?;
                 Ok(DirEntry::new(name, metadata))

--- a/crates/filesystem/src/path_cache.rs
+++ b/crates/filesystem/src/path_cache.rs
@@ -167,12 +167,12 @@ impl Cache {
             let mut original_name = None;
             let mut new_cactus_index = 0;
             for entry in entries.into_iter() {
-                let entry_name = camino::Utf8Path::new(entry.file_name())
+                let entry_name = camino::Utf8Path::new(&entry.name)
                     .file_stem()
-                    .unwrap_or(entry.file_name())
+                    .unwrap_or(&entry.name)
                     .to_lowercase();
 
-                let entry_extension = camino::Utf8Path::new(entry.file_name())
+                let entry_extension = camino::Utf8Path::new(&entry.name)
                     .extension()
                     .unwrap_or_default()
                     .to_lowercase();
@@ -191,7 +191,7 @@ impl Cache {
                     .copied()
                     .unwrap_or_else(|| {
                         let index = self.cactus.insert(CactusNode {
-                            value: entry.file_name().to_string(),
+                            value: entry.name.clone(),
                             next: cactus_index,
                             len,
                         });
@@ -200,7 +200,7 @@ impl Cache {
                     });
 
                 if entry_name == name {
-                    original_name = Some(entry.file_name().to_string());
+                    original_name = Some(entry.name);
                     new_cactus_index = index;
                 }
             }

--- a/crates/filesystem/src/project.rs
+++ b/crates/filesystem/src/project.rs
@@ -90,8 +90,8 @@ impl FileSystem {
             return Some(luminol_config::RMVer::Ace);
         }
 
-        for path in self.read_dir("").ok()? {
-            let path = path.path();
+        for entry in self.read_dir("").ok()? {
+            let path = camino::Utf8Path::new(&entry.name);
             if path.extension() == Some("rgssad") {
                 return Some(luminol_config::RMVer::XP);
             }
@@ -428,9 +428,12 @@ impl FileSystem {
             .into_iter()
             .find(|entry| {
                 entry.metadata.is_file
-                    && matches!(entry.path.extension(), Some("rgssad" | "rgss2a" | "rgss3a"))
+                    && matches!(
+                        camino::Utf8Path::new(&entry.name).extension(),
+                        Some("rgssad" | "rgss2a" | "rgss3a")
+                    )
             })
-            .map(|entry| host.open_file(entry.path, OpenFlags::Read | OpenFlags::Write))
+            .map(|entry| host.open_file(entry.name, OpenFlags::Read | OpenFlags::Write))
             .transpose()?
             .map(archiver::FileSystem::new)
             .transpose()?;

--- a/crates/filesystem/src/project.rs
+++ b/crates/filesystem/src/project.rs
@@ -521,7 +521,7 @@ impl FileSystem {
     ) -> Result<LoadResult> {
         let entries = host.read_dir("")?;
         if !entries.iter().any(|e| {
-            if let Some(extension) = e.path.extension() {
+            if let Some(extension) = camino::Utf8Path::new(&e.name).extension() {
                 e.metadata.is_file
                     && (extension == "rxproj"
                         || extension == "rvproj"
@@ -549,9 +549,17 @@ impl FileSystem {
             .into_iter()
             .find(|entry| {
                 entry.metadata.is_file
-                    && matches!(entry.path.extension(), Some("rgssad" | "rgss2a" | "rgss3a"))
+                    && matches!(
+                        camino::Utf8Path::new(&entry.name).extension(),
+                        Some("rgssad" | "rgss2a" | "rgss3a")
+                    )
             })
-            .map(|entry| host.open_file(entry.path, OpenFlags::Read | OpenFlags::Write))
+            .map(|entry| {
+                host.open_file(
+                    camino::Utf8Path::new(&entry.name),
+                    OpenFlags::Read | OpenFlags::Write,
+                )
+            })
             .transpose()?
             .map(archiver::FileSystem::new)
             .transpose()?;

--- a/crates/filesystem/src/web/events.rs
+++ b/crates/filesystem/src/web/events.rs
@@ -411,7 +411,7 @@ pub fn setup_main_thread_hooks(main_channels: super::MainChannels) {
                                         to_future::<web_sys::File>(entry.get_file()).await
                                     {
                                         vec.push(DirEntry::new(
-                                            path.join(entry.name()),
+                                            entry.name(),
                                             Metadata {
                                                 is_file: true,
                                                 size: blob.size() as u64,
@@ -421,7 +421,7 @@ pub fn setup_main_thread_hooks(main_channels: super::MainChannels) {
                                 }
                                 web_sys::FileSystemHandleKind::Directory => {
                                     vec.push(DirEntry::new(
-                                        path.join(entry.name()),
+                                        entry.name(),
                                         Metadata {
                                             is_file: false,
                                             size: 0,

--- a/crates/ui/src/components/filesystem_view.rs
+++ b/crates/ui/src/components/filesystem_view.rs
@@ -208,19 +208,16 @@ where
                 } else if b.metadata.is_file && !a.metadata.is_file {
                     std::cmp::Ordering::Less
                 } else {
-                    let path_a = a.path.iter().next_back().unwrap();
-                    let path_b = b.path.iter().next_back().unwrap();
-                    lexical_sort::natural_lexical_cmp(path_a, path_b)
+                    lexical_sort::natural_lexical_cmp(&a.name, &b.name)
                 }
             });
             length = Some(subentries.len());
 
             for subentry in subentries {
-                let subentry_name = subentry.path.iter().next_back().unwrap().to_string();
                 if subentry.metadata.is_file {
                     node_id.append_value(
                         Entry::File {
-                            name: subentry_name,
+                            name: subentry.name,
                             selected,
                         },
                         &mut self.arena,
@@ -228,10 +225,10 @@ where
                 } else {
                     let should_select = is_root
                         && default_selected_dirs
-                            .is_some_and(|dirs| dirs.contains_key_str(&subentry_name));
+                            .is_some_and(|dirs| dirs.contains_key_str(&subentry.name));
                     let child_id = node_id.append_value(
                         Entry::Dir {
-                            name: subentry_name,
+                            name: subentry.name,
                             selected,
                             initialized: false,
                             depersisted: false,

--- a/crates/ui/src/components/sound_tab.rs
+++ b/crates/ui/src/components/sound_tab.rs
@@ -48,9 +48,8 @@ impl SoundTab {
         let mut folder_children = filesystem
             .read_dir(format!("Audio/{source}"))
             .unwrap_or_default();
-        folder_children.sort_unstable_by(|a, b| {
-            lexical_sort::natural_lexical_cmp(a.file_name(), b.file_name())
-        });
+        folder_children
+            .sort_unstable_by(|a, b| lexical_sort::natural_lexical_cmp(&a.name, &b.name));
         Self {
             source,
             audio_file,
@@ -177,7 +176,7 @@ impl SoundTab {
                         .iter()
                         .filter(|entry| {
                             matcher
-                                .fuzzy(entry.file_name(), &self.search_text, false)
+                                .fuzzy(&entry.name, &self.search_text, false)
                                 .is_some()
                         })
                         .cloned()
@@ -231,7 +230,7 @@ impl SoundTab {
                                 {
                                     let faint = (i + row_range.start) % 2 == 0;
                                     let res = ui.with_stripe(faint, |ui| {
-                                        let entry_name = camino::Utf8Path::new(entry.file_name());
+                                        let entry_name = camino::Utf8Path::new(&entry.name);
                                         let res = ui.add(egui::Button::selectable(
                                             audio_file_name.as_deref() == Some(entry_name),
                                             entry_name.as_str(),
@@ -266,8 +265,9 @@ impl SoundTab {
                             .iter()
                             .enumerate()
                             .find_map(|(i, entry)| {
-                                (audio_file_name.as_deref() == Some(entry.file_name().into()))
-                                    .then_some(i + 1)
+                                (audio_file_name.as_deref()
+                                    == Some(camino::Utf8Path::new(&entry.name)))
+                                .then_some(i + 1)
                             })
                     };
                     if let Some(row) = row {

--- a/crates/ui/src/modals/graphic_picker/mod.rs
+++ b/crates/ui/src/modals/graphic_picker/mod.rs
@@ -112,7 +112,7 @@ impl Entry {
             .unwrap_or_default()
             .into_iter()
             .map(|m| Entry {
-                path: m.path.file_name().unwrap_or_default().into(),
+                path: m.name.into(),
                 invalid: false,
             })
             .collect();

--- a/crates/ui/src/windows/actors.rs
+++ b/crates/ui/src/windows/actors.rs
@@ -136,9 +136,8 @@ fn draw_graph(
                     let index = iter_parameters(&actor.parameters, param, range.clone(), rect)
                         .with_position()
                         .position(|(iter_pos, p)| {
-                            (iter_pos == itertools::Position::First || hover_pos.x >= p.x - width)
-                                && (iter_pos == itertools::Position::Last
-                                    || hover_pos.x < p.x + width)
+                            (iter_pos.is_first || hover_pos.x >= p.x - width)
+                                && (iter_pos.is_last || hover_pos.x < p.x + width)
                         })
                         .unwrap()
                         + 1;
@@ -195,12 +194,12 @@ fn draw_graph(
                         .map(|(iter_pos, (p, q))| {
                             // Round the horizontal position of each point to the nearest pixel so egui doesn't
                             // try to anti-alias the vertical edges of the trapezoids
-                            let p = if iter_pos == itertools::Position::First {
+                            let p = if iter_pos.is_first {
                                 p
                             } else {
                                 egui::pos2((p.x * ppp).round() / ppp, p.y)
                             };
-                            let q = if iter_pos == itertools::Position::Last {
+                            let q = if iter_pos.is_last {
                                 q
                             } else {
                                 egui::pos2((q.x * ppp).round() / ppp, q.y)
@@ -274,11 +273,7 @@ fn draw_exp(ui: &mut egui::Ui, actor: &luminol_data::rpg::Actor, total: &mut boo
                                         ui.add(
                                             egui::Label::new(if *total {
                                                 exp[i].to_string()
-                                            } else if matches!(
-                                                pos,
-                                                itertools::Position::Last
-                                                    | itertools::Position::Only
-                                            ) {
+                                            } else if pos.is_last {
                                                 "(None)".into()
                                             } else {
                                                 (exp[i + 1] - exp[i]).to_string()

--- a/crates/ui/src/windows/archive_manager.rs
+++ b/crates/ui/src/windows/archive_manager.rs
@@ -105,12 +105,12 @@ impl luminol_core::Window for Window {
                                 .find(|entry| {
                                     entry.metadata.is_file
                                         && matches!(
-                                            entry.path.extension(),
+                                            camino::Utf8Path::new(&entry.name).extension(),
                                             Some("rgssad" | "rgss2a" | "rgss3a")
                                         )
                                 })
                                 .map(|entry| {
-                                    host.open_file(&entry.path, OpenFlags::Read)
+                                    host.open_file(&entry.name, OpenFlags::Read)
                                         .and_then(luminol_filesystem::archiver::FileSystem::new)
                                         .map(|archive| (entry, archive))
                                 })
@@ -119,7 +119,7 @@ impl luminol_core::Window for Window {
                             *view = Some(FileSystemView::new(
                                 "luminol_archive_manager_extract_view".into(),
                                 archive,
-                                entry.path.to_string(),
+                                entry.name,
                             ))
                         }
                     }
@@ -575,7 +575,12 @@ impl Window {
             vec.push(path.to_owned());
         } else {
             for entry in src_fs.read_dir(path)? {
-                Self::find_files_recurse(vec, src_fs, &entry.path, entry.metadata.is_file)?;
+                Self::find_files_recurse(
+                    vec,
+                    src_fs,
+                    &path.join(entry.name),
+                    entry.metadata.is_file,
+                )?;
             }
         }
         Ok(())

--- a/crates/ui/src/windows/script_manager.rs
+++ b/crates/ui/src/windows/script_manager.rs
@@ -76,41 +76,12 @@ enum ScriptsFormat {
     Ron,
 }
 
-struct ScriptsFileSystem(std::sync::Arc<parking_lot::Mutex<ScriptsFileSystemInner>>);
-
-struct ScriptsFileSystemInner {
-    trie: luminol_filesystem::FileSystemTrie<luminol_data::rpg::Script>,
-    names: Vec<String>,
-}
+struct ScriptsFileSystem(std::sync::Arc<parking_lot::Mutex<Vec<luminol_data::rpg::Script>>>);
 
 impl ScriptsFileSystem {
     fn new(scripts: impl Iterator<Item = luminol_data::rpg::Script>) -> Self {
-        let mut trie = luminol_filesystem::FileSystemTrie::new();
-        let (_, hint) = scripts.size_hint();
-        let mut names = Vec::with_capacity(hint.unwrap_or_default());
-        for script in scripts {
-            let mut name = script.name.replace('\\', "/");
-            loop {
-                let new_name = name.replace("//", "/");
-                if new_name == name {
-                    break;
-                } else {
-                    name = new_name;
-                }
-            }
-            if let Some(stripped) = name.strip_prefix('/') {
-                name = stripped.to_string();
-            }
-            if let Some(stripped) = name.strip_suffix('/') {
-                name = stripped.to_string();
-            }
-            if !name.is_empty() && !script.script_text.is_empty() {
-                trie.create_file(&name, script);
-                names.push(name);
-            }
-        }
         Self(std::sync::Arc::new(parking_lot::Mutex::new(
-            ScriptsFileSystemInner { trie, names },
+            scripts.collect(),
         )))
     }
 }
@@ -118,31 +89,21 @@ impl ScriptsFileSystem {
 impl luminol_filesystem::ReadDir for ScriptsFileSystem {
     fn read_dir(
         &self,
-        path: impl AsRef<camino::Utf8Path>,
+        _path: impl AsRef<camino::Utf8Path>,
     ) -> luminol_filesystem::Result<Vec<luminol_filesystem::DirEntry>> {
-        let path = path.as_ref();
         Ok(self
             .0
             .lock()
-            .trie
-            .iter_dir(path)
-            .map_or_else(Default::default, |iter| {
-                iter.map(|(name, maybe_script)| luminol_filesystem::DirEntry {
-                    name: name.to_string(),
-                    metadata: if let Some(script) = maybe_script {
-                        luminol_filesystem::Metadata {
-                            is_file: true,
-                            size: script.script_text.len() as u64,
-                        }
-                    } else {
-                        luminol_filesystem::Metadata {
-                            is_file: false,
-                            size: 0,
-                        }
-                    },
-                })
-                .collect()
-            }))
+            .iter()
+            .enumerate()
+            .map(|(i, script)| luminol_filesystem::DirEntry {
+                name: format!("{i:0>3}:{}", script.name),
+                metadata: luminol_filesystem::Metadata {
+                    is_file: true,
+                    size: script.script_text.len() as u64,
+                },
+            })
+            .collect())
     }
 }
 
@@ -524,11 +485,11 @@ impl Window {
                                 {
                                     let view = view.as_ref().unwrap();
                                     match Self::find_files(view) {
-                                        Ok(file_paths) => {
+                                        Ok(script_names) => {
                                             let ctx = ui.ctx().clone();
                                             let progress = progress.clone();
                                             let scripts = view.filesystem().0.clone();
-                                            *progress_total = file_paths.len();
+                                            *progress_total = script_names.len();
                                             progress.store(usize::MAX, std::sync::atomic::Ordering::Relaxed);
 
                                             *save_promise = Some(luminol_core::spawn_future(async move {
@@ -537,27 +498,30 @@ impl Window {
                                                 progress.store(0, std::sync::atomic::Ordering::Relaxed);
                                                 ctx.request_repaint();
 
-                                                let mut names_file = dest_fs.open_file("_scripts.txt", OpenFlags::Write | OpenFlags::Create | OpenFlags::Truncate)?;
-                                                let names_len = scripts.lock().names.len();
-                                                for i in 0..names_len {
-                                                    let name = scripts.lock().names[i].clone();
-                                                    names_file.write_all(name.as_bytes()).await?;
-                                                    names_file.write_all(b"\n").await?;
-                                                }
-                                                names_file.flush().await?;
-                                                drop(names_file);
-
-                                                for mut path in file_paths {
-                                                    if let Some(parent) = path.parent() {
-                                                        dest_fs.create_dir(parent)?;
-                                                    }
-                                                    let src = scripts.lock().trie.get_file(path.as_str()).ok_or(luminol_filesystem::Error::NotExist)?.script_text.clone();
-                                                    let src_data = src.as_bytes();
-                                                    if let Some(filename) = path.file_name() {
-                                                        path.set_file_name(format!("{filename}.rb"));
-                                                    }
-                                                    let mut dest_file = dest_fs.open_file(&path, OpenFlags::Write | OpenFlags::Create | OpenFlags::Truncate)?;
-                                                    async_std::io::copy(&mut async_std::io::Cursor::new(src_data), &mut dest_file).await?;
+                                                for name in script_names {
+                                                    let (index, _) = name.as_str().split_once(':').ok_or(luminol_filesystem::Error::NotExist)?;
+                                                    let index: usize = index.parse().map_err(|_| luminol_filesystem::Error::NotExist)?;
+                                                    let (mut dest_file, script_text) = {
+                                                        let scripts = scripts.lock();
+                                                        let script = scripts.get(index).ok_or(luminol_filesystem::Error::NotExist)?;
+                                                        let mut filename = format!("{index:0>3}:{}.rb", script.name);
+                                                        for forbidden_character in [
+                                                            '%',
+                                                            '"',
+                                                            '*',
+                                                            '/',
+                                                            ':',
+                                                            '<',
+                                                            '>',
+                                                            '?',
+                                                            '\\',
+                                                            '|',
+                                                        ] {
+                                                            filename = filename.replace(forbidden_character, &format!("%{:02X}", forbidden_character as u8));
+                                                        }
+                                                        (dest_fs.open_file(filename, OpenFlags::Write | OpenFlags::Create | OpenFlags::Truncate)?, script.script_text.clone())
+                                                    };
+                                                    async_std::io::copy(&mut async_std::io::Cursor::new(script_text), &mut dest_file).await?;
 
                                                     progress.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                                                     ctx.request_repaint();

--- a/crates/ui/src/windows/script_manager.rs
+++ b/crates/ui/src/windows/script_manager.rs
@@ -128,11 +128,7 @@ impl luminol_filesystem::ReadDir for ScriptsFileSystem {
             .iter_dir(path)
             .map_or_else(Default::default, |iter| {
                 iter.map(|(name, maybe_script)| luminol_filesystem::DirEntry {
-                    path: if path.as_str().is_empty() {
-                        name.into()
-                    } else {
-                        format!("{path}/{name}").into()
-                    },
+                    name: name.to_string(),
                     metadata: if let Some(script) = maybe_script {
                         luminol_filesystem::Metadata {
                             is_file: true,
@@ -1083,7 +1079,12 @@ impl Window {
             vec.push(path.to_owned());
         } else {
             for entry in src_fs.read_dir(path)? {
-                Self::find_files_recurse(vec, src_fs, &entry.path, entry.metadata.is_file)?;
+                Self::find_files_recurse(
+                    vec,
+                    src_fs,
+                    &path.join(entry.name),
+                    entry.metadata.is_file,
+                )?;
             }
         }
         Ok(())

--- a/crates/ui/src/windows/script_manager.rs
+++ b/crates/ui/src/windows/script_manager.rs
@@ -24,6 +24,7 @@
 
 use crate::components::{EnumComboBox, FileSystemView, UiExt};
 use futures_lite::{AsyncReadExt, AsyncWriteExt, StreamExt};
+use itertools::Itertools;
 use luminol_filesystem::{File, FileSystem, OpenFlags};
 
 /// The script manager for creating and extracting Scripts.rxdata.
@@ -646,7 +647,7 @@ impl Window {
                                     if let Some(view) = view {
                                         let format = *format;
                                         match Self::find_files(view) {
-                                            Ok(file_paths) => {
+                                            Ok(mut file_paths) => {
                                                 let ctx = ui.ctx().clone();
                                                 let progress = progress.clone();
                                                 let view_filesystem = view.filesystem().clone();
@@ -662,55 +663,80 @@ impl Window {
                                                         progress.store(0, std::sync::atomic::Ordering::Relaxed);
                                                         ctx.request_repaint();
 
-                                                        let mut lines = view_filesystem.exists("_scripts.txt")?
-                                                            .then(|| view_filesystem.open_file("_scripts.txt", OpenFlags::Read))
-                                                            .transpose()?
-                                                            .map(|names_file| async_std::io::BufReader::new(names_file).lines());
-
                                                         let mut scripts = Vec::with_capacity(file_paths.len());
 
-                                                        let mut file_path_trie = qp_trie::Trie::new();
-                                                        for path in file_paths.iter() {
-                                                            let name = path.as_str().replace('\\', "/");
-                                                            let name = if [".rb", ".ru"].iter().any(|suffix| name.to_lowercase().ends_with(suffix)) {
-                                                                name.rsplit_once('.').unwrap().0.to_string()
-                                                            } else {
-                                                                continue;
-                                                            };
-                                                            file_path_trie.insert_str(&name, ());
-                                                        }
-                                                        let mut file_path_iter = file_paths.iter();
-
-                                                        while let Some(path) =
-                                                            if let Some(mut l) = lines.take() {
-                                                                let line = loop {
-                                                                    let line = l.next().await;
-                                                                    if !line.as_ref().is_some_and(|line| line.as_ref().is_ok_and(|line| line.is_empty())) {
-                                                                        break line;
-                                                                    }
-                                                                };
-                                                                if line.is_some() {
-                                                                    lines = Some(l);
-                                                                    line.transpose().map(|o| o.map(|line| format!("{line}.rb")))
-                                                                } else {
-                                                                    Ok(file_path_iter.next().map(ToString::to_string))
-                                                                }
-                                                            } else {
-                                                                Ok(file_path_iter.next().map(ToString::to_string))
-                                                            }?
+                                                        let mut trie = qp_trie::Trie::new();
+                                                        if let Some(mut lines) = view_filesystem.exists("_scripts.txt")?
+                                                            .then(|| view_filesystem.open_file("_scripts.txt", OpenFlags::Read))
+                                                            .transpose()?
+                                                            .map(|names_file| async_std::io::BufReader::new(names_file).lines())
                                                         {
-                                                            let name = path.to_string().replace('\\', "/");
-                                                            let name = if [".rb", ".ru"].iter().any(|suffix| name.to_lowercase().ends_with(suffix)) {
-                                                                name.rsplit_once('.').unwrap().0.to_string()
-                                                            } else {
-                                                                continue;
-                                                            };
-
-                                                            if !file_path_trie.contains_key_str(&name) {
-                                                                continue;
+                                                            while let Some(Ok(line)) = lines.next().await {
+                                                                if line.is_empty() {
+                                                                    continue;
+                                                                }
+                                                                if !trie.contains_key_str(&line) {
+                                                                    trie.insert_str(&line, trie.count());
+                                                                }
                                                             }
-                                                            file_path_trie.remove_str(&name);
+                                                        }
 
+                                                        // Remove scripts whose filenames don't end in .rb or .ru
+                                                        file_paths.retain(|path| {
+                                                            ["rb", "ru"].iter().any(|&ruby_extension| path.extension().is_some_and(|extension| extension == ruby_extension))
+                                                        });
+
+                                                        let parse_percent_encoding = |path: &camino::Utf8Path| -> camino::Utf8PathBuf {
+                                                            let mut new_path = String::with_capacity(path.as_str().len());
+                                                            let mut chars_iter = path
+                                                                .as_str()
+                                                                .chars()
+                                                                .chain(std::iter::once('\0'))
+                                                                .circular_array_windows::<3>();
+                                                            while let Some(chars) = chars_iter.next() {
+                                                                if chars[0] == '\0' {
+                                                                    break;
+                                                                }
+                                                                if let Some(escaped_codepoint) = (chars[0] == '%' && chars[1].is_ascii_alphanumeric() && chars[2].is_ascii_alphanumeric())
+                                                                    .then(|| u8::from_str_radix(&format!("{}{}", chars[1], chars[2]), 16).ok())
+                                                                    .flatten()
+                                                                    .filter(|&escaped_codepoint| escaped_codepoint < 0x80)
+                                                                {
+                                                                    new_path.push(escaped_codepoint as char);
+                                                                    chars_iter.next();
+                                                                    chars_iter.next();
+                                                                } else {
+                                                                    new_path.push(chars[0]);
+                                                                }
+                                                            }
+                                                            new_path.into()
+                                                        };
+
+                                                        // Sort the scripts in the following order:
+                                                        //   * Sort the scripts whose paths appear in _scripts.txt in the order in which they appear in _scripts.txt
+                                                        //   * Then sort the remaining scripts whose filenames start with a nonnegative decimal integer followed by a colon by the integer in the filename
+                                                        //   * Then put all the remaining scripts after that in the order in which they appear in the UI
+                                                        file_paths.sort_by(|a, b| {
+                                                            let a = parse_percent_encoding(a);
+                                                            let b = parse_percent_encoding(b);
+                                                            let get_script_index_from_trie = |path: &camino::Utf8Path| -> Option<usize> {
+                                                                trie.get_str(path.as_str().rsplit_once('.').unwrap().0).copied()
+                                                            };
+                                                            if let (Some(a), Some(b)) = (get_script_index_from_trie(&a), get_script_index_from_trie(&b)) {
+                                                                return a.cmp(&b);
+                                                            }
+                                                            let get_script_index_from_prefix = |path: &camino::Utf8Path| -> Option<usize> {
+                                                                let name = path.file_stem().unwrap();
+                                                                let (index, _) = name.split_once(':')?;
+                                                                index.parse().ok()
+                                                            };
+                                                            if let (Some(a), Some(b)) = (get_script_index_from_prefix(&a), get_script_index_from_prefix(&b)) {
+                                                                return a.cmp(&b);
+                                                            }
+                                                            std::cmp::Ordering::Equal
+                                                        });
+
+                                                        for path in file_paths {
                                                             if is_first {
                                                                 is_first = false;
                                                             } else {
@@ -721,8 +747,19 @@ impl Window {
                                                             let mut script_text = String::new();
                                                             view_filesystem.open_file(&path, OpenFlags::Read)?.read_to_string(&mut script_text).await?;
 
+                                                            let script_name = parse_percent_encoding(&path).to_string();
+                                                            let script_name = if let Some((prefix, _)) = script_name.rsplit_once('.') {
+                                                                prefix.to_string()
+                                                            } else {
+                                                                script_name
+                                                            };
+                                                            let script_name = if let Some((_, suffix)) = script_name.split_once(':') {
+                                                                suffix.to_string()
+                                                            } else {
+                                                                script_name
+                                                            };
                                                             let script = luminol_data::rpg::Script::new(
-                                                                name,
+                                                                script_name,
                                                                 script_text,
                                                             );
                                                             scripts.push(script);

--- a/crates/ui/src/windows/script_manager.rs
+++ b/crates/ui/src/windows/script_manager.rs
@@ -508,6 +508,7 @@ impl Window {
                                                         let mut filename = format!("{index:0>3}:{}.rb", script.name);
                                                         for forbidden_character in [
                                                             '%',
+                                                            '\0',
                                                             '"',
                                                             '*',
                                                             '/',


### PR DESCRIPTION
**Description**
Some games have multiple scripts with the same name or scripts with empty names. Previously, those could not be extracted correctly, so I've changed the script manager to extract scripts by prepending the script filename with the index of the script (e.g. "001:name.rb" instead of simply "name.rb"). I've also changed the script manager to URI-escape the extracted filenames to handle scripts whose names contain characters that are not allowed in filenames.

**Testing**
I was trying to use Luminol earlier to extract the script files from the free trial version of the game [Shukyusho Gakuen Gaiden: The Legend of Hanpane Island](https://www.dlsite.com/maniax/work/=/product_id/RJ119804.html) because someone reported issues running this game in mkxp-z, but that game has two scripts with identical names and Luminol only extracts the second one, and so the game doesn't run anymore if you extract the scripts and then create the Scripts.rvdata from the extracted scripts (specifically it throws an exception as soon as you start a new game using the newly created Scripts.rvdata). It should be able to do round-trip extracting and creating of the Scripts.rvdata now without causing an exception when you start a new game.

<!-- 
Thanks for filing a pull request! The codeowners file will automatically request reviews.

After you get a review and have addressed any comments, please explicitly re-request a review from the
person(s) who reviewed your changes. This will make sure it gets re-added to their review queue - you're not bothering us!
-->

**Checklist**

- [x] Run `cargo fmt`.
- [x] Run `cargo clippy`. If applicable, add:
  - [ ] `--target wasm32-unknown-unknown -Z build-std=std,panic_abort`
- [x] Run `cargo build --release`
- [ ] If applicable, run `trunk build --release`
